### PR TITLE
Move categorical dimension filter pushdown to PredicatePushdownOptimizer

### DIFF
--- a/.changes/unreleased/Under the Hood-20240617-110749.yaml
+++ b/.changes/unreleased/Under the Hood-20240617-110749.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Move categorical dimension predicate pushdown to DataflowPlanOptimizer
+time: 2024-06-17T11:07:49.619225-07:00
+custom:
+    Author: tlento
+    Issue: "1011"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -188,7 +188,9 @@ class DataflowPlanBuilder:
         )
 
         predicate_pushdown_state = PredicatePushdownState(
-            time_range_constraint=query_spec.time_range_constraint, where_filter_specs=query_level_filter_specs
+            time_range_constraint=query_spec.time_range_constraint,
+            where_filter_specs=(),
+            pushdown_enabled_types=frozenset({PredicateInputType.TIME_RANGE_CONSTRAINT}),
         )
 
         return self._build_metrics_output_node(
@@ -521,12 +523,6 @@ class DataflowPlanBuilder:
             ),
             descendent_filter_specs=metric_spec.filter_specs,
         )
-        if predicate_pushdown_state.where_filter_pushdown_enabled:
-            predicate_pushdown_state = PredicatePushdownState.with_additional_where_filter_specs(
-                original_pushdown_state=predicate_pushdown_state,
-                additional_where_filter_specs=metric_input_measure_spec.filter_specs,
-            )
-
         logger.info(
             f"For\n{indent(mf_pformat(metric_spec))}"
             f"\nneeded measure is:"

--- a/metricflow/dataflow/nodes/combine_aggregated_outputs.py
+++ b/metricflow/dataflow/nodes/combine_aggregated_outputs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence, Union
+from typing import Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.visitor import VisitorOutputT
@@ -16,8 +16,13 @@ class CombineAggregatedOutputsNode(DataflowPlanNode):
 
     def __init__(  # noqa: D107
         self,
-        parent_nodes: Sequence[Union[DataflowPlanNode, DataflowPlanNode]],
+        parent_nodes: Sequence[DataflowPlanNode],
     ) -> None:
+        num_parents = len(parent_nodes)
+        assert num_parents > 1, (
+            "The CombineAggregatedOutputsNode is intended to merge the output datasets from 2 or more nodes, but this "
+            f"node is being initialized with with only {num_parents} parent(s)."
+        )
         super().__init__(node_id=self.create_unique_id(), parent_nodes=parent_nodes)
 
     @classmethod
@@ -37,5 +42,4 @@ class CombineAggregatedOutputsNode(DataflowPlanNode):
     def with_new_parents(  # noqa: D102
         self, new_parent_nodes: Sequence[DataflowPlanNode]
     ) -> CombineAggregatedOutputsNode:
-        assert len(new_parent_nodes) == 1
         return CombineAggregatedOutputsNode(parent_nodes=new_parent_nodes)

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_35
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > DATE_SUB(CAST(subq_30.ds__day AS DATETIME), INTERVAL 7 day)
+            subq_28.ds__day > DATE_SUB(CAST(subq_31.ds__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_35
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
+            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > subq_30.ds__day - INTERVAL 7 day
+            subq_28.ds__day > subq_31.ds__day - INTERVAL 7 day
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > subq_30.ds__day - MAKE_INTERVAL(days => 7)
+            subq_28.ds__day > subq_31.ds__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
+            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
+            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_20.visits) AS visits
-    , MAX(subq_30.buys) AS buys
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_21.visits) AS visits
+    , MAX(subq_31.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,20 +18,28 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_18
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_17
+      WHERE visit__referrer_id = 'ref_id_01'
+    ) subq_19
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_20
+  ) subq_21
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -43,48 +51,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_23.visits) OVER (
+        FIRST_VALUE(subq_24.visits) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_23.ds__day) OVER (
+        , FIRST_VALUE(subq_24.ds__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_23.metric_time__day) OVER (
+        , FIRST_VALUE(subq_24.metric_time__day) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_23.user) OVER (
+        , FIRST_VALUE(subq_24.user) OVER (
           PARTITION BY
-            subq_26.user
-            , subq_26.ds__day
-            , subq_26.mf_internal_uuid
-          ORDER BY subq_23.ds__day DESC
+            subq_27.user
+            , subq_27.ds__day
+            , subq_27.mf_internal_uuid
+          ORDER BY subq_24.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_26.mf_internal_uuid AS mf_internal_uuid
-        , subq_26.buys AS buys
+        , subq_27.mf_internal_uuid AS mf_internal_uuid
+        , subq_27.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +104,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      ) subq_24
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,25 +115,25 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_26
+      ) subq_27
       ON
         (
-          subq_23.user = subq_26.user
+          subq_24.user = subq_27.user
         ) AND (
-          (subq_23.ds__day <= subq_26.ds__day)
+          (subq_24.ds__day <= subq_27.ds__day)
         )
-    ) subq_27
+    ) subq_28
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_30
+  ) subq_31
   ON
     (
-      subq_20.visit__referrer_id = subq_30.visit__referrer_id
+      subq_21.visit__referrer_id = subq_31.visit__referrer_id
     ) AND (
-      subq_20.metric_time__day = subq_30.metric_time__day
+      subq_21.metric_time__day = subq_31.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
-    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
-) subq_31
+    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
+    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
+) subq_32

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -15,20 +15,31 @@ FROM (
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_21
+        visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -39,40 +50,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -85,7 +96,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +107,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
-          (subq_27.ds__day <= subq_30.ds__day)
+          (subq_28.ds__day <= subq_31.ds__day)
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
-    subq_23.visit__referrer_id = subq_34.visit__referrer_id
+    subq_24.visit__referrer_id = subq_35.visit__referrer_id
   GROUP BY
-    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,10 +6,10 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_23.visits) AS visits
-    , MAX(subq_34.buys) AS buys
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_24.visits) AS visits
+    , MAX(subq_35.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
     -- Aggregate Measures
@@ -18,22 +18,33 @@ FROM (
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
+      -- Constrain Output with WHERE
       -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
       -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) subq_21
+        metric_time__day
+        , visit__referrer_id
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_19
+      WHERE (
+        metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+      ) AND (
+        visit__referrer_id = 'ref_id_01'
+      )
+    ) subq_22
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_23
+  ) subq_24
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -45,48 +56,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_27.visits) OVER (
+        FIRST_VALUE(subq_28.visits) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_27.ds__day) OVER (
+        , FIRST_VALUE(subq_28.ds__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_27.metric_time__day) OVER (
+        , FIRST_VALUE(subq_28.metric_time__day) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_27.user) OVER (
+        , FIRST_VALUE(subq_28.user) OVER (
           PARTITION BY
-            subq_30.user
-            , subq_30.ds__day
-            , subq_30.mf_internal_uuid
-          ORDER BY subq_27.ds__day DESC
+            subq_31.user
+            , subq_31.ds__day
+            , subq_31.mf_internal_uuid
+          ORDER BY subq_28.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_30.mf_internal_uuid AS mf_internal_uuid
-        , subq_30.buys AS buys
+        , subq_31.mf_internal_uuid AS mf_internal_uuid
+        , subq_31.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -100,7 +111,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_27
+      ) subq_28
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -111,29 +122,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_30
+      ) subq_31
       ON
         (
-          subq_27.user = subq_30.user
+          subq_28.user = subq_31.user
         ) AND (
           (
-            subq_27.ds__day <= subq_30.ds__day
+            subq_28.ds__day <= subq_31.ds__day
           ) AND (
-            subq_27.ds__day > DATE_ADD('day', -7, subq_30.ds__day)
+            subq_28.ds__day > DATE_ADD('day', -7, subq_31.ds__day)
           )
         )
-    ) subq_31
+    ) subq_32
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_34
+  ) subq_35
   ON
     (
-      subq_23.visit__referrer_id = subq_34.visit__referrer_id
+      subq_24.visit__referrer_id = subq_35.visit__referrer_id
     ) AND (
-      subq_23.metric_time__day = subq_34.metric_time__day
+      subq_24.metric_time__day = subq_35.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
-    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
-) subq_35
+    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
+    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -58,7 +58,7 @@
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
-                                <!-- node_id = NodeId(id_str='wcc_1') -->
+                                <!-- node_id = NodeId(id_str='wcc_0') -->
                                 <!-- where_condition =                                                -->
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->
@@ -100,53 +100,16 @@
                                     <!-- include_spec =                                                        -->
                                     <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                                     <!-- distinct = False -->
-                                    <WhereConstraintNode>
-                                        <!-- description = 'Constrain Output with WHERE' -->
-                                        <!-- node_id = NodeId(id_str='wcc_0') -->
-                                        <!-- where_condition =                                               -->
-                                        <!--   WhereFilterSpec(                                              -->
-                                        <!--     where_sql='booking__is_instant',                            -->
-                                        <!--     bind_parameters=SqlBindParameters(),                        -->
-                                        <!--     linkable_specs=(                                            -->
-                                        <!--       DimensionSpec(                                            -->
-                                        <!--         element_name='is_instant',                              -->
-                                        <!--         entity_links=(                                          -->
-                                        <!--           EntityReference(element_name='booking'),              -->
-                                        <!--         ),                                                      -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
-                                        <!--     linkable_elements=(                                         -->
-                                        <!--       LinkableDimension(                                        -->
-                                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                        <!--           semantic_model_name='bookings_source',                -->
-                                        <!--         ),                                                      -->
-                                        <!--         element_name='is_instant',                              -->
-                                        <!--         dimension_type=CATEGORICAL,                             -->
-                                        <!--         entity_links=(                                          -->
-                                        <!--           EntityReference(                                      -->
-                                        <!--             element_name='booking',                             -->
-                                        <!--           ),                                                    -->
-                                        <!--         ),                                                      -->
-                                        <!--         join_path=SemanticModelJoinPath(                        -->
-                                        <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                        <!--             semantic_model_name='bookings_source',              -->
-                                        <!--           ),                                                    -->
-                                        <!--         ),                                                      -->
-                                        <!--         properties=frozenset('LOCAL',),                         -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
-                                        <!--   )                                                             -->
-                                        <MetricTimeDimensionTransformNode>
-                                            <!-- description = "Metric Time Dimension 'ds'" -->
-                                            <!-- node_id = NodeId(id_str='sma_28002') -->
-                                            <!-- aggregation_time_dimension = 'ds' -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                                <!-- node_id = NodeId(id_str='rss_28014') -->
-                                                <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                            </ReadSqlSourceNode>
-                                        </MetricTimeDimensionTransformNode>
-                                    </WhereConstraintNode>
+                                    <MetricTimeDimensionTransformNode>
+                                        <!-- description = "Metric Time Dimension 'ds'" -->
+                                        <!-- node_id = NodeId(id_str='sma_28002') -->
+                                        <!-- aggregation_time_dimension = 'ds' -->
+                                        <ReadSqlSourceNode>
+                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                            <!-- node_id = NodeId(id_str='rss_28014') -->
+                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                        </ReadSqlSourceNode>
+                                    </MetricTimeDimensionTransformNode>
                                 </FilterElementsNode>
                             </WhereConstraintNode>
                         </FilterElementsNode>

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
@@ -8,420 +8,317 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_12.average_booking_value) AS average_booking_value
-      , MAX(subq_25.bookings) AS bookings
-      , MAX(subq_33.booking_value) AS booking_value
+      MAX(subq_11.average_booking_value) AS average_booking_value
+      , MAX(subq_23.bookings) AS bookings
+      , MAX(subq_30.booking_value) AS booking_value
     FROM (
       -- Compute Metrics via Expressions
       SELECT
-        subq_11.average_booking_value
+        subq_10.average_booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          AVG(subq_10.average_booking_value) AS average_booking_value
+          AVG(subq_9.average_booking_value) AS average_booking_value
         FROM (
           -- Pass Only Elements: ['average_booking_value',]
           SELECT
-            subq_9.average_booking_value
+            subq_8.average_booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_8.booking__is_instant
-              , subq_8.listing__is_lux_latest
-              , subq_8.average_booking_value
+              subq_7.booking__is_instant
+              , subq_7.listing__is_lux_latest
+              , subq_7.average_booking_value
             FROM (
               -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_7.booking__is_instant
-                , subq_7.listing__is_lux_latest
-                , subq_7.average_booking_value
+                subq_6.booking__is_instant
+                , subq_6.listing__is_lux_latest
+                , subq_6.average_booking_value
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_3.listing AS listing
-                  , subq_3.booking__is_instant AS booking__is_instant
-                  , subq_6.is_lux_latest AS listing__is_lux_latest
-                  , subq_3.average_booking_value AS average_booking_value
+                  subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_2.listing
-                    , subq_2.booking__is_instant
-                    , subq_2.average_booking_value
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_1.ds__day
-                      , subq_1.ds__week
-                      , subq_1.ds__month
-                      , subq_1.ds__quarter
-                      , subq_1.ds__year
-                      , subq_1.ds__extract_year
-                      , subq_1.ds__extract_quarter
-                      , subq_1.ds__extract_month
-                      , subq_1.ds__extract_day
-                      , subq_1.ds__extract_dow
-                      , subq_1.ds__extract_doy
-                      , subq_1.ds_partitioned__day
-                      , subq_1.ds_partitioned__week
-                      , subq_1.ds_partitioned__month
-                      , subq_1.ds_partitioned__quarter
-                      , subq_1.ds_partitioned__year
-                      , subq_1.ds_partitioned__extract_year
-                      , subq_1.ds_partitioned__extract_quarter
-                      , subq_1.ds_partitioned__extract_month
-                      , subq_1.ds_partitioned__extract_day
-                      , subq_1.ds_partitioned__extract_dow
-                      , subq_1.ds_partitioned__extract_doy
-                      , subq_1.paid_at__day
-                      , subq_1.paid_at__week
-                      , subq_1.paid_at__month
-                      , subq_1.paid_at__quarter
-                      , subq_1.paid_at__year
-                      , subq_1.paid_at__extract_year
-                      , subq_1.paid_at__extract_quarter
-                      , subq_1.paid_at__extract_month
-                      , subq_1.paid_at__extract_day
-                      , subq_1.paid_at__extract_dow
-                      , subq_1.paid_at__extract_doy
-                      , subq_1.booking__ds__day
-                      , subq_1.booking__ds__week
-                      , subq_1.booking__ds__month
-                      , subq_1.booking__ds__quarter
-                      , subq_1.booking__ds__year
-                      , subq_1.booking__ds__extract_year
-                      , subq_1.booking__ds__extract_quarter
-                      , subq_1.booking__ds__extract_month
-                      , subq_1.booking__ds__extract_day
-                      , subq_1.booking__ds__extract_dow
-                      , subq_1.booking__ds__extract_doy
-                      , subq_1.booking__ds_partitioned__day
-                      , subq_1.booking__ds_partitioned__week
-                      , subq_1.booking__ds_partitioned__month
-                      , subq_1.booking__ds_partitioned__quarter
-                      , subq_1.booking__ds_partitioned__year
-                      , subq_1.booking__ds_partitioned__extract_year
-                      , subq_1.booking__ds_partitioned__extract_quarter
-                      , subq_1.booking__ds_partitioned__extract_month
-                      , subq_1.booking__ds_partitioned__extract_day
-                      , subq_1.booking__ds_partitioned__extract_dow
-                      , subq_1.booking__ds_partitioned__extract_doy
-                      , subq_1.booking__paid_at__day
-                      , subq_1.booking__paid_at__week
-                      , subq_1.booking__paid_at__month
-                      , subq_1.booking__paid_at__quarter
-                      , subq_1.booking__paid_at__year
-                      , subq_1.booking__paid_at__extract_year
-                      , subq_1.booking__paid_at__extract_quarter
-                      , subq_1.booking__paid_at__extract_month
-                      , subq_1.booking__paid_at__extract_day
-                      , subq_1.booking__paid_at__extract_dow
-                      , subq_1.booking__paid_at__extract_doy
-                      , subq_1.metric_time__day
-                      , subq_1.metric_time__week
-                      , subq_1.metric_time__month
-                      , subq_1.metric_time__quarter
-                      , subq_1.metric_time__year
-                      , subq_1.metric_time__extract_year
-                      , subq_1.metric_time__extract_quarter
-                      , subq_1.metric_time__extract_month
-                      , subq_1.metric_time__extract_day
-                      , subq_1.metric_time__extract_dow
-                      , subq_1.metric_time__extract_doy
-                      , subq_1.listing
-                      , subq_1.guest
-                      , subq_1.host
-                      , subq_1.booking__listing
-                      , subq_1.booking__guest
-                      , subq_1.booking__host
-                      , subq_1.is_instant
-                      , subq_1.booking__is_instant
-                      , subq_1.bookings
-                      , subq_1.instant_bookings
-                      , subq_1.booking_value
-                      , subq_1.max_booking_value
-                      , subq_1.min_booking_value
-                      , subq_1.bookers
-                      , subq_1.average_booking_value
-                      , subq_1.referred_bookings
-                      , subq_1.median_booking_value
-                      , subq_1.booking_value_p99
-                      , subq_1.discrete_booking_value_p99
-                      , subq_1.approximate_continuous_booking_value_p99
-                      , subq_1.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_0.ds__day
-                        , subq_0.ds__week
-                        , subq_0.ds__month
-                        , subq_0.ds__quarter
-                        , subq_0.ds__year
-                        , subq_0.ds__extract_year
-                        , subq_0.ds__extract_quarter
-                        , subq_0.ds__extract_month
-                        , subq_0.ds__extract_day
-                        , subq_0.ds__extract_dow
-                        , subq_0.ds__extract_doy
-                        , subq_0.ds_partitioned__day
-                        , subq_0.ds_partitioned__week
-                        , subq_0.ds_partitioned__month
-                        , subq_0.ds_partitioned__quarter
-                        , subq_0.ds_partitioned__year
-                        , subq_0.ds_partitioned__extract_year
-                        , subq_0.ds_partitioned__extract_quarter
-                        , subq_0.ds_partitioned__extract_month
-                        , subq_0.ds_partitioned__extract_day
-                        , subq_0.ds_partitioned__extract_dow
-                        , subq_0.ds_partitioned__extract_doy
-                        , subq_0.paid_at__day
-                        , subq_0.paid_at__week
-                        , subq_0.paid_at__month
-                        , subq_0.paid_at__quarter
-                        , subq_0.paid_at__year
-                        , subq_0.paid_at__extract_year
-                        , subq_0.paid_at__extract_quarter
-                        , subq_0.paid_at__extract_month
-                        , subq_0.paid_at__extract_day
-                        , subq_0.paid_at__extract_dow
-                        , subq_0.paid_at__extract_doy
-                        , subq_0.booking__ds__day
-                        , subq_0.booking__ds__week
-                        , subq_0.booking__ds__month
-                        , subq_0.booking__ds__quarter
-                        , subq_0.booking__ds__year
-                        , subq_0.booking__ds__extract_year
-                        , subq_0.booking__ds__extract_quarter
-                        , subq_0.booking__ds__extract_month
-                        , subq_0.booking__ds__extract_day
-                        , subq_0.booking__ds__extract_dow
-                        , subq_0.booking__ds__extract_doy
-                        , subq_0.booking__ds_partitioned__day
-                        , subq_0.booking__ds_partitioned__week
-                        , subq_0.booking__ds_partitioned__month
-                        , subq_0.booking__ds_partitioned__quarter
-                        , subq_0.booking__ds_partitioned__year
-                        , subq_0.booking__ds_partitioned__extract_year
-                        , subq_0.booking__ds_partitioned__extract_quarter
-                        , subq_0.booking__ds_partitioned__extract_month
-                        , subq_0.booking__ds_partitioned__extract_day
-                        , subq_0.booking__ds_partitioned__extract_dow
-                        , subq_0.booking__ds_partitioned__extract_doy
-                        , subq_0.booking__paid_at__day
-                        , subq_0.booking__paid_at__week
-                        , subq_0.booking__paid_at__month
-                        , subq_0.booking__paid_at__quarter
-                        , subq_0.booking__paid_at__year
-                        , subq_0.booking__paid_at__extract_year
-                        , subq_0.booking__paid_at__extract_quarter
-                        , subq_0.booking__paid_at__extract_month
-                        , subq_0.booking__paid_at__extract_day
-                        , subq_0.booking__paid_at__extract_dow
-                        , subq_0.booking__paid_at__extract_doy
-                        , subq_0.ds__day AS metric_time__day
-                        , subq_0.ds__week AS metric_time__week
-                        , subq_0.ds__month AS metric_time__month
-                        , subq_0.ds__quarter AS metric_time__quarter
-                        , subq_0.ds__year AS metric_time__year
-                        , subq_0.ds__extract_year AS metric_time__extract_year
-                        , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_0.ds__extract_month AS metric_time__extract_month
-                        , subq_0.ds__extract_day AS metric_time__extract_day
-                        , subq_0.ds__extract_dow AS metric_time__extract_dow
-                        , subq_0.ds__extract_doy AS metric_time__extract_doy
-                        , subq_0.listing
-                        , subq_0.guest
-                        , subq_0.host
-                        , subq_0.booking__listing
-                        , subq_0.booking__guest
-                        , subq_0.booking__host
-                        , subq_0.is_instant
-                        , subq_0.booking__is_instant
-                        , subq_0.bookings
-                        , subq_0.instant_bookings
-                        , subq_0.booking_value
-                        , subq_0.max_booking_value
-                        , subq_0.min_booking_value
-                        , subq_0.bookers
-                        , subq_0.average_booking_value
-                        , subq_0.referred_bookings
-                        , subq_0.median_booking_value
-                        , subq_0.booking_value_p99
-                        , subq_0.discrete_booking_value_p99
-                        , subq_0.approximate_continuous_booking_value_p99
-                        , subq_0.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_0
-                    ) subq_1
-                    WHERE booking__is_instant
-                  ) subq_2
-                ) subq_3
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_5.listing
-                    , subq_5.is_lux_latest
+                    subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.average_booking_value
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_4.ds__day
-                      , subq_4.ds__week
-                      , subq_4.ds__month
-                      , subq_4.ds__quarter
-                      , subq_4.ds__year
-                      , subq_4.ds__extract_year
-                      , subq_4.ds__extract_quarter
-                      , subq_4.ds__extract_month
-                      , subq_4.ds__extract_day
-                      , subq_4.ds__extract_dow
-                      , subq_4.ds__extract_doy
-                      , subq_4.created_at__day
-                      , subq_4.created_at__week
-                      , subq_4.created_at__month
-                      , subq_4.created_at__quarter
-                      , subq_4.created_at__year
-                      , subq_4.created_at__extract_year
-                      , subq_4.created_at__extract_quarter
-                      , subq_4.created_at__extract_month
-                      , subq_4.created_at__extract_day
-                      , subq_4.created_at__extract_dow
-                      , subq_4.created_at__extract_doy
-                      , subq_4.listing__ds__day
-                      , subq_4.listing__ds__week
-                      , subq_4.listing__ds__month
-                      , subq_4.listing__ds__quarter
-                      , subq_4.listing__ds__year
-                      , subq_4.listing__ds__extract_year
-                      , subq_4.listing__ds__extract_quarter
-                      , subq_4.listing__ds__extract_month
-                      , subq_4.listing__ds__extract_day
-                      , subq_4.listing__ds__extract_dow
-                      , subq_4.listing__ds__extract_doy
-                      , subq_4.listing__created_at__day
-                      , subq_4.listing__created_at__week
-                      , subq_4.listing__created_at__month
-                      , subq_4.listing__created_at__quarter
-                      , subq_4.listing__created_at__year
-                      , subq_4.listing__created_at__extract_year
-                      , subq_4.listing__created_at__extract_quarter
-                      , subq_4.listing__created_at__extract_month
-                      , subq_4.listing__created_at__extract_day
-                      , subq_4.listing__created_at__extract_dow
-                      , subq_4.listing__created_at__extract_doy
-                      , subq_4.ds__day AS metric_time__day
-                      , subq_4.ds__week AS metric_time__week
-                      , subq_4.ds__month AS metric_time__month
-                      , subq_4.ds__quarter AS metric_time__quarter
-                      , subq_4.ds__year AS metric_time__year
-                      , subq_4.ds__extract_year AS metric_time__extract_year
-                      , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_4.ds__extract_month AS metric_time__extract_month
-                      , subq_4.ds__extract_day AS metric_time__extract_day
-                      , subq_4.ds__extract_dow AS metric_time__extract_dow
-                      , subq_4.ds__extract_doy AS metric_time__extract_doy
-                      , subq_4.listing
-                      , subq_4.user
-                      , subq_4.listing__user
-                      , subq_4.country_latest
-                      , subq_4.is_lux_latest
-                      , subq_4.capacity_latest
-                      , subq_4.listing__country_latest
-                      , subq_4.listing__is_lux_latest
-                      , subq_4.listing__capacity_latest
-                      , subq_4.listings
-                      , subq_4.largest_listing
-                      , subq_4.smallest_listing
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -482,429 +379,326 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_4
-                  ) subq_5
-                ) subq_6
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
                 ON
-                  subq_3.listing = subq_6.listing
-              ) subq_7
-            ) subq_8
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_9
-        ) subq_10
-      ) subq_11
-    ) subq_12
+          ) subq_8
+        ) subq_9
+      ) subq_10
+    ) subq_11
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_24.bookings
+        subq_22.bookings
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_23.bookings) AS bookings
+          SUM(subq_21.bookings) AS bookings
         FROM (
           -- Pass Only Elements: ['bookings',]
           SELECT
-            subq_22.bookings
+            subq_20.bookings
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_21.booking__is_instant
-              , subq_21.listing__is_lux_latest
-              , subq_21.bookings
+              subq_19.booking__is_instant
+              , subq_19.listing__is_lux_latest
+              , subq_19.bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
               SELECT
-                subq_20.booking__is_instant
-                , subq_20.listing__is_lux_latest
-                , subq_20.bookings
+                subq_18.booking__is_instant
+                , subq_18.listing__is_lux_latest
+                , subq_18.bookings
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_16.listing AS listing
-                  , subq_16.booking__is_instant AS booking__is_instant
-                  , subq_19.is_lux_latest AS listing__is_lux_latest
-                  , subq_16.bookings AS bookings
+                  subq_14.listing AS listing
+                  , subq_14.booking__is_instant AS booking__is_instant
+                  , subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
                   SELECT
-                    subq_15.listing
-                    , subq_15.booking__is_instant
-                    , subq_15.bookings
-                  FROM (
-                    -- Constrain Output with WHERE
-                    SELECT
-                      subq_14.ds__day
-                      , subq_14.ds__week
-                      , subq_14.ds__month
-                      , subq_14.ds__quarter
-                      , subq_14.ds__year
-                      , subq_14.ds__extract_year
-                      , subq_14.ds__extract_quarter
-                      , subq_14.ds__extract_month
-                      , subq_14.ds__extract_day
-                      , subq_14.ds__extract_dow
-                      , subq_14.ds__extract_doy
-                      , subq_14.ds_partitioned__day
-                      , subq_14.ds_partitioned__week
-                      , subq_14.ds_partitioned__month
-                      , subq_14.ds_partitioned__quarter
-                      , subq_14.ds_partitioned__year
-                      , subq_14.ds_partitioned__extract_year
-                      , subq_14.ds_partitioned__extract_quarter
-                      , subq_14.ds_partitioned__extract_month
-                      , subq_14.ds_partitioned__extract_day
-                      , subq_14.ds_partitioned__extract_dow
-                      , subq_14.ds_partitioned__extract_doy
-                      , subq_14.paid_at__day
-                      , subq_14.paid_at__week
-                      , subq_14.paid_at__month
-                      , subq_14.paid_at__quarter
-                      , subq_14.paid_at__year
-                      , subq_14.paid_at__extract_year
-                      , subq_14.paid_at__extract_quarter
-                      , subq_14.paid_at__extract_month
-                      , subq_14.paid_at__extract_day
-                      , subq_14.paid_at__extract_dow
-                      , subq_14.paid_at__extract_doy
-                      , subq_14.booking__ds__day
-                      , subq_14.booking__ds__week
-                      , subq_14.booking__ds__month
-                      , subq_14.booking__ds__quarter
-                      , subq_14.booking__ds__year
-                      , subq_14.booking__ds__extract_year
-                      , subq_14.booking__ds__extract_quarter
-                      , subq_14.booking__ds__extract_month
-                      , subq_14.booking__ds__extract_day
-                      , subq_14.booking__ds__extract_dow
-                      , subq_14.booking__ds__extract_doy
-                      , subq_14.booking__ds_partitioned__day
-                      , subq_14.booking__ds_partitioned__week
-                      , subq_14.booking__ds_partitioned__month
-                      , subq_14.booking__ds_partitioned__quarter
-                      , subq_14.booking__ds_partitioned__year
-                      , subq_14.booking__ds_partitioned__extract_year
-                      , subq_14.booking__ds_partitioned__extract_quarter
-                      , subq_14.booking__ds_partitioned__extract_month
-                      , subq_14.booking__ds_partitioned__extract_day
-                      , subq_14.booking__ds_partitioned__extract_dow
-                      , subq_14.booking__ds_partitioned__extract_doy
-                      , subq_14.booking__paid_at__day
-                      , subq_14.booking__paid_at__week
-                      , subq_14.booking__paid_at__month
-                      , subq_14.booking__paid_at__quarter
-                      , subq_14.booking__paid_at__year
-                      , subq_14.booking__paid_at__extract_year
-                      , subq_14.booking__paid_at__extract_quarter
-                      , subq_14.booking__paid_at__extract_month
-                      , subq_14.booking__paid_at__extract_day
-                      , subq_14.booking__paid_at__extract_dow
-                      , subq_14.booking__paid_at__extract_doy
-                      , subq_14.metric_time__day
-                      , subq_14.metric_time__week
-                      , subq_14.metric_time__month
-                      , subq_14.metric_time__quarter
-                      , subq_14.metric_time__year
-                      , subq_14.metric_time__extract_year
-                      , subq_14.metric_time__extract_quarter
-                      , subq_14.metric_time__extract_month
-                      , subq_14.metric_time__extract_day
-                      , subq_14.metric_time__extract_dow
-                      , subq_14.metric_time__extract_doy
-                      , subq_14.listing
-                      , subq_14.guest
-                      , subq_14.host
-                      , subq_14.booking__listing
-                      , subq_14.booking__guest
-                      , subq_14.booking__host
-                      , subq_14.is_instant
-                      , subq_14.booking__is_instant
-                      , subq_14.bookings
-                      , subq_14.instant_bookings
-                      , subq_14.booking_value
-                      , subq_14.max_booking_value
-                      , subq_14.min_booking_value
-                      , subq_14.bookers
-                      , subq_14.average_booking_value
-                      , subq_14.referred_bookings
-                      , subq_14.median_booking_value
-                      , subq_14.booking_value_p99
-                      , subq_14.discrete_booking_value_p99
-                      , subq_14.approximate_continuous_booking_value_p99
-                      , subq_14.approximate_discrete_booking_value_p99
-                    FROM (
-                      -- Metric Time Dimension 'ds'
-                      SELECT
-                        subq_13.ds__day
-                        , subq_13.ds__week
-                        , subq_13.ds__month
-                        , subq_13.ds__quarter
-                        , subq_13.ds__year
-                        , subq_13.ds__extract_year
-                        , subq_13.ds__extract_quarter
-                        , subq_13.ds__extract_month
-                        , subq_13.ds__extract_day
-                        , subq_13.ds__extract_dow
-                        , subq_13.ds__extract_doy
-                        , subq_13.ds_partitioned__day
-                        , subq_13.ds_partitioned__week
-                        , subq_13.ds_partitioned__month
-                        , subq_13.ds_partitioned__quarter
-                        , subq_13.ds_partitioned__year
-                        , subq_13.ds_partitioned__extract_year
-                        , subq_13.ds_partitioned__extract_quarter
-                        , subq_13.ds_partitioned__extract_month
-                        , subq_13.ds_partitioned__extract_day
-                        , subq_13.ds_partitioned__extract_dow
-                        , subq_13.ds_partitioned__extract_doy
-                        , subq_13.paid_at__day
-                        , subq_13.paid_at__week
-                        , subq_13.paid_at__month
-                        , subq_13.paid_at__quarter
-                        , subq_13.paid_at__year
-                        , subq_13.paid_at__extract_year
-                        , subq_13.paid_at__extract_quarter
-                        , subq_13.paid_at__extract_month
-                        , subq_13.paid_at__extract_day
-                        , subq_13.paid_at__extract_dow
-                        , subq_13.paid_at__extract_doy
-                        , subq_13.booking__ds__day
-                        , subq_13.booking__ds__week
-                        , subq_13.booking__ds__month
-                        , subq_13.booking__ds__quarter
-                        , subq_13.booking__ds__year
-                        , subq_13.booking__ds__extract_year
-                        , subq_13.booking__ds__extract_quarter
-                        , subq_13.booking__ds__extract_month
-                        , subq_13.booking__ds__extract_day
-                        , subq_13.booking__ds__extract_dow
-                        , subq_13.booking__ds__extract_doy
-                        , subq_13.booking__ds_partitioned__day
-                        , subq_13.booking__ds_partitioned__week
-                        , subq_13.booking__ds_partitioned__month
-                        , subq_13.booking__ds_partitioned__quarter
-                        , subq_13.booking__ds_partitioned__year
-                        , subq_13.booking__ds_partitioned__extract_year
-                        , subq_13.booking__ds_partitioned__extract_quarter
-                        , subq_13.booking__ds_partitioned__extract_month
-                        , subq_13.booking__ds_partitioned__extract_day
-                        , subq_13.booking__ds_partitioned__extract_dow
-                        , subq_13.booking__ds_partitioned__extract_doy
-                        , subq_13.booking__paid_at__day
-                        , subq_13.booking__paid_at__week
-                        , subq_13.booking__paid_at__month
-                        , subq_13.booking__paid_at__quarter
-                        , subq_13.booking__paid_at__year
-                        , subq_13.booking__paid_at__extract_year
-                        , subq_13.booking__paid_at__extract_quarter
-                        , subq_13.booking__paid_at__extract_month
-                        , subq_13.booking__paid_at__extract_day
-                        , subq_13.booking__paid_at__extract_dow
-                        , subq_13.booking__paid_at__extract_doy
-                        , subq_13.ds__day AS metric_time__day
-                        , subq_13.ds__week AS metric_time__week
-                        , subq_13.ds__month AS metric_time__month
-                        , subq_13.ds__quarter AS metric_time__quarter
-                        , subq_13.ds__year AS metric_time__year
-                        , subq_13.ds__extract_year AS metric_time__extract_year
-                        , subq_13.ds__extract_quarter AS metric_time__extract_quarter
-                        , subq_13.ds__extract_month AS metric_time__extract_month
-                        , subq_13.ds__extract_day AS metric_time__extract_day
-                        , subq_13.ds__extract_dow AS metric_time__extract_dow
-                        , subq_13.ds__extract_doy AS metric_time__extract_doy
-                        , subq_13.listing
-                        , subq_13.guest
-                        , subq_13.host
-                        , subq_13.booking__listing
-                        , subq_13.booking__guest
-                        , subq_13.booking__host
-                        , subq_13.is_instant
-                        , subq_13.booking__is_instant
-                        , subq_13.bookings
-                        , subq_13.instant_bookings
-                        , subq_13.booking_value
-                        , subq_13.max_booking_value
-                        , subq_13.min_booking_value
-                        , subq_13.bookers
-                        , subq_13.average_booking_value
-                        , subq_13.referred_bookings
-                        , subq_13.median_booking_value
-                        , subq_13.booking_value_p99
-                        , subq_13.discrete_booking_value_p99
-                        , subq_13.approximate_continuous_booking_value_p99
-                        , subq_13.approximate_discrete_booking_value_p99
-                      FROM (
-                        -- Read Elements From Semantic Model 'bookings_source'
-                        SELECT
-                          1 AS bookings
-                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                          , bookings_source_src_28000.booking_value
-                          , bookings_source_src_28000.booking_value AS max_booking_value
-                          , bookings_source_src_28000.booking_value AS min_booking_value
-                          , bookings_source_src_28000.guest_id AS bookers
-                          , bookings_source_src_28000.booking_value AS average_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_payments
-                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                          , bookings_source_src_28000.booking_value AS median_booking_value
-                          , bookings_source_src_28000.booking_value AS booking_value_p99
-                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                          , bookings_source_src_28000.is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                          , bookings_source_src_28000.is_instant AS booking__is_instant
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                          , bookings_source_src_28000.listing_id AS listing
-                          , bookings_source_src_28000.guest_id AS guest
-                          , bookings_source_src_28000.host_id AS host
-                          , bookings_source_src_28000.listing_id AS booking__listing
-                          , bookings_source_src_28000.guest_id AS booking__guest
-                          , bookings_source_src_28000.host_id AS booking__host
-                        FROM ***************************.fct_bookings bookings_source_src_28000
-                      ) subq_13
-                    ) subq_14
-                    WHERE booking__is_instant
-                  ) subq_15
-                ) subq_16
-                LEFT OUTER JOIN (
-                  -- Pass Only Elements: ['is_lux_latest', 'listing']
-                  SELECT
-                    subq_18.listing
-                    , subq_18.is_lux_latest
+                    subq_13.listing
+                    , subq_13.booking__is_instant
+                    , subq_13.bookings
                   FROM (
                     -- Metric Time Dimension 'ds'
                     SELECT
-                      subq_17.ds__day
-                      , subq_17.ds__week
-                      , subq_17.ds__month
-                      , subq_17.ds__quarter
-                      , subq_17.ds__year
-                      , subq_17.ds__extract_year
-                      , subq_17.ds__extract_quarter
-                      , subq_17.ds__extract_month
-                      , subq_17.ds__extract_day
-                      , subq_17.ds__extract_dow
-                      , subq_17.ds__extract_doy
-                      , subq_17.created_at__day
-                      , subq_17.created_at__week
-                      , subq_17.created_at__month
-                      , subq_17.created_at__quarter
-                      , subq_17.created_at__year
-                      , subq_17.created_at__extract_year
-                      , subq_17.created_at__extract_quarter
-                      , subq_17.created_at__extract_month
-                      , subq_17.created_at__extract_day
-                      , subq_17.created_at__extract_dow
-                      , subq_17.created_at__extract_doy
-                      , subq_17.listing__ds__day
-                      , subq_17.listing__ds__week
-                      , subq_17.listing__ds__month
-                      , subq_17.listing__ds__quarter
-                      , subq_17.listing__ds__year
-                      , subq_17.listing__ds__extract_year
-                      , subq_17.listing__ds__extract_quarter
-                      , subq_17.listing__ds__extract_month
-                      , subq_17.listing__ds__extract_day
-                      , subq_17.listing__ds__extract_dow
-                      , subq_17.listing__ds__extract_doy
-                      , subq_17.listing__created_at__day
-                      , subq_17.listing__created_at__week
-                      , subq_17.listing__created_at__month
-                      , subq_17.listing__created_at__quarter
-                      , subq_17.listing__created_at__year
-                      , subq_17.listing__created_at__extract_year
-                      , subq_17.listing__created_at__extract_quarter
-                      , subq_17.listing__created_at__extract_month
-                      , subq_17.listing__created_at__extract_day
-                      , subq_17.listing__created_at__extract_dow
-                      , subq_17.listing__created_at__extract_doy
-                      , subq_17.ds__day AS metric_time__day
-                      , subq_17.ds__week AS metric_time__week
-                      , subq_17.ds__month AS metric_time__month
-                      , subq_17.ds__quarter AS metric_time__quarter
-                      , subq_17.ds__year AS metric_time__year
-                      , subq_17.ds__extract_year AS metric_time__extract_year
-                      , subq_17.ds__extract_quarter AS metric_time__extract_quarter
-                      , subq_17.ds__extract_month AS metric_time__extract_month
-                      , subq_17.ds__extract_day AS metric_time__extract_day
-                      , subq_17.ds__extract_dow AS metric_time__extract_dow
-                      , subq_17.ds__extract_doy AS metric_time__extract_doy
-                      , subq_17.listing
-                      , subq_17.user
-                      , subq_17.listing__user
-                      , subq_17.country_latest
-                      , subq_17.is_lux_latest
-                      , subq_17.capacity_latest
-                      , subq_17.listing__country_latest
-                      , subq_17.listing__is_lux_latest
-                      , subq_17.listing__capacity_latest
-                      , subq_17.listings
-                      , subq_17.largest_listing
-                      , subq_17.smallest_listing
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                ) subq_14
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['is_lux_latest', 'listing']
+                  SELECT
+                    subq_16.listing
+                    , subq_16.is_lux_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_15.ds__day
+                      , subq_15.ds__week
+                      , subq_15.ds__month
+                      , subq_15.ds__quarter
+                      , subq_15.ds__year
+                      , subq_15.ds__extract_year
+                      , subq_15.ds__extract_quarter
+                      , subq_15.ds__extract_month
+                      , subq_15.ds__extract_day
+                      , subq_15.ds__extract_dow
+                      , subq_15.ds__extract_doy
+                      , subq_15.created_at__day
+                      , subq_15.created_at__week
+                      , subq_15.created_at__month
+                      , subq_15.created_at__quarter
+                      , subq_15.created_at__year
+                      , subq_15.created_at__extract_year
+                      , subq_15.created_at__extract_quarter
+                      , subq_15.created_at__extract_month
+                      , subq_15.created_at__extract_day
+                      , subq_15.created_at__extract_dow
+                      , subq_15.created_at__extract_doy
+                      , subq_15.listing__ds__day
+                      , subq_15.listing__ds__week
+                      , subq_15.listing__ds__month
+                      , subq_15.listing__ds__quarter
+                      , subq_15.listing__ds__year
+                      , subq_15.listing__ds__extract_year
+                      , subq_15.listing__ds__extract_quarter
+                      , subq_15.listing__ds__extract_month
+                      , subq_15.listing__ds__extract_day
+                      , subq_15.listing__ds__extract_dow
+                      , subq_15.listing__ds__extract_doy
+                      , subq_15.listing__created_at__day
+                      , subq_15.listing__created_at__week
+                      , subq_15.listing__created_at__month
+                      , subq_15.listing__created_at__quarter
+                      , subq_15.listing__created_at__year
+                      , subq_15.listing__created_at__extract_year
+                      , subq_15.listing__created_at__extract_quarter
+                      , subq_15.listing__created_at__extract_month
+                      , subq_15.listing__created_at__extract_day
+                      , subq_15.listing__created_at__extract_dow
+                      , subq_15.listing__created_at__extract_doy
+                      , subq_15.ds__day AS metric_time__day
+                      , subq_15.ds__week AS metric_time__week
+                      , subq_15.ds__month AS metric_time__month
+                      , subq_15.ds__quarter AS metric_time__quarter
+                      , subq_15.ds__year AS metric_time__year
+                      , subq_15.ds__extract_year AS metric_time__extract_year
+                      , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_15.ds__extract_month AS metric_time__extract_month
+                      , subq_15.ds__extract_day AS metric_time__extract_day
+                      , subq_15.ds__extract_dow AS metric_time__extract_dow
+                      , subq_15.ds__extract_doy AS metric_time__extract_doy
+                      , subq_15.listing
+                      , subq_15.user
+                      , subq_15.listing__user
+                      , subq_15.country_latest
+                      , subq_15.is_lux_latest
+                      , subq_15.capacity_latest
+                      , subq_15.listing__country_latest
+                      , subq_15.listing__is_lux_latest
+                      , subq_15.listing__capacity_latest
+                      , subq_15.listings
+                      , subq_15.largest_listing
+                      , subq_15.smallest_listing
                     FROM (
                       -- Read Elements From Semantic Model 'listings_latest'
                       SELECT
@@ -965,343 +759,240 @@ FROM (
                         , listings_latest_src_28000.user_id AS user
                         , listings_latest_src_28000.user_id AS listing__user
                       FROM ***************************.dim_listings_latest listings_latest_src_28000
-                    ) subq_17
-                  ) subq_18
-                ) subq_19
+                    ) subq_15
+                  ) subq_16
+                ) subq_17
                 ON
-                  subq_16.listing = subq_19.listing
-              ) subq_20
-            ) subq_21
+                  subq_14.listing = subq_17.listing
+              ) subq_18
+            ) subq_19
             WHERE (listing__is_lux_latest) AND (booking__is_instant)
-          ) subq_22
-        ) subq_23
-      ) subq_24
-    ) subq_25
+          ) subq_20
+        ) subq_21
+      ) subq_22
+    ) subq_23
     CROSS JOIN (
       -- Compute Metrics via Expressions
       SELECT
-        subq_32.booking_value
+        subq_29.booking_value
       FROM (
         -- Aggregate Measures
         SELECT
-          SUM(subq_31.booking_value) AS booking_value
+          SUM(subq_28.booking_value) AS booking_value
         FROM (
           -- Pass Only Elements: ['booking_value',]
           SELECT
-            subq_30.booking_value
+            subq_27.booking_value
           FROM (
             -- Constrain Output with WHERE
             SELECT
-              subq_29.booking__is_instant
-              , subq_29.booking_value
+              subq_26.booking__is_instant
+              , subq_26.booking_value
             FROM (
               -- Pass Only Elements: ['booking_value', 'booking__is_instant']
               SELECT
-                subq_28.booking__is_instant
-                , subq_28.booking_value
+                subq_25.booking__is_instant
+                , subq_25.booking_value
               FROM (
-                -- Constrain Output with WHERE
+                -- Metric Time Dimension 'ds'
                 SELECT
-                  subq_27.ds__day
-                  , subq_27.ds__week
-                  , subq_27.ds__month
-                  , subq_27.ds__quarter
-                  , subq_27.ds__year
-                  , subq_27.ds__extract_year
-                  , subq_27.ds__extract_quarter
-                  , subq_27.ds__extract_month
-                  , subq_27.ds__extract_day
-                  , subq_27.ds__extract_dow
-                  , subq_27.ds__extract_doy
-                  , subq_27.ds_partitioned__day
-                  , subq_27.ds_partitioned__week
-                  , subq_27.ds_partitioned__month
-                  , subq_27.ds_partitioned__quarter
-                  , subq_27.ds_partitioned__year
-                  , subq_27.ds_partitioned__extract_year
-                  , subq_27.ds_partitioned__extract_quarter
-                  , subq_27.ds_partitioned__extract_month
-                  , subq_27.ds_partitioned__extract_day
-                  , subq_27.ds_partitioned__extract_dow
-                  , subq_27.ds_partitioned__extract_doy
-                  , subq_27.paid_at__day
-                  , subq_27.paid_at__week
-                  , subq_27.paid_at__month
-                  , subq_27.paid_at__quarter
-                  , subq_27.paid_at__year
-                  , subq_27.paid_at__extract_year
-                  , subq_27.paid_at__extract_quarter
-                  , subq_27.paid_at__extract_month
-                  , subq_27.paid_at__extract_day
-                  , subq_27.paid_at__extract_dow
-                  , subq_27.paid_at__extract_doy
-                  , subq_27.booking__ds__day
-                  , subq_27.booking__ds__week
-                  , subq_27.booking__ds__month
-                  , subq_27.booking__ds__quarter
-                  , subq_27.booking__ds__year
-                  , subq_27.booking__ds__extract_year
-                  , subq_27.booking__ds__extract_quarter
-                  , subq_27.booking__ds__extract_month
-                  , subq_27.booking__ds__extract_day
-                  , subq_27.booking__ds__extract_dow
-                  , subq_27.booking__ds__extract_doy
-                  , subq_27.booking__ds_partitioned__day
-                  , subq_27.booking__ds_partitioned__week
-                  , subq_27.booking__ds_partitioned__month
-                  , subq_27.booking__ds_partitioned__quarter
-                  , subq_27.booking__ds_partitioned__year
-                  , subq_27.booking__ds_partitioned__extract_year
-                  , subq_27.booking__ds_partitioned__extract_quarter
-                  , subq_27.booking__ds_partitioned__extract_month
-                  , subq_27.booking__ds_partitioned__extract_day
-                  , subq_27.booking__ds_partitioned__extract_dow
-                  , subq_27.booking__ds_partitioned__extract_doy
-                  , subq_27.booking__paid_at__day
-                  , subq_27.booking__paid_at__week
-                  , subq_27.booking__paid_at__month
-                  , subq_27.booking__paid_at__quarter
-                  , subq_27.booking__paid_at__year
-                  , subq_27.booking__paid_at__extract_year
-                  , subq_27.booking__paid_at__extract_quarter
-                  , subq_27.booking__paid_at__extract_month
-                  , subq_27.booking__paid_at__extract_day
-                  , subq_27.booking__paid_at__extract_dow
-                  , subq_27.booking__paid_at__extract_doy
-                  , subq_27.metric_time__day
-                  , subq_27.metric_time__week
-                  , subq_27.metric_time__month
-                  , subq_27.metric_time__quarter
-                  , subq_27.metric_time__year
-                  , subq_27.metric_time__extract_year
-                  , subq_27.metric_time__extract_quarter
-                  , subq_27.metric_time__extract_month
-                  , subq_27.metric_time__extract_day
-                  , subq_27.metric_time__extract_dow
-                  , subq_27.metric_time__extract_doy
-                  , subq_27.listing
-                  , subq_27.guest
-                  , subq_27.host
-                  , subq_27.booking__listing
-                  , subq_27.booking__guest
-                  , subq_27.booking__host
-                  , subq_27.is_instant
-                  , subq_27.booking__is_instant
-                  , subq_27.bookings
-                  , subq_27.instant_bookings
-                  , subq_27.booking_value
-                  , subq_27.max_booking_value
-                  , subq_27.min_booking_value
-                  , subq_27.bookers
-                  , subq_27.average_booking_value
-                  , subq_27.referred_bookings
-                  , subq_27.median_booking_value
-                  , subq_27.booking_value_p99
-                  , subq_27.discrete_booking_value_p99
-                  , subq_27.approximate_continuous_booking_value_p99
-                  , subq_27.approximate_discrete_booking_value_p99
+                  subq_24.ds__day
+                  , subq_24.ds__week
+                  , subq_24.ds__month
+                  , subq_24.ds__quarter
+                  , subq_24.ds__year
+                  , subq_24.ds__extract_year
+                  , subq_24.ds__extract_quarter
+                  , subq_24.ds__extract_month
+                  , subq_24.ds__extract_day
+                  , subq_24.ds__extract_dow
+                  , subq_24.ds__extract_doy
+                  , subq_24.ds_partitioned__day
+                  , subq_24.ds_partitioned__week
+                  , subq_24.ds_partitioned__month
+                  , subq_24.ds_partitioned__quarter
+                  , subq_24.ds_partitioned__year
+                  , subq_24.ds_partitioned__extract_year
+                  , subq_24.ds_partitioned__extract_quarter
+                  , subq_24.ds_partitioned__extract_month
+                  , subq_24.ds_partitioned__extract_day
+                  , subq_24.ds_partitioned__extract_dow
+                  , subq_24.ds_partitioned__extract_doy
+                  , subq_24.paid_at__day
+                  , subq_24.paid_at__week
+                  , subq_24.paid_at__month
+                  , subq_24.paid_at__quarter
+                  , subq_24.paid_at__year
+                  , subq_24.paid_at__extract_year
+                  , subq_24.paid_at__extract_quarter
+                  , subq_24.paid_at__extract_month
+                  , subq_24.paid_at__extract_day
+                  , subq_24.paid_at__extract_dow
+                  , subq_24.paid_at__extract_doy
+                  , subq_24.booking__ds__day
+                  , subq_24.booking__ds__week
+                  , subq_24.booking__ds__month
+                  , subq_24.booking__ds__quarter
+                  , subq_24.booking__ds__year
+                  , subq_24.booking__ds__extract_year
+                  , subq_24.booking__ds__extract_quarter
+                  , subq_24.booking__ds__extract_month
+                  , subq_24.booking__ds__extract_day
+                  , subq_24.booking__ds__extract_dow
+                  , subq_24.booking__ds__extract_doy
+                  , subq_24.booking__ds_partitioned__day
+                  , subq_24.booking__ds_partitioned__week
+                  , subq_24.booking__ds_partitioned__month
+                  , subq_24.booking__ds_partitioned__quarter
+                  , subq_24.booking__ds_partitioned__year
+                  , subq_24.booking__ds_partitioned__extract_year
+                  , subq_24.booking__ds_partitioned__extract_quarter
+                  , subq_24.booking__ds_partitioned__extract_month
+                  , subq_24.booking__ds_partitioned__extract_day
+                  , subq_24.booking__ds_partitioned__extract_dow
+                  , subq_24.booking__ds_partitioned__extract_doy
+                  , subq_24.booking__paid_at__day
+                  , subq_24.booking__paid_at__week
+                  , subq_24.booking__paid_at__month
+                  , subq_24.booking__paid_at__quarter
+                  , subq_24.booking__paid_at__year
+                  , subq_24.booking__paid_at__extract_year
+                  , subq_24.booking__paid_at__extract_quarter
+                  , subq_24.booking__paid_at__extract_month
+                  , subq_24.booking__paid_at__extract_day
+                  , subq_24.booking__paid_at__extract_dow
+                  , subq_24.booking__paid_at__extract_doy
+                  , subq_24.ds__day AS metric_time__day
+                  , subq_24.ds__week AS metric_time__week
+                  , subq_24.ds__month AS metric_time__month
+                  , subq_24.ds__quarter AS metric_time__quarter
+                  , subq_24.ds__year AS metric_time__year
+                  , subq_24.ds__extract_year AS metric_time__extract_year
+                  , subq_24.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_24.ds__extract_month AS metric_time__extract_month
+                  , subq_24.ds__extract_day AS metric_time__extract_day
+                  , subq_24.ds__extract_dow AS metric_time__extract_dow
+                  , subq_24.ds__extract_doy AS metric_time__extract_doy
+                  , subq_24.listing
+                  , subq_24.guest
+                  , subq_24.host
+                  , subq_24.booking__listing
+                  , subq_24.booking__guest
+                  , subq_24.booking__host
+                  , subq_24.is_instant
+                  , subq_24.booking__is_instant
+                  , subq_24.bookings
+                  , subq_24.instant_bookings
+                  , subq_24.booking_value
+                  , subq_24.max_booking_value
+                  , subq_24.min_booking_value
+                  , subq_24.bookers
+                  , subq_24.average_booking_value
+                  , subq_24.referred_bookings
+                  , subq_24.median_booking_value
+                  , subq_24.booking_value_p99
+                  , subq_24.discrete_booking_value_p99
+                  , subq_24.approximate_continuous_booking_value_p99
+                  , subq_24.approximate_discrete_booking_value_p99
                 FROM (
-                  -- Metric Time Dimension 'ds'
+                  -- Read Elements From Semantic Model 'bookings_source'
                   SELECT
-                    subq_26.ds__day
-                    , subq_26.ds__week
-                    , subq_26.ds__month
-                    , subq_26.ds__quarter
-                    , subq_26.ds__year
-                    , subq_26.ds__extract_year
-                    , subq_26.ds__extract_quarter
-                    , subq_26.ds__extract_month
-                    , subq_26.ds__extract_day
-                    , subq_26.ds__extract_dow
-                    , subq_26.ds__extract_doy
-                    , subq_26.ds_partitioned__day
-                    , subq_26.ds_partitioned__week
-                    , subq_26.ds_partitioned__month
-                    , subq_26.ds_partitioned__quarter
-                    , subq_26.ds_partitioned__year
-                    , subq_26.ds_partitioned__extract_year
-                    , subq_26.ds_partitioned__extract_quarter
-                    , subq_26.ds_partitioned__extract_month
-                    , subq_26.ds_partitioned__extract_day
-                    , subq_26.ds_partitioned__extract_dow
-                    , subq_26.ds_partitioned__extract_doy
-                    , subq_26.paid_at__day
-                    , subq_26.paid_at__week
-                    , subq_26.paid_at__month
-                    , subq_26.paid_at__quarter
-                    , subq_26.paid_at__year
-                    , subq_26.paid_at__extract_year
-                    , subq_26.paid_at__extract_quarter
-                    , subq_26.paid_at__extract_month
-                    , subq_26.paid_at__extract_day
-                    , subq_26.paid_at__extract_dow
-                    , subq_26.paid_at__extract_doy
-                    , subq_26.booking__ds__day
-                    , subq_26.booking__ds__week
-                    , subq_26.booking__ds__month
-                    , subq_26.booking__ds__quarter
-                    , subq_26.booking__ds__year
-                    , subq_26.booking__ds__extract_year
-                    , subq_26.booking__ds__extract_quarter
-                    , subq_26.booking__ds__extract_month
-                    , subq_26.booking__ds__extract_day
-                    , subq_26.booking__ds__extract_dow
-                    , subq_26.booking__ds__extract_doy
-                    , subq_26.booking__ds_partitioned__day
-                    , subq_26.booking__ds_partitioned__week
-                    , subq_26.booking__ds_partitioned__month
-                    , subq_26.booking__ds_partitioned__quarter
-                    , subq_26.booking__ds_partitioned__year
-                    , subq_26.booking__ds_partitioned__extract_year
-                    , subq_26.booking__ds_partitioned__extract_quarter
-                    , subq_26.booking__ds_partitioned__extract_month
-                    , subq_26.booking__ds_partitioned__extract_day
-                    , subq_26.booking__ds_partitioned__extract_dow
-                    , subq_26.booking__ds_partitioned__extract_doy
-                    , subq_26.booking__paid_at__day
-                    , subq_26.booking__paid_at__week
-                    , subq_26.booking__paid_at__month
-                    , subq_26.booking__paid_at__quarter
-                    , subq_26.booking__paid_at__year
-                    , subq_26.booking__paid_at__extract_year
-                    , subq_26.booking__paid_at__extract_quarter
-                    , subq_26.booking__paid_at__extract_month
-                    , subq_26.booking__paid_at__extract_day
-                    , subq_26.booking__paid_at__extract_dow
-                    , subq_26.booking__paid_at__extract_doy
-                    , subq_26.ds__day AS metric_time__day
-                    , subq_26.ds__week AS metric_time__week
-                    , subq_26.ds__month AS metric_time__month
-                    , subq_26.ds__quarter AS metric_time__quarter
-                    , subq_26.ds__year AS metric_time__year
-                    , subq_26.ds__extract_year AS metric_time__extract_year
-                    , subq_26.ds__extract_quarter AS metric_time__extract_quarter
-                    , subq_26.ds__extract_month AS metric_time__extract_month
-                    , subq_26.ds__extract_day AS metric_time__extract_day
-                    , subq_26.ds__extract_dow AS metric_time__extract_dow
-                    , subq_26.ds__extract_doy AS metric_time__extract_doy
-                    , subq_26.listing
-                    , subq_26.guest
-                    , subq_26.host
-                    , subq_26.booking__listing
-                    , subq_26.booking__guest
-                    , subq_26.booking__host
-                    , subq_26.is_instant
-                    , subq_26.booking__is_instant
-                    , subq_26.bookings
-                    , subq_26.instant_bookings
-                    , subq_26.booking_value
-                    , subq_26.max_booking_value
-                    , subq_26.min_booking_value
-                    , subq_26.bookers
-                    , subq_26.average_booking_value
-                    , subq_26.referred_bookings
-                    , subq_26.median_booking_value
-                    , subq_26.booking_value_p99
-                    , subq_26.discrete_booking_value_p99
-                    , subq_26.approximate_continuous_booking_value_p99
-                    , subq_26.approximate_discrete_booking_value_p99
-                  FROM (
-                    -- Read Elements From Semantic Model 'bookings_source'
-                    SELECT
-                      1 AS bookings
-                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                      , bookings_source_src_28000.booking_value
-                      , bookings_source_src_28000.booking_value AS max_booking_value
-                      , bookings_source_src_28000.booking_value AS min_booking_value
-                      , bookings_source_src_28000.guest_id AS bookers
-                      , bookings_source_src_28000.booking_value AS average_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_payments
-                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                      , bookings_source_src_28000.booking_value AS median_booking_value
-                      , bookings_source_src_28000.booking_value AS booking_value_p99
-                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                      , bookings_source_src_28000.is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                      , bookings_source_src_28000.is_instant AS booking__is_instant
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                      , bookings_source_src_28000.listing_id AS listing
-                      , bookings_source_src_28000.guest_id AS guest
-                      , bookings_source_src_28000.host_id AS host
-                      , bookings_source_src_28000.listing_id AS booking__listing
-                      , bookings_source_src_28000.guest_id AS booking__guest
-                      , bookings_source_src_28000.host_id AS booking__host
-                    FROM ***************************.fct_bookings bookings_source_src_28000
-                  ) subq_26
-                ) subq_27
-                WHERE booking__is_instant
-              ) subq_28
-            ) subq_29
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_24
+              ) subq_25
+            ) subq_26
             WHERE booking__is_instant
-          ) subq_30
-        ) subq_31
-      ) subq_32
-    ) subq_33
-  ) subq_34
-) subq_35
+          ) subq_27
+        ) subq_28
+      ) subq_29
+    ) subq_30
+  ) subq_31
+) subq_32

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_48.average_booking_value) AS average_booking_value
-      , MAX(subq_61.bookings) AS bookings
-      , MAX(subq_69.booking_value) AS booking_value
+      MAX(subq_45.average_booking_value) AS average_booking_value
+      , MAX(subq_58.bookings) AS bookings
+      , MAX(subq_66.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,9 +22,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_39.booking__is_instant AS booking__is_instant
+          subq_36.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_39.average_booking_value AS average_booking_value
+          , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -40,16 +40,16 @@ FROM (
               , is_instant AS booking__is_instant
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_37
+          ) subq_34
           WHERE booking__is_instant
-        ) subq_39
+        ) subq_36
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_39.listing = listings_latest_src_28000.listing_id
-      ) subq_44
+          subq_36.listing = listings_latest_src_28000.listing_id
+      ) subq_41
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_48
+    ) subq_45
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['bookings',]
@@ -61,9 +61,9 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_52.booking__is_instant AS booking__is_instant
+          subq_49.booking__is_instant AS booking__is_instant
           , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_52.bookings AS bookings
+          , subq_49.bookings AS bookings
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -79,16 +79,16 @@ FROM (
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_50
+          ) subq_47
           WHERE booking__is_instant
-        ) subq_52
+        ) subq_49
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_52.listing = listings_latest_src_28000.listing_id
-      ) subq_57
+          subq_49.listing = listings_latest_src_28000.listing_id
+      ) subq_54
       WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_61
+    ) subq_58
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value',]
@@ -109,10 +109,10 @@ FROM (
             is_instant AS booking__is_instant
             , booking_value
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_63
+        ) subq_60
         WHERE booking__is_instant
-      ) subq_65
+      ) subq_62
       WHERE booking__is_instant
-    ) subq_69
-  ) subq_70
-) subq_71
+    ) subq_66
+  ) subq_67
+) subq_68

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS acquired_ds__day
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS acquired_ds__week
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS acquired_ds__month
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS acquired_ds__quarter
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS acquired_ds__extract_dow
-                              , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS customer_id__acquired_ds__day
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS customer_id__acquired_ds__week
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS customer_id__acquired_ds__month
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS customer_id__acquired_ds__quarter
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS customer_third_hop_id__acquired_ds__day
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS customer_third_hop_id__acquired_ds__week
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS customer_third_hop_id__acquired_ds__month
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS acquired_ds__day
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS acquired_ds__week
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS acquired_ds__month
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS acquired_ds__quarter
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS acquired_ds__extract_dow
+                            , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS customer_id__acquired_ds__day
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS customer_id__acquired_ds__week
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS customer_id__acquired_ds__month
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS customer_id__acquired_ds__quarter
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, day) AS customer_third_hop_id__acquired_ds__day
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, isoweek) AS customer_third_hop_id__acquired_ds__week
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, month) AS customer_third_hop_id__acquired_ds__month
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, quarter) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATETIME_TRUNC(customer_other_data_src_22000.acquired_ds, year) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , IF(EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) = 1, 7, EXTRACT(dayofweek FROM customer_other_data_src_22000.acquired_ds) - 1) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(dayofyear FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
                   customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , EXTRACT(DAYOFWEEK_ISO FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , EXTRACT(isodow FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , CASE WHEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) = 0 THEN EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) + 7 ELSE EXTRACT(dow FROM customer_other_data_src_22000.acquired_ds) END AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , EXTRACT(dayofweekiso FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
@@ -1,30 +1,30 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_16.third_hop_count
+  subq_15.third_hop_count
 FROM (
   -- Aggregate Measures
   SELECT
-    COUNT(DISTINCT subq_15.third_hop_count) AS third_hop_count
+    COUNT(DISTINCT subq_14.third_hop_count) AS third_hop_count
   FROM (
     -- Pass Only Elements: ['third_hop_count',]
     SELECT
-      subq_14.third_hop_count
+      subq_13.third_hop_count
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_13.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-        , subq_13.third_hop_count
+        subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+        , subq_12.third_hop_count
       FROM (
         -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
         SELECT
-          subq_12.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
-          , subq_12.third_hop_count
+          subq_11.customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+          , subq_11.third_hop_count
         FROM (
           -- Join Standard Outputs
           SELECT
             subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
-            , subq_11.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -107,208 +107,151 @@ FROM (
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['customer_id__customer_third_hop_id', 'customer_id__customer_third_hop_id__paraguayan_customers']
             SELECT
-              subq_10.customer_id__customer_third_hop_id
-              , subq_10.customer_id__customer_third_hop_id__paraguayan_customers
+              subq_9.customer_id__customer_third_hop_id
+              , subq_9.customer_id__customer_third_hop_id__paraguayan_customers
             FROM (
               -- Compute Metrics via Expressions
               SELECT
-                subq_9.customer_id__customer_third_hop_id
-                , subq_9.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
+                subq_8.customer_id__customer_third_hop_id
+                , subq_8.customers_with_other_data AS customer_id__customer_third_hop_id__paraguayan_customers
               FROM (
                 -- Aggregate Measures
                 SELECT
-                  subq_8.customer_id__customer_third_hop_id
-                  , SUM(subq_8.customers_with_other_data) AS customers_with_other_data
+                  subq_7.customer_id__customer_third_hop_id
+                  , SUM(subq_7.customers_with_other_data) AS customers_with_other_data
                 FROM (
                   -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
                   SELECT
-                    subq_7.customer_id__customer_third_hop_id
-                    , subq_7.customers_with_other_data
+                    subq_6.customer_id__customer_third_hop_id
+                    , subq_6.customers_with_other_data
                   FROM (
                     -- Constrain Output with WHERE
                     SELECT
-                      subq_6.customer_id__customer_third_hop_id
-                      , subq_6.customer_id__country
-                      , subq_6.customers_with_other_data
+                      subq_5.customer_id__customer_third_hop_id
+                      , subq_5.customer_id__country
+                      , subq_5.customers_with_other_data
                     FROM (
                       -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
                       SELECT
-                        subq_5.customer_id__customer_third_hop_id
-                        , subq_5.customer_id__country
-                        , subq_5.customers_with_other_data
+                        subq_4.customer_id__customer_third_hop_id
+                        , subq_4.customer_id__country
+                        , subq_4.customers_with_other_data
                       FROM (
-                        -- Constrain Output with WHERE
+                        -- Metric Time Dimension 'acquired_ds'
                         SELECT
-                          subq_4.acquired_ds__day
-                          , subq_4.acquired_ds__week
-                          , subq_4.acquired_ds__month
-                          , subq_4.acquired_ds__quarter
-                          , subq_4.acquired_ds__year
-                          , subq_4.acquired_ds__extract_year
-                          , subq_4.acquired_ds__extract_quarter
-                          , subq_4.acquired_ds__extract_month
-                          , subq_4.acquired_ds__extract_day
-                          , subq_4.acquired_ds__extract_dow
-                          , subq_4.acquired_ds__extract_doy
-                          , subq_4.customer_id__acquired_ds__day
-                          , subq_4.customer_id__acquired_ds__week
-                          , subq_4.customer_id__acquired_ds__month
-                          , subq_4.customer_id__acquired_ds__quarter
-                          , subq_4.customer_id__acquired_ds__year
-                          , subq_4.customer_id__acquired_ds__extract_year
-                          , subq_4.customer_id__acquired_ds__extract_quarter
-                          , subq_4.customer_id__acquired_ds__extract_month
-                          , subq_4.customer_id__acquired_ds__extract_day
-                          , subq_4.customer_id__acquired_ds__extract_dow
-                          , subq_4.customer_id__acquired_ds__extract_doy
-                          , subq_4.customer_third_hop_id__acquired_ds__day
-                          , subq_4.customer_third_hop_id__acquired_ds__week
-                          , subq_4.customer_third_hop_id__acquired_ds__month
-                          , subq_4.customer_third_hop_id__acquired_ds__quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_year
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_month
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_day
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_4.customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_4.metric_time__day
-                          , subq_4.metric_time__week
-                          , subq_4.metric_time__month
-                          , subq_4.metric_time__quarter
-                          , subq_4.metric_time__year
-                          , subq_4.metric_time__extract_year
-                          , subq_4.metric_time__extract_quarter
-                          , subq_4.metric_time__extract_month
-                          , subq_4.metric_time__extract_day
-                          , subq_4.metric_time__extract_dow
-                          , subq_4.metric_time__extract_doy
-                          , subq_4.customer_id
-                          , subq_4.customer_third_hop_id
-                          , subq_4.customer_id__customer_third_hop_id
-                          , subq_4.customer_third_hop_id__customer_id
-                          , subq_4.country
-                          , subq_4.customer_id__country
-                          , subq_4.customer_third_hop_id__country
-                          , subq_4.customers_with_other_data
+                          subq_3.acquired_ds__day
+                          , subq_3.acquired_ds__week
+                          , subq_3.acquired_ds__month
+                          , subq_3.acquired_ds__quarter
+                          , subq_3.acquired_ds__year
+                          , subq_3.acquired_ds__extract_year
+                          , subq_3.acquired_ds__extract_quarter
+                          , subq_3.acquired_ds__extract_month
+                          , subq_3.acquired_ds__extract_day
+                          , subq_3.acquired_ds__extract_dow
+                          , subq_3.acquired_ds__extract_doy
+                          , subq_3.customer_id__acquired_ds__day
+                          , subq_3.customer_id__acquired_ds__week
+                          , subq_3.customer_id__acquired_ds__month
+                          , subq_3.customer_id__acquired_ds__quarter
+                          , subq_3.customer_id__acquired_ds__year
+                          , subq_3.customer_id__acquired_ds__extract_year
+                          , subq_3.customer_id__acquired_ds__extract_quarter
+                          , subq_3.customer_id__acquired_ds__extract_month
+                          , subq_3.customer_id__acquired_ds__extract_day
+                          , subq_3.customer_id__acquired_ds__extract_dow
+                          , subq_3.customer_id__acquired_ds__extract_doy
+                          , subq_3.customer_third_hop_id__acquired_ds__day
+                          , subq_3.customer_third_hop_id__acquired_ds__week
+                          , subq_3.customer_third_hop_id__acquired_ds__month
+                          , subq_3.customer_third_hop_id__acquired_ds__quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_year
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_month
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_day
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_3.customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_3.acquired_ds__day AS metric_time__day
+                          , subq_3.acquired_ds__week AS metric_time__week
+                          , subq_3.acquired_ds__month AS metric_time__month
+                          , subq_3.acquired_ds__quarter AS metric_time__quarter
+                          , subq_3.acquired_ds__year AS metric_time__year
+                          , subq_3.acquired_ds__extract_year AS metric_time__extract_year
+                          , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
+                          , subq_3.acquired_ds__extract_month AS metric_time__extract_month
+                          , subq_3.acquired_ds__extract_day AS metric_time__extract_day
+                          , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
+                          , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
+                          , subq_3.customer_id
+                          , subq_3.customer_third_hop_id
+                          , subq_3.customer_id__customer_third_hop_id
+                          , subq_3.customer_third_hop_id__customer_id
+                          , subq_3.country
+                          , subq_3.customer_id__country
+                          , subq_3.customer_third_hop_id__country
+                          , subq_3.customers_with_other_data
                         FROM (
-                          -- Metric Time Dimension 'acquired_ds'
+                          -- Read Elements From Semantic Model 'customer_other_data'
                           SELECT
-                            subq_3.acquired_ds__day
-                            , subq_3.acquired_ds__week
-                            , subq_3.acquired_ds__month
-                            , subq_3.acquired_ds__quarter
-                            , subq_3.acquired_ds__year
-                            , subq_3.acquired_ds__extract_year
-                            , subq_3.acquired_ds__extract_quarter
-                            , subq_3.acquired_ds__extract_month
-                            , subq_3.acquired_ds__extract_day
-                            , subq_3.acquired_ds__extract_dow
-                            , subq_3.acquired_ds__extract_doy
-                            , subq_3.customer_id__acquired_ds__day
-                            , subq_3.customer_id__acquired_ds__week
-                            , subq_3.customer_id__acquired_ds__month
-                            , subq_3.customer_id__acquired_ds__quarter
-                            , subq_3.customer_id__acquired_ds__year
-                            , subq_3.customer_id__acquired_ds__extract_year
-                            , subq_3.customer_id__acquired_ds__extract_quarter
-                            , subq_3.customer_id__acquired_ds__extract_month
-                            , subq_3.customer_id__acquired_ds__extract_day
-                            , subq_3.customer_id__acquired_ds__extract_dow
-                            , subq_3.customer_id__acquired_ds__extract_doy
-                            , subq_3.customer_third_hop_id__acquired_ds__day
-                            , subq_3.customer_third_hop_id__acquired_ds__week
-                            , subq_3.customer_third_hop_id__acquired_ds__month
-                            , subq_3.customer_third_hop_id__acquired_ds__quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_year
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_quarter
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_month
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_day
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_dow
-                            , subq_3.customer_third_hop_id__acquired_ds__extract_doy
-                            , subq_3.acquired_ds__day AS metric_time__day
-                            , subq_3.acquired_ds__week AS metric_time__week
-                            , subq_3.acquired_ds__month AS metric_time__month
-                            , subq_3.acquired_ds__quarter AS metric_time__quarter
-                            , subq_3.acquired_ds__year AS metric_time__year
-                            , subq_3.acquired_ds__extract_year AS metric_time__extract_year
-                            , subq_3.acquired_ds__extract_quarter AS metric_time__extract_quarter
-                            , subq_3.acquired_ds__extract_month AS metric_time__extract_month
-                            , subq_3.acquired_ds__extract_day AS metric_time__extract_day
-                            , subq_3.acquired_ds__extract_dow AS metric_time__extract_dow
-                            , subq_3.acquired_ds__extract_doy AS metric_time__extract_doy
-                            , subq_3.customer_id
-                            , subq_3.customer_third_hop_id
-                            , subq_3.customer_id__customer_third_hop_id
-                            , subq_3.customer_third_hop_id__customer_id
-                            , subq_3.country
-                            , subq_3.customer_id__country
-                            , subq_3.customer_third_hop_id__country
-                            , subq_3.customers_with_other_data
-                          FROM (
-                            -- Read Elements From Semantic Model 'customer_other_data'
-                            SELECT
-                              1 AS customers_with_other_data
-                              , customer_other_data_src_22000.country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
-                              , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
-                              , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.country AS customer_third_hop_id__country
-                              , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
-                              , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
-                              , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
-                              , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
-                              , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
-                              , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
-                              , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
-                              , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
-                              , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
-                              , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
-                              , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
-                              , customer_other_data_src_22000.customer_id
-                              , customer_other_data_src_22000.customer_third_hop_id
-                              , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
-                              , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
-                            FROM ***************************.customer_other_data customer_other_data_src_22000
-                          ) subq_3
-                        ) subq_4
-                        WHERE customer_id__country = 'paraguay'
-                      ) subq_5
-                    ) subq_6
+                            1 AS customers_with_other_data
+                            , customer_other_data_src_22000.country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_day
+                            , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_day
+                            , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.country AS customer_third_hop_id__country
+                            , DATE_TRUNC('day', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__day
+                            , DATE_TRUNC('week', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__week
+                            , DATE_TRUNC('month', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__month
+                            , DATE_TRUNC('quarter', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__quarter
+                            , DATE_TRUNC('year', customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__year
+                            , EXTRACT(year FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_year
+                            , EXTRACT(quarter FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_quarter
+                            , EXTRACT(month FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_month
+                            , EXTRACT(day FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_day
+                            , EXTRACT(DAY_OF_WEEK FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_dow
+                            , EXTRACT(doy FROM customer_other_data_src_22000.acquired_ds) AS customer_third_hop_id__acquired_ds__extract_doy
+                            , customer_other_data_src_22000.customer_id
+                            , customer_other_data_src_22000.customer_third_hop_id
+                            , customer_other_data_src_22000.customer_third_hop_id AS customer_id__customer_third_hop_id
+                            , customer_other_data_src_22000.customer_id AS customer_third_hop_id__customer_id
+                          FROM ***************************.customer_other_data customer_other_data_src_22000
+                        ) subq_3
+                      ) subq_4
+                    ) subq_5
                     WHERE customer_id__country = 'paraguay'
-                  ) subq_7
-                ) subq_8
+                  ) subq_6
+                ) subq_7
                 GROUP BY
-                  subq_8.customer_id__customer_third_hop_id
-              ) subq_9
-            ) subq_10
-          ) subq_11
+                  subq_7.customer_id__customer_third_hop_id
+              ) subq_8
+            ) subq_9
+          ) subq_10
           ON
-            subq_2.customer_third_hop_id = subq_11.customer_id__customer_third_hop_id
-        ) subq_12
-      ) subq_13
+            subq_2.customer_third_hop_id = subq_10.customer_id__customer_third_hop_id
+        ) subq_11
+      ) subq_12
       WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0
-    ) subq_14
-  ) subq_15
-) subq_16
+    ) subq_13
+  ) subq_14
+) subq_15

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_28.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
@@ -35,14 +35,14 @@ FROM (
           , country AS customer_id__country
           , 1 AS customers_with_other_data
         FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_21
+      ) subq_20
       WHERE customer_id__country = 'paraguay'
-    ) subq_23
+    ) subq_22
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_28
+  ) subq_27
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_28.customer_id__customer_third_hop_id
-) subq_30
+    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
+) subq_29
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS FLOAT64) / CAST(NULLIF(subq_13.max_booking_value, 0) AS FLOAT64) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS FLOAT64) / CAST(NULLIF(subq_12.max_booking_value, 0) AS FLOAT64) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
         metric_time__day
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
         metric_time__day
-    ) subq_11
-  ) subq_12
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
     metric_time__day
-) subq_13
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
     metric_time__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
-                    , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
-                    , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
-                    , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
-                    , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
     user__home_state_latest
-) subq_10
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
     listing__country_latest
-) subq_11
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_13.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
+  subq_12.metric_time__day
+  , CAST(subq_12.average_booking_value AS DOUBLE) / CAST(NULLIF(subq_12.max_booking_value, 0) AS DOUBLE) AS instant_booking_fraction_of_max_value
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.average_booking_value) AS average_booking_value
-    , MAX(subq_12.max_booking_value) AS max_booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.average_booking_value) AS average_booking_value
+    , MAX(subq_11.max_booking_value) AS max_booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.average_booking_value
+      subq_5.metric_time__day
+      , subq_5.average_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , AVG(subq_5.average_booking_value) AS average_booking_value
+        subq_4.metric_time__day
+        , AVG(subq_4.average_booking_value) AS average_booking_value
       FROM (
         -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.average_booking_value
+          subq_3.metric_time__day
+          , subq_3.average_booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.average_booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.average_booking_value
           FROM (
             -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.average_booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.average_booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.max_booking_value
+      subq_10.metric_time__day
+      , subq_10.max_booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , MAX(subq_10.max_booking_value) AS max_booking_value
+        subq_9.metric_time__day
+        , MAX(subq_9.max_booking_value) AS max_booking_value
       FROM (
         -- Pass Only Elements: ['max_booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.max_booking_value
+          subq_8.metric_time__day
+          , subq_8.max_booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.average_booking_value) AS average_booking_value
-    , MAX(subq_26.max_booking_value) AS max_booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.average_booking_value) AS average_booking_value
+    , MAX(subq_25.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value AS average_booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -1,256 +1,184 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_10.user__home_state_latest
-  , subq_10.listings
+  subq_9.user__home_state_latest
+  , subq_9.listings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_9.user__home_state_latest
-    , SUM(subq_9.listings) AS listings
+    subq_8.user__home_state_latest
+    , SUM(subq_8.listings) AS listings
   FROM (
     -- Pass Only Elements: ['listings', 'user__home_state_latest']
     SELECT
-      subq_8.user__home_state_latest
-      , subq_8.listings
+      subq_7.user__home_state_latest
+      , subq_7.listings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_7.listing__is_lux_latest
-        , subq_7.listing__capacity_latest
-        , subq_7.user__home_state_latest
-        , subq_7.listings
+        subq_6.listing__is_lux_latest
+        , subq_6.listing__capacity_latest
+        , subq_6.user__home_state_latest
+        , subq_6.listings
       FROM (
         -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
         SELECT
-          subq_6.listing__is_lux_latest
-          , subq_6.listing__capacity_latest
-          , subq_6.user__home_state_latest
-          , subq_6.listings
+          subq_5.listing__is_lux_latest
+          , subq_5.listing__capacity_latest
+          , subq_5.user__home_state_latest
+          , subq_5.listings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.user AS user
-            , subq_3.listing__is_lux_latest AS listing__is_lux_latest
-            , subq_3.listing__capacity_latest AS listing__capacity_latest
-            , subq_5.home_state_latest AS user__home_state_latest
-            , subq_3.listings AS listings
+            subq_2.user AS user
+            , subq_2.listing__is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing__capacity_latest AS listing__capacity_latest
+            , subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
             SELECT
-              subq_2.user
-              , subq_2.listing__is_lux_latest
-              , subq_2.listing__capacity_latest
-              , subq_2.listings
+              subq_1.user
+              , subq_1.listing__is_lux_latest
+              , subq_1.listing__capacity_latest
+              , subq_1.listings
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.created_at__day
-                , subq_1.created_at__week
-                , subq_1.created_at__month
-                , subq_1.created_at__quarter
-                , subq_1.created_at__year
-                , subq_1.created_at__extract_year
-                , subq_1.created_at__extract_quarter
-                , subq_1.created_at__extract_month
-                , subq_1.created_at__extract_day
-                , subq_1.created_at__extract_dow
-                , subq_1.created_at__extract_doy
-                , subq_1.listing__ds__day
-                , subq_1.listing__ds__week
-                , subq_1.listing__ds__month
-                , subq_1.listing__ds__quarter
-                , subq_1.listing__ds__year
-                , subq_1.listing__ds__extract_year
-                , subq_1.listing__ds__extract_quarter
-                , subq_1.listing__ds__extract_month
-                , subq_1.listing__ds__extract_day
-                , subq_1.listing__ds__extract_dow
-                , subq_1.listing__ds__extract_doy
-                , subq_1.listing__created_at__day
-                , subq_1.listing__created_at__week
-                , subq_1.listing__created_at__month
-                , subq_1.listing__created_at__quarter
-                , subq_1.listing__created_at__year
-                , subq_1.listing__created_at__extract_year
-                , subq_1.listing__created_at__extract_quarter
-                , subq_1.listing__created_at__extract_month
-                , subq_1.listing__created_at__extract_day
-                , subq_1.listing__created_at__extract_dow
-                , subq_1.listing__created_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.user
-                , subq_1.listing__user
-                , subq_1.country_latest
-                , subq_1.is_lux_latest
-                , subq_1.capacity_latest
-                , subq_1.listing__country_latest
-                , subq_1.listing__is_lux_latest
-                , subq_1.listing__capacity_latest
-                , subq_1.listings
-                , subq_1.largest_listing
-                , subq_1.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.created_at__day
+                , subq_0.created_at__week
+                , subq_0.created_at__month
+                , subq_0.created_at__quarter
+                , subq_0.created_at__year
+                , subq_0.created_at__extract_year
+                , subq_0.created_at__extract_quarter
+                , subq_0.created_at__extract_month
+                , subq_0.created_at__extract_day
+                , subq_0.created_at__extract_dow
+                , subq_0.created_at__extract_doy
+                , subq_0.listing__ds__day
+                , subq_0.listing__ds__week
+                , subq_0.listing__ds__month
+                , subq_0.listing__ds__quarter
+                , subq_0.listing__ds__year
+                , subq_0.listing__ds__extract_year
+                , subq_0.listing__ds__extract_quarter
+                , subq_0.listing__ds__extract_month
+                , subq_0.listing__ds__extract_day
+                , subq_0.listing__ds__extract_dow
+                , subq_0.listing__ds__extract_doy
+                , subq_0.listing__created_at__day
+                , subq_0.listing__created_at__week
+                , subq_0.listing__created_at__month
+                , subq_0.listing__created_at__quarter
+                , subq_0.listing__created_at__year
+                , subq_0.listing__created_at__extract_year
+                , subq_0.listing__created_at__extract_quarter
+                , subq_0.listing__created_at__extract_month
+                , subq_0.listing__created_at__extract_day
+                , subq_0.listing__created_at__extract_dow
+                , subq_0.listing__created_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.user
+                , subq_0.listing__user
+                , subq_0.country_latest
+                , subq_0.is_lux_latest
+                , subq_0.capacity_latest
+                , subq_0.listing__country_latest
+                , subq_0.listing__is_lux_latest
+                , subq_0.listing__capacity_latest
+                , subq_0.listings
+                , subq_0.largest_listing
+                , subq_0.smallest_listing
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.created_at__day
-                  , subq_0.created_at__week
-                  , subq_0.created_at__month
-                  , subq_0.created_at__quarter
-                  , subq_0.created_at__year
-                  , subq_0.created_at__extract_year
-                  , subq_0.created_at__extract_quarter
-                  , subq_0.created_at__extract_month
-                  , subq_0.created_at__extract_day
-                  , subq_0.created_at__extract_dow
-                  , subq_0.created_at__extract_doy
-                  , subq_0.listing__ds__day
-                  , subq_0.listing__ds__week
-                  , subq_0.listing__ds__month
-                  , subq_0.listing__ds__quarter
-                  , subq_0.listing__ds__year
-                  , subq_0.listing__ds__extract_year
-                  , subq_0.listing__ds__extract_quarter
-                  , subq_0.listing__ds__extract_month
-                  , subq_0.listing__ds__extract_day
-                  , subq_0.listing__ds__extract_dow
-                  , subq_0.listing__ds__extract_doy
-                  , subq_0.listing__created_at__day
-                  , subq_0.listing__created_at__week
-                  , subq_0.listing__created_at__month
-                  , subq_0.listing__created_at__quarter
-                  , subq_0.listing__created_at__year
-                  , subq_0.listing__created_at__extract_year
-                  , subq_0.listing__created_at__extract_quarter
-                  , subq_0.listing__created_at__extract_month
-                  , subq_0.listing__created_at__extract_day
-                  , subq_0.listing__created_at__extract_dow
-                  , subq_0.listing__created_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.user
-                  , subq_0.listing__user
-                  , subq_0.country_latest
-                  , subq_0.is_lux_latest
-                  , subq_0.capacity_latest
-                  , subq_0.listing__country_latest
-                  , subq_0.listing__is_lux_latest
-                  , subq_0.listing__capacity_latest
-                  , subq_0.listings
-                  , subq_0.largest_listing
-                  , subq_0.smallest_listing
-                FROM (
-                  -- Read Elements From Semantic Model 'listings_latest'
-                  SELECT
-                    1 AS listings
-                    , listings_latest_src_28000.capacity AS largest_listing
-                    , listings_latest_src_28000.capacity AS smallest_listing
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
-                    , listings_latest_src_28000.country AS country_latest
-                    , listings_latest_src_28000.is_lux AS is_lux_latest
-                    , listings_latest_src_28000.capacity AS capacity_latest
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
-                    , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
-                    , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
-                    , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
-                    , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
-                    , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
-                    , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
-                    , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
-                    , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
-                    , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
-                    , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
-                    , listings_latest_src_28000.country AS listing__country_latest
-                    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-                    , listings_latest_src_28000.capacity AS listing__capacity_latest
-                    , listings_latest_src_28000.listing_id AS listing
-                    , listings_latest_src_28000.user_id AS user
-                    , listings_latest_src_28000.user_id AS listing__user
-                  FROM ***************************.dim_listings_latest listings_latest_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-            ) subq_2
-          ) subq_3
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           LEFT OUTER JOIN (
             -- Pass Only Elements: ['home_state_latest', 'user']
             SELECT
-              subq_4.user
-              , subq_4.home_state_latest
+              subq_3.user
+              , subq_3.home_state_latest
             FROM (
               -- Read Elements From Semantic Model 'users_latest'
               SELECT
@@ -280,15 +208,15 @@ FROM (
                 , users_latest_src_28000.home_state_latest AS user__home_state_latest
                 , users_latest_src_28000.user_id AS user
               FROM ***************************.dim_users_latest users_latest_src_28000
-            ) subq_4
-          ) subq_5
+            ) subq_3
+          ) subq_4
           ON
-            subq_3.user = subq_5.user
-        ) subq_6
-      ) subq_7
+            subq_2.user = subq_4.user
+        ) subq_5
+      ) subq_6
       WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-    ) subq_8
-  ) subq_9
+    ) subq_7
+  ) subq_8
   GROUP BY
-    subq_9.user__home_state_latest
-) subq_10
+    subq_8.user__home_state_latest
+) subq_9

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,15 +9,15 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_14.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_14.listing__capacity_latest AS listing__capacity_latest
+    subq_13.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_13.listing__capacity_latest AS listing__capacity_latest
     , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_14.listings AS listings
+    , subq_13.listings AS listings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
-      subq_12.user
+      subq_11.user
       , listing__is_lux_latest
       , listing__capacity_latest
       , listings
@@ -30,14 +30,14 @@ FROM (
         , capacity AS listing__capacity_latest
         , 1 AS listings
       FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_12
+    ) subq_11
     WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_14
+  ) subq_13
   LEFT OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000
   ON
-    subq_14.user = users_latest_src_28000.user_id
-) subq_18
+    subq_13.user = users_latest_src_28000.user_id
+) subq_17
 WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
@@ -1,416 +1,313 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_11.listing__country_latest
-  , subq_11.bookings
+  subq_10.listing__country_latest
+  , subq_10.bookings
 FROM (
   -- Aggregate Measures
   SELECT
-    subq_10.listing__country_latest
-    , SUM(subq_10.bookings) AS bookings
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
   FROM (
     -- Pass Only Elements: ['bookings', 'listing__country_latest']
     SELECT
-      subq_9.listing__country_latest
-      , subq_9.bookings
+      subq_8.listing__country_latest
+      , subq_8.bookings
     FROM (
       -- Constrain Output with WHERE
       SELECT
-        subq_8.booking__is_instant
-        , subq_8.listing__country_latest
-        , subq_8.bookings
+        subq_7.booking__is_instant
+        , subq_7.listing__country_latest
+        , subq_7.bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
         SELECT
-          subq_7.booking__is_instant
-          , subq_7.listing__country_latest
-          , subq_7.bookings
+          subq_6.booking__is_instant
+          , subq_6.listing__country_latest
+          , subq_6.bookings
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.listing AS listing
-            , subq_3.booking__is_instant AS booking__is_instant
-            , subq_6.country_latest AS listing__country_latest
-            , subq_3.bookings AS bookings
+            subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
             SELECT
-              subq_2.listing
-              , subq_2.booking__is_instant
-              , subq_2.bookings
-            FROM (
-              -- Constrain Output with WHERE
-              SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
-              FROM (
-                -- Metric Time Dimension 'ds'
-                SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
-          LEFT OUTER JOIN (
-            -- Pass Only Elements: ['country_latest', 'listing']
-            SELECT
-              subq_5.listing
-              , subq_5.country_latest
+              subq_1.listing
+              , subq_1.booking__is_instant
+              , subq_1.bookings
             FROM (
               -- Metric Time Dimension 'ds'
               SELECT
-                subq_4.ds__day
-                , subq_4.ds__week
-                , subq_4.ds__month
-                , subq_4.ds__quarter
-                , subq_4.ds__year
-                , subq_4.ds__extract_year
-                , subq_4.ds__extract_quarter
-                , subq_4.ds__extract_month
-                , subq_4.ds__extract_day
-                , subq_4.ds__extract_dow
-                , subq_4.ds__extract_doy
-                , subq_4.created_at__day
-                , subq_4.created_at__week
-                , subq_4.created_at__month
-                , subq_4.created_at__quarter
-                , subq_4.created_at__year
-                , subq_4.created_at__extract_year
-                , subq_4.created_at__extract_quarter
-                , subq_4.created_at__extract_month
-                , subq_4.created_at__extract_day
-                , subq_4.created_at__extract_dow
-                , subq_4.created_at__extract_doy
-                , subq_4.listing__ds__day
-                , subq_4.listing__ds__week
-                , subq_4.listing__ds__month
-                , subq_4.listing__ds__quarter
-                , subq_4.listing__ds__year
-                , subq_4.listing__ds__extract_year
-                , subq_4.listing__ds__extract_quarter
-                , subq_4.listing__ds__extract_month
-                , subq_4.listing__ds__extract_day
-                , subq_4.listing__ds__extract_dow
-                , subq_4.listing__ds__extract_doy
-                , subq_4.listing__created_at__day
-                , subq_4.listing__created_at__week
-                , subq_4.listing__created_at__month
-                , subq_4.listing__created_at__quarter
-                , subq_4.listing__created_at__year
-                , subq_4.listing__created_at__extract_year
-                , subq_4.listing__created_at__extract_quarter
-                , subq_4.listing__created_at__extract_month
-                , subq_4.listing__created_at__extract_day
-                , subq_4.listing__created_at__extract_dow
-                , subq_4.listing__created_at__extract_doy
-                , subq_4.ds__day AS metric_time__day
-                , subq_4.ds__week AS metric_time__week
-                , subq_4.ds__month AS metric_time__month
-                , subq_4.ds__quarter AS metric_time__quarter
-                , subq_4.ds__year AS metric_time__year
-                , subq_4.ds__extract_year AS metric_time__extract_year
-                , subq_4.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_4.ds__extract_month AS metric_time__extract_month
-                , subq_4.ds__extract_day AS metric_time__extract_day
-                , subq_4.ds__extract_dow AS metric_time__extract_dow
-                , subq_4.ds__extract_doy AS metric_time__extract_doy
-                , subq_4.listing
-                , subq_4.user
-                , subq_4.listing__user
-                , subq_4.country_latest
-                , subq_4.is_lux_latest
-                , subq_4.capacity_latest
-                , subq_4.listing__country_latest
-                , subq_4.listing__is_lux_latest
-                , subq_4.listing__capacity_latest
-                , subq_4.listings
-                , subq_4.largest_listing
-                , subq_4.smallest_listing
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
               FROM (
                 -- Read Elements From Semantic Model 'listings_latest'
                 SELECT
@@ -471,16 +368,16 @@ FROM (
                   , listings_latest_src_28000.user_id AS user
                   , listings_latest_src_28000.user_id AS listing__user
                 FROM ***************************.dim_listings_latest listings_latest_src_28000
-              ) subq_4
-            ) subq_5
-          ) subq_6
+              ) subq_3
+            ) subq_4
+          ) subq_5
           ON
-            subq_3.listing = subq_6.listing
-        ) subq_7
-      ) subq_8
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
       WHERE booking__is_instant
-    ) subq_9
-  ) subq_10
+    ) subq_8
+  ) subq_9
   GROUP BY
-    subq_10.listing__country_latest
-) subq_11
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -9,9 +9,9 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    subq_15.booking__is_instant AS booking__is_instant
+    subq_14.booking__is_instant AS booking__is_instant
     , listings_latest_src_28000.country AS listing__country_latest
-    , subq_15.bookings AS bookings
+    , subq_14.bookings AS bookings
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
@@ -27,14 +27,14 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
-  ) subq_15
+  ) subq_14
   LEFT OUTER JOIN
     ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    subq_15.listing = listings_latest_src_28000.listing_id
-) subq_20
+    subq_14.listing = listings_latest_src_28000.listing_id
+) subq_19
 WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_13.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS FLOAT64) / CAST(NULLIF(subq_12.booking_value, 0) AS FLOAT64) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
         metric_time__day
-    ) subq_6
-  ) subq_7
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
         metric_time__day
-    ) subq_11
-  ) subq_12
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
     metric_time__day
-) subq_13
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
     metric_time__day
-) subq_27
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
       metric_time__day
-  ) subq_6
-) subq_7
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE PRECISION) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE PRECISION) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_distinct_values__plan0_optimized.sql
@@ -4,11 +4,17 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Read Elements From Semantic Model 'listings_latest'
+  -- Constrain Output with WHERE
   SELECT
-    country AS listing__country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_3
+    listing__country_latest
+  FROM (
+    -- Read Elements From Semantic Model 'listings_latest'
+    SELECT
+      country AS listing__country_latest
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_3
+  WHERE listing__country_latest = 'us'
+) subq_4
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0.sql
@@ -1,462 +1,359 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_13.metric_time__day
-  , CAST(subq_13.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_13.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
+  subq_12.metric_time__day
+  , CAST(subq_12.booking_value_with_is_instant_constraint AS DOUBLE) / CAST(NULLIF(subq_12.booking_value, 0) AS DOUBLE) AS instant_booking_value_ratio
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day) AS metric_time__day
-    , MAX(subq_7.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_12.booking_value) AS booking_value
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day) AS metric_time__day
+    , MAX(subq_6.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_11.booking_value) AS booking_value
   FROM (
     -- Compute Metrics via Expressions
     SELECT
-      subq_6.metric_time__day
-      , subq_6.booking_value AS booking_value_with_is_instant_constraint
+      subq_5.metric_time__day
+      , subq_5.booking_value AS booking_value_with_is_instant_constraint
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_5.metric_time__day
-        , SUM(subq_5.booking_value) AS booking_value
+        subq_4.metric_time__day
+        , SUM(subq_4.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_4.metric_time__day
-          , subq_4.booking_value
+          subq_3.metric_time__day
+          , subq_3.booking_value
         FROM (
           -- Constrain Output with WHERE
           SELECT
-            subq_3.metric_time__day
-            , subq_3.booking__is_instant
-            , subq_3.booking_value
+            subq_2.metric_time__day
+            , subq_2.booking__is_instant
+            , subq_2.booking_value
           FROM (
             -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
             SELECT
-              subq_2.metric_time__day
-              , subq_2.booking__is_instant
-              , subq_2.booking_value
+              subq_1.metric_time__day
+              , subq_1.booking__is_instant
+              , subq_1.booking_value
             FROM (
-              -- Constrain Output with WHERE
+              -- Metric Time Dimension 'ds'
               SELECT
-                subq_1.ds__day
-                , subq_1.ds__week
-                , subq_1.ds__month
-                , subq_1.ds__quarter
-                , subq_1.ds__year
-                , subq_1.ds__extract_year
-                , subq_1.ds__extract_quarter
-                , subq_1.ds__extract_month
-                , subq_1.ds__extract_day
-                , subq_1.ds__extract_dow
-                , subq_1.ds__extract_doy
-                , subq_1.ds_partitioned__day
-                , subq_1.ds_partitioned__week
-                , subq_1.ds_partitioned__month
-                , subq_1.ds_partitioned__quarter
-                , subq_1.ds_partitioned__year
-                , subq_1.ds_partitioned__extract_year
-                , subq_1.ds_partitioned__extract_quarter
-                , subq_1.ds_partitioned__extract_month
-                , subq_1.ds_partitioned__extract_day
-                , subq_1.ds_partitioned__extract_dow
-                , subq_1.ds_partitioned__extract_doy
-                , subq_1.paid_at__day
-                , subq_1.paid_at__week
-                , subq_1.paid_at__month
-                , subq_1.paid_at__quarter
-                , subq_1.paid_at__year
-                , subq_1.paid_at__extract_year
-                , subq_1.paid_at__extract_quarter
-                , subq_1.paid_at__extract_month
-                , subq_1.paid_at__extract_day
-                , subq_1.paid_at__extract_dow
-                , subq_1.paid_at__extract_doy
-                , subq_1.booking__ds__day
-                , subq_1.booking__ds__week
-                , subq_1.booking__ds__month
-                , subq_1.booking__ds__quarter
-                , subq_1.booking__ds__year
-                , subq_1.booking__ds__extract_year
-                , subq_1.booking__ds__extract_quarter
-                , subq_1.booking__ds__extract_month
-                , subq_1.booking__ds__extract_day
-                , subq_1.booking__ds__extract_dow
-                , subq_1.booking__ds__extract_doy
-                , subq_1.booking__ds_partitioned__day
-                , subq_1.booking__ds_partitioned__week
-                , subq_1.booking__ds_partitioned__month
-                , subq_1.booking__ds_partitioned__quarter
-                , subq_1.booking__ds_partitioned__year
-                , subq_1.booking__ds_partitioned__extract_year
-                , subq_1.booking__ds_partitioned__extract_quarter
-                , subq_1.booking__ds_partitioned__extract_month
-                , subq_1.booking__ds_partitioned__extract_day
-                , subq_1.booking__ds_partitioned__extract_dow
-                , subq_1.booking__ds_partitioned__extract_doy
-                , subq_1.booking__paid_at__day
-                , subq_1.booking__paid_at__week
-                , subq_1.booking__paid_at__month
-                , subq_1.booking__paid_at__quarter
-                , subq_1.booking__paid_at__year
-                , subq_1.booking__paid_at__extract_year
-                , subq_1.booking__paid_at__extract_quarter
-                , subq_1.booking__paid_at__extract_month
-                , subq_1.booking__paid_at__extract_day
-                , subq_1.booking__paid_at__extract_dow
-                , subq_1.booking__paid_at__extract_doy
-                , subq_1.metric_time__day
-                , subq_1.metric_time__week
-                , subq_1.metric_time__month
-                , subq_1.metric_time__quarter
-                , subq_1.metric_time__year
-                , subq_1.metric_time__extract_year
-                , subq_1.metric_time__extract_quarter
-                , subq_1.metric_time__extract_month
-                , subq_1.metric_time__extract_day
-                , subq_1.metric_time__extract_dow
-                , subq_1.metric_time__extract_doy
-                , subq_1.listing
-                , subq_1.guest
-                , subq_1.host
-                , subq_1.booking__listing
-                , subq_1.booking__guest
-                , subq_1.booking__host
-                , subq_1.is_instant
-                , subq_1.booking__is_instant
-                , subq_1.bookings
-                , subq_1.instant_bookings
-                , subq_1.booking_value
-                , subq_1.max_booking_value
-                , subq_1.min_booking_value
-                , subq_1.bookers
-                , subq_1.average_booking_value
-                , subq_1.referred_bookings
-                , subq_1.median_booking_value
-                , subq_1.booking_value_p99
-                , subq_1.discrete_booking_value_p99
-                , subq_1.approximate_continuous_booking_value_p99
-                , subq_1.approximate_discrete_booking_value_p99
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
               FROM (
-                -- Metric Time Dimension 'ds'
+                -- Read Elements From Semantic Model 'bookings_source'
                 SELECT
-                  subq_0.ds__day
-                  , subq_0.ds__week
-                  , subq_0.ds__month
-                  , subq_0.ds__quarter
-                  , subq_0.ds__year
-                  , subq_0.ds__extract_year
-                  , subq_0.ds__extract_quarter
-                  , subq_0.ds__extract_month
-                  , subq_0.ds__extract_day
-                  , subq_0.ds__extract_dow
-                  , subq_0.ds__extract_doy
-                  , subq_0.ds_partitioned__day
-                  , subq_0.ds_partitioned__week
-                  , subq_0.ds_partitioned__month
-                  , subq_0.ds_partitioned__quarter
-                  , subq_0.ds_partitioned__year
-                  , subq_0.ds_partitioned__extract_year
-                  , subq_0.ds_partitioned__extract_quarter
-                  , subq_0.ds_partitioned__extract_month
-                  , subq_0.ds_partitioned__extract_day
-                  , subq_0.ds_partitioned__extract_dow
-                  , subq_0.ds_partitioned__extract_doy
-                  , subq_0.paid_at__day
-                  , subq_0.paid_at__week
-                  , subq_0.paid_at__month
-                  , subq_0.paid_at__quarter
-                  , subq_0.paid_at__year
-                  , subq_0.paid_at__extract_year
-                  , subq_0.paid_at__extract_quarter
-                  , subq_0.paid_at__extract_month
-                  , subq_0.paid_at__extract_day
-                  , subq_0.paid_at__extract_dow
-                  , subq_0.paid_at__extract_doy
-                  , subq_0.booking__ds__day
-                  , subq_0.booking__ds__week
-                  , subq_0.booking__ds__month
-                  , subq_0.booking__ds__quarter
-                  , subq_0.booking__ds__year
-                  , subq_0.booking__ds__extract_year
-                  , subq_0.booking__ds__extract_quarter
-                  , subq_0.booking__ds__extract_month
-                  , subq_0.booking__ds__extract_day
-                  , subq_0.booking__ds__extract_dow
-                  , subq_0.booking__ds__extract_doy
-                  , subq_0.booking__ds_partitioned__day
-                  , subq_0.booking__ds_partitioned__week
-                  , subq_0.booking__ds_partitioned__month
-                  , subq_0.booking__ds_partitioned__quarter
-                  , subq_0.booking__ds_partitioned__year
-                  , subq_0.booking__ds_partitioned__extract_year
-                  , subq_0.booking__ds_partitioned__extract_quarter
-                  , subq_0.booking__ds_partitioned__extract_month
-                  , subq_0.booking__ds_partitioned__extract_day
-                  , subq_0.booking__ds_partitioned__extract_dow
-                  , subq_0.booking__ds_partitioned__extract_doy
-                  , subq_0.booking__paid_at__day
-                  , subq_0.booking__paid_at__week
-                  , subq_0.booking__paid_at__month
-                  , subq_0.booking__paid_at__quarter
-                  , subq_0.booking__paid_at__year
-                  , subq_0.booking__paid_at__extract_year
-                  , subq_0.booking__paid_at__extract_quarter
-                  , subq_0.booking__paid_at__extract_month
-                  , subq_0.booking__paid_at__extract_day
-                  , subq_0.booking__paid_at__extract_dow
-                  , subq_0.booking__paid_at__extract_doy
-                  , subq_0.ds__day AS metric_time__day
-                  , subq_0.ds__week AS metric_time__week
-                  , subq_0.ds__month AS metric_time__month
-                  , subq_0.ds__quarter AS metric_time__quarter
-                  , subq_0.ds__year AS metric_time__year
-                  , subq_0.ds__extract_year AS metric_time__extract_year
-                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                  , subq_0.ds__extract_month AS metric_time__extract_month
-                  , subq_0.ds__extract_day AS metric_time__extract_day
-                  , subq_0.ds__extract_dow AS metric_time__extract_dow
-                  , subq_0.ds__extract_doy AS metric_time__extract_doy
-                  , subq_0.listing
-                  , subq_0.guest
-                  , subq_0.host
-                  , subq_0.booking__listing
-                  , subq_0.booking__guest
-                  , subq_0.booking__host
-                  , subq_0.is_instant
-                  , subq_0.booking__is_instant
-                  , subq_0.bookings
-                  , subq_0.instant_bookings
-                  , subq_0.booking_value
-                  , subq_0.max_booking_value
-                  , subq_0.min_booking_value
-                  , subq_0.bookers
-                  , subq_0.average_booking_value
-                  , subq_0.referred_bookings
-                  , subq_0.median_booking_value
-                  , subq_0.booking_value_p99
-                  , subq_0.discrete_booking_value_p99
-                  , subq_0.approximate_continuous_booking_value_p99
-                  , subq_0.approximate_discrete_booking_value_p99
-                FROM (
-                  -- Read Elements From Semantic Model 'bookings_source'
-                  SELECT
-                    1 AS bookings
-                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                    , bookings_source_src_28000.booking_value
-                    , bookings_source_src_28000.booking_value AS max_booking_value
-                    , bookings_source_src_28000.booking_value AS min_booking_value
-                    , bookings_source_src_28000.guest_id AS bookers
-                    , bookings_source_src_28000.booking_value AS average_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_payments
-                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                    , bookings_source_src_28000.booking_value AS median_booking_value
-                    , bookings_source_src_28000.booking_value AS booking_value_p99
-                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                    , bookings_source_src_28000.is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                    , bookings_source_src_28000.is_instant AS booking__is_instant
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                    , bookings_source_src_28000.listing_id AS listing
-                    , bookings_source_src_28000.guest_id AS guest
-                    , bookings_source_src_28000.host_id AS host
-                    , bookings_source_src_28000.listing_id AS booking__listing
-                    , bookings_source_src_28000.guest_id AS booking__guest
-                    , bookings_source_src_28000.host_id AS booking__host
-                  FROM ***************************.fct_bookings bookings_source_src_28000
-                ) subq_0
-              ) subq_1
-              WHERE booking__is_instant
-            ) subq_2
-          ) subq_3
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
           WHERE booking__is_instant
-        ) subq_4
-      ) subq_5
+        ) subq_3
+      ) subq_4
       GROUP BY
-        subq_5.metric_time__day
-    ) subq_6
-  ) subq_7
+        subq_4.metric_time__day
+    ) subq_5
+  ) subq_6
   FULL OUTER JOIN (
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day
-      , subq_11.booking_value
+      subq_10.metric_time__day
+      , subq_10.booking_value
     FROM (
       -- Aggregate Measures
       SELECT
-        subq_10.metric_time__day
-        , SUM(subq_10.booking_value) AS booking_value
+        subq_9.metric_time__day
+        , SUM(subq_9.booking_value) AS booking_value
       FROM (
         -- Pass Only Elements: ['booking_value', 'metric_time__day']
         SELECT
-          subq_9.metric_time__day
-          , subq_9.booking_value
+          subq_8.metric_time__day
+          , subq_8.booking_value
         FROM (
           -- Metric Time Dimension 'ds'
           SELECT
-            subq_8.ds__day
-            , subq_8.ds__week
-            , subq_8.ds__month
-            , subq_8.ds__quarter
-            , subq_8.ds__year
-            , subq_8.ds__extract_year
-            , subq_8.ds__extract_quarter
-            , subq_8.ds__extract_month
-            , subq_8.ds__extract_day
-            , subq_8.ds__extract_dow
-            , subq_8.ds__extract_doy
-            , subq_8.ds_partitioned__day
-            , subq_8.ds_partitioned__week
-            , subq_8.ds_partitioned__month
-            , subq_8.ds_partitioned__quarter
-            , subq_8.ds_partitioned__year
-            , subq_8.ds_partitioned__extract_year
-            , subq_8.ds_partitioned__extract_quarter
-            , subq_8.ds_partitioned__extract_month
-            , subq_8.ds_partitioned__extract_day
-            , subq_8.ds_partitioned__extract_dow
-            , subq_8.ds_partitioned__extract_doy
-            , subq_8.paid_at__day
-            , subq_8.paid_at__week
-            , subq_8.paid_at__month
-            , subq_8.paid_at__quarter
-            , subq_8.paid_at__year
-            , subq_8.paid_at__extract_year
-            , subq_8.paid_at__extract_quarter
-            , subq_8.paid_at__extract_month
-            , subq_8.paid_at__extract_day
-            , subq_8.paid_at__extract_dow
-            , subq_8.paid_at__extract_doy
-            , subq_8.booking__ds__day
-            , subq_8.booking__ds__week
-            , subq_8.booking__ds__month
-            , subq_8.booking__ds__quarter
-            , subq_8.booking__ds__year
-            , subq_8.booking__ds__extract_year
-            , subq_8.booking__ds__extract_quarter
-            , subq_8.booking__ds__extract_month
-            , subq_8.booking__ds__extract_day
-            , subq_8.booking__ds__extract_dow
-            , subq_8.booking__ds__extract_doy
-            , subq_8.booking__ds_partitioned__day
-            , subq_8.booking__ds_partitioned__week
-            , subq_8.booking__ds_partitioned__month
-            , subq_8.booking__ds_partitioned__quarter
-            , subq_8.booking__ds_partitioned__year
-            , subq_8.booking__ds_partitioned__extract_year
-            , subq_8.booking__ds_partitioned__extract_quarter
-            , subq_8.booking__ds_partitioned__extract_month
-            , subq_8.booking__ds_partitioned__extract_day
-            , subq_8.booking__ds_partitioned__extract_dow
-            , subq_8.booking__ds_partitioned__extract_doy
-            , subq_8.booking__paid_at__day
-            , subq_8.booking__paid_at__week
-            , subq_8.booking__paid_at__month
-            , subq_8.booking__paid_at__quarter
-            , subq_8.booking__paid_at__year
-            , subq_8.booking__paid_at__extract_year
-            , subq_8.booking__paid_at__extract_quarter
-            , subq_8.booking__paid_at__extract_month
-            , subq_8.booking__paid_at__extract_day
-            , subq_8.booking__paid_at__extract_dow
-            , subq_8.booking__paid_at__extract_doy
-            , subq_8.ds__day AS metric_time__day
-            , subq_8.ds__week AS metric_time__week
-            , subq_8.ds__month AS metric_time__month
-            , subq_8.ds__quarter AS metric_time__quarter
-            , subq_8.ds__year AS metric_time__year
-            , subq_8.ds__extract_year AS metric_time__extract_year
-            , subq_8.ds__extract_quarter AS metric_time__extract_quarter
-            , subq_8.ds__extract_month AS metric_time__extract_month
-            , subq_8.ds__extract_day AS metric_time__extract_day
-            , subq_8.ds__extract_dow AS metric_time__extract_dow
-            , subq_8.ds__extract_doy AS metric_time__extract_doy
-            , subq_8.listing
-            , subq_8.guest
-            , subq_8.host
-            , subq_8.booking__listing
-            , subq_8.booking__guest
-            , subq_8.booking__host
-            , subq_8.is_instant
-            , subq_8.booking__is_instant
-            , subq_8.bookings
-            , subq_8.instant_bookings
-            , subq_8.booking_value
-            , subq_8.max_booking_value
-            , subq_8.min_booking_value
-            , subq_8.bookers
-            , subq_8.average_booking_value
-            , subq_8.referred_bookings
-            , subq_8.median_booking_value
-            , subq_8.booking_value_p99
-            , subq_8.discrete_booking_value_p99
-            , subq_8.approximate_continuous_booking_value_p99
-            , subq_8.approximate_discrete_booking_value_p99
+            subq_7.ds__day
+            , subq_7.ds__week
+            , subq_7.ds__month
+            , subq_7.ds__quarter
+            , subq_7.ds__year
+            , subq_7.ds__extract_year
+            , subq_7.ds__extract_quarter
+            , subq_7.ds__extract_month
+            , subq_7.ds__extract_day
+            , subq_7.ds__extract_dow
+            , subq_7.ds__extract_doy
+            , subq_7.ds_partitioned__day
+            , subq_7.ds_partitioned__week
+            , subq_7.ds_partitioned__month
+            , subq_7.ds_partitioned__quarter
+            , subq_7.ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy
+            , subq_7.paid_at__day
+            , subq_7.paid_at__week
+            , subq_7.paid_at__month
+            , subq_7.paid_at__quarter
+            , subq_7.paid_at__year
+            , subq_7.paid_at__extract_year
+            , subq_7.paid_at__extract_quarter
+            , subq_7.paid_at__extract_month
+            , subq_7.paid_at__extract_day
+            , subq_7.paid_at__extract_dow
+            , subq_7.paid_at__extract_doy
+            , subq_7.booking__ds__day
+            , subq_7.booking__ds__week
+            , subq_7.booking__ds__month
+            , subq_7.booking__ds__quarter
+            , subq_7.booking__ds__year
+            , subq_7.booking__ds__extract_year
+            , subq_7.booking__ds__extract_quarter
+            , subq_7.booking__ds__extract_month
+            , subq_7.booking__ds__extract_day
+            , subq_7.booking__ds__extract_dow
+            , subq_7.booking__ds__extract_doy
+            , subq_7.booking__ds_partitioned__day
+            , subq_7.booking__ds_partitioned__week
+            , subq_7.booking__ds_partitioned__month
+            , subq_7.booking__ds_partitioned__quarter
+            , subq_7.booking__ds_partitioned__year
+            , subq_7.booking__ds_partitioned__extract_year
+            , subq_7.booking__ds_partitioned__extract_quarter
+            , subq_7.booking__ds_partitioned__extract_month
+            , subq_7.booking__ds_partitioned__extract_day
+            , subq_7.booking__ds_partitioned__extract_dow
+            , subq_7.booking__ds_partitioned__extract_doy
+            , subq_7.booking__paid_at__day
+            , subq_7.booking__paid_at__week
+            , subq_7.booking__paid_at__month
+            , subq_7.booking__paid_at__quarter
+            , subq_7.booking__paid_at__year
+            , subq_7.booking__paid_at__extract_year
+            , subq_7.booking__paid_at__extract_quarter
+            , subq_7.booking__paid_at__extract_month
+            , subq_7.booking__paid_at__extract_day
+            , subq_7.booking__paid_at__extract_dow
+            , subq_7.booking__paid_at__extract_doy
+            , subq_7.ds__day AS metric_time__day
+            , subq_7.ds__week AS metric_time__week
+            , subq_7.ds__month AS metric_time__month
+            , subq_7.ds__quarter AS metric_time__quarter
+            , subq_7.ds__year AS metric_time__year
+            , subq_7.ds__extract_year AS metric_time__extract_year
+            , subq_7.ds__extract_quarter AS metric_time__extract_quarter
+            , subq_7.ds__extract_month AS metric_time__extract_month
+            , subq_7.ds__extract_day AS metric_time__extract_day
+            , subq_7.ds__extract_dow AS metric_time__extract_dow
+            , subq_7.ds__extract_doy AS metric_time__extract_doy
+            , subq_7.listing
+            , subq_7.guest
+            , subq_7.host
+            , subq_7.booking__listing
+            , subq_7.booking__guest
+            , subq_7.booking__host
+            , subq_7.is_instant
+            , subq_7.booking__is_instant
+            , subq_7.bookings
+            , subq_7.instant_bookings
+            , subq_7.booking_value
+            , subq_7.max_booking_value
+            , subq_7.min_booking_value
+            , subq_7.bookers
+            , subq_7.average_booking_value
+            , subq_7.referred_bookings
+            , subq_7.median_booking_value
+            , subq_7.booking_value_p99
+            , subq_7.discrete_booking_value_p99
+            , subq_7.approximate_continuous_booking_value_p99
+            , subq_7.approximate_discrete_booking_value_p99
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             SELECT
@@ -549,15 +446,15 @@ FROM (
               , bookings_source_src_28000.guest_id AS booking__guest
               , bookings_source_src_28000.host_id AS booking__host
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_8
-        ) subq_9
-      ) subq_10
+          ) subq_7
+        ) subq_8
+      ) subq_9
       GROUP BY
-        subq_10.metric_time__day
-    ) subq_11
-  ) subq_12
+        subq_9.metric_time__day
+    ) subq_10
+  ) subq_11
   ON
-    subq_7.metric_time__day = subq_12.metric_time__day
+    subq_6.metric_time__day = subq_11.metric_time__day
   GROUP BY
-    COALESCE(subq_7.metric_time__day, subq_12.metric_time__day)
-) subq_13
+    COALESCE(subq_6.metric_time__day, subq_11.metric_time__day)
+) subq_12

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day) AS metric_time__day
-    , MAX(subq_21.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_26.booking_value) AS booking_value
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
+    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_25.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
@@ -31,13 +31,13 @@ FROM (
           , is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_15
+      ) subq_14
       WHERE booking__is_instant
-    ) subq_17
+    ) subq_16
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +50,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_26
+  ) subq_25
   ON
-    subq_21.metric_time__day = subq_26.metric_time__day
+    subq_20.metric_time__day = subq_25.metric_time__day
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_26.metric_time__day)
-) subq_27
+    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
+) subq_26

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0.sql
@@ -1,337 +1,234 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_7.metric_time__day
+  subq_6.metric_time__day
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Compute Metrics via Expressions
   SELECT
-    subq_6.metric_time__day
-    , subq_6.bookings AS delayed_bookings
+    subq_5.metric_time__day
+    , subq_5.bookings AS delayed_bookings
   FROM (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE NOT booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE NOT booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
-) subq_7
+      subq_4.metric_time__day
+  ) subq_5
+) subq_6

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -25,10 +25,10 @@ FROM (
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_9
+    ) subq_8
     WHERE NOT booking__is_instant
-  ) subq_11
+  ) subq_10
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_15
+) subq_14

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -46,7 +46,7 @@
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
-                            <!-- node_id = NodeId(id_str='wcc_1') -->
+                            <!-- node_id = NodeId(id_str='wcc_0') -->
                             <!-- where_condition =                                                -->
                             <!--   WhereFilterSpec(                                               -->
                             <!--     where_sql='booking__is_instant',                             -->
@@ -86,47 +86,16 @@
                                 <!--   )                                                          -->
                                 <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                                 <!-- distinct = False -->
-                                <WhereConstraintNode>
-                                    <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_0') -->
-                                    <!-- where_condition =                                                -->
-                                    <!--   WhereFilterSpec(                                               -->
-                                    <!--     where_sql='booking__is_instant',                             -->
-                                    <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--     linkable_elements=(                                          -->
-                                    <!--       LinkableDimension(                                         -->
-                                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                                    <!--           semantic_model_name='bookings_source',                 -->
-                                    <!--         ),                                                       -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         dimension_type=CATEGORICAL,                              -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--         join_path=SemanticModelJoinPath(                         -->
-                                    <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                                    <!--             semantic_model_name='bookings_source',               -->
-                                    <!--           ),                                                     -->
-                                    <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--   )                                                              -->
-                                    <MetricTimeDimensionTransformNode>
-                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_28002') -->
-                                        <!-- aggregation_time_dimension = 'ds' -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_28014') -->
-                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                        </ReadSqlSourceNode>
-                                    </MetricTimeDimensionTransformNode>
-                                </WhereConstraintNode>
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = "Metric Time Dimension 'ds'" -->
+                                    <!-- node_id = NodeId(id_str='sma_28002') -->
+                                    <!-- aggregation_time_dimension = 'ds' -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                        <!-- node_id = NodeId(id_str='rss_28014') -->
+                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
                             </FilterElementsNode>
                         </WhereConstraintNode>
                     </FilterElementsNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -46,7 +46,7 @@
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
-                            <!-- node_id = NodeId(id_str='wcc_3') -->
+                            <!-- node_id = NodeId(id_str='wcc_1') -->
                             <!-- where_condition =                                                -->
                             <!--   WhereFilterSpec(                                               -->
                             <!--     where_sql='booking__is_instant',                             -->
@@ -86,47 +86,16 @@
                                 <!--   )                                                          -->
                                 <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                                 <!-- distinct = False -->
-                                <WhereConstraintNode>
-                                    <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_2') -->
-                                    <!-- where_condition =                                                -->
-                                    <!--   WhereFilterSpec(                                               -->
-                                    <!--     where_sql='booking__is_instant',                             -->
-                                    <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--     linkable_elements=(                                          -->
-                                    <!--       LinkableDimension(                                         -->
-                                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                                    <!--           semantic_model_name='bookings_source',                 -->
-                                    <!--         ),                                                       -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         dimension_type=CATEGORICAL,                              -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--         join_path=SemanticModelJoinPath(                         -->
-                                    <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                                    <!--             semantic_model_name='bookings_source',               -->
-                                    <!--           ),                                                     -->
-                                    <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--   )                                                              -->
-                                    <MetricTimeDimensionTransformNode>
-                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
-                                        <!-- aggregation_time_dimension = 'ds' -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
-                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                        </ReadSqlSourceNode>
-                                    </MetricTimeDimensionTransformNode>
-                                </WhereConstraintNode>
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = "Metric Time Dimension 'ds'" -->
+                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- aggregation_time_dimension = 'ds' -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
                             </FilterElementsNode>
                         </WhereConstraintNode>
                     </FilterElementsNode>

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
       metric_time__day
-  ) subq_6
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
-                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
-                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_5
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0.sql
@@ -1,345 +1,242 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_7.metric_time__day AS metric_time__day
-    , subq_6.bookings AS bookings
+    subq_6.metric_time__day AS metric_time__day
+    , subq_5.bookings AS bookings
   FROM (
     -- Time Spine
     SELECT
-      subq_8.ds AS metric_time__day
-    FROM ***************************.mf_time_spine subq_8
-  ) subq_7
+      subq_7.ds AS metric_time__day
+    FROM ***************************.mf_time_spine subq_7
+  ) subq_6
   LEFT OUTER JOIN (
     -- Aggregate Measures
     SELECT
-      subq_5.metric_time__day
-      , SUM(subq_5.bookings) AS bookings
+      subq_4.metric_time__day
+      , SUM(subq_4.bookings) AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'metric_time__day']
       SELECT
-        subq_4.metric_time__day
-        , subq_4.bookings
+        subq_3.metric_time__day
+        , subq_3.bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
-    ) subq_5
+      ) subq_3
+    ) subq_4
     GROUP BY
-      subq_5.metric_time__day
-  ) subq_6
+      subq_4.metric_time__day
+  ) subq_5
   ON
-    subq_7.metric_time__day = subq_6.metric_time__day
-) subq_9
+    subq_6.metric_time__day = subq_5.metric_time__day
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,9 +5,9 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_18
+    subq_17.ds AS metric_time__day
+    , subq_15.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_17
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'metric_time__day']
@@ -30,13 +30,13 @@ FROM (
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_11
+      ) subq_10
       WHERE booking__is_instant
-    ) subq_13
+    ) subq_12
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_16
+  ) subq_15
   ON
-    subq_18.ds = subq_16.metric_time__day
-) subq_19
+    subq_17.ds = subq_15.metric_time__day
+) subq_18

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0.sql
@@ -1,351 +1,248 @@
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day
-  , subq_9.booking__is_instant
-  , COALESCE(subq_9.bookings, 0) AS bookings_fill_nulls_with_0
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , COALESCE(subq_8.bookings, 0) AS bookings_fill_nulls_with_0
 FROM (
   -- Constrain Output with WHERE
   SELECT
-    subq_8.metric_time__day
-    , subq_8.booking__is_instant
-    , subq_8.bookings
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_6.metric_time__day AS metric_time__day
-      , subq_5.booking__is_instant AS booking__is_instant
-      , subq_5.bookings AS bookings
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
     FROM (
       -- Time Spine
       SELECT
-        subq_7.ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_7
-    ) subq_6
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
     LEFT OUTER JOIN (
       -- Aggregate Measures
       SELECT
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-        , SUM(subq_4.bookings) AS bookings
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
       FROM (
         -- Constrain Output with WHERE
         SELECT
-          subq_3.metric_time__day
-          , subq_3.booking__is_instant
-          , subq_3.bookings
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
         FROM (
           -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
           SELECT
-            subq_2.metric_time__day
-            , subq_2.booking__is_instant
-            , subq_2.bookings
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
           FROM (
-            -- Constrain Output with WHERE
+            -- Metric Time Dimension 'ds'
             SELECT
-              subq_1.ds__day
-              , subq_1.ds__week
-              , subq_1.ds__month
-              , subq_1.ds__quarter
-              , subq_1.ds__year
-              , subq_1.ds__extract_year
-              , subq_1.ds__extract_quarter
-              , subq_1.ds__extract_month
-              , subq_1.ds__extract_day
-              , subq_1.ds__extract_dow
-              , subq_1.ds__extract_doy
-              , subq_1.ds_partitioned__day
-              , subq_1.ds_partitioned__week
-              , subq_1.ds_partitioned__month
-              , subq_1.ds_partitioned__quarter
-              , subq_1.ds_partitioned__year
-              , subq_1.ds_partitioned__extract_year
-              , subq_1.ds_partitioned__extract_quarter
-              , subq_1.ds_partitioned__extract_month
-              , subq_1.ds_partitioned__extract_day
-              , subq_1.ds_partitioned__extract_dow
-              , subq_1.ds_partitioned__extract_doy
-              , subq_1.paid_at__day
-              , subq_1.paid_at__week
-              , subq_1.paid_at__month
-              , subq_1.paid_at__quarter
-              , subq_1.paid_at__year
-              , subq_1.paid_at__extract_year
-              , subq_1.paid_at__extract_quarter
-              , subq_1.paid_at__extract_month
-              , subq_1.paid_at__extract_day
-              , subq_1.paid_at__extract_dow
-              , subq_1.paid_at__extract_doy
-              , subq_1.booking__ds__day
-              , subq_1.booking__ds__week
-              , subq_1.booking__ds__month
-              , subq_1.booking__ds__quarter
-              , subq_1.booking__ds__year
-              , subq_1.booking__ds__extract_year
-              , subq_1.booking__ds__extract_quarter
-              , subq_1.booking__ds__extract_month
-              , subq_1.booking__ds__extract_day
-              , subq_1.booking__ds__extract_dow
-              , subq_1.booking__ds__extract_doy
-              , subq_1.booking__ds_partitioned__day
-              , subq_1.booking__ds_partitioned__week
-              , subq_1.booking__ds_partitioned__month
-              , subq_1.booking__ds_partitioned__quarter
-              , subq_1.booking__ds_partitioned__year
-              , subq_1.booking__ds_partitioned__extract_year
-              , subq_1.booking__ds_partitioned__extract_quarter
-              , subq_1.booking__ds_partitioned__extract_month
-              , subq_1.booking__ds_partitioned__extract_day
-              , subq_1.booking__ds_partitioned__extract_dow
-              , subq_1.booking__ds_partitioned__extract_doy
-              , subq_1.booking__paid_at__day
-              , subq_1.booking__paid_at__week
-              , subq_1.booking__paid_at__month
-              , subq_1.booking__paid_at__quarter
-              , subq_1.booking__paid_at__year
-              , subq_1.booking__paid_at__extract_year
-              , subq_1.booking__paid_at__extract_quarter
-              , subq_1.booking__paid_at__extract_month
-              , subq_1.booking__paid_at__extract_day
-              , subq_1.booking__paid_at__extract_dow
-              , subq_1.booking__paid_at__extract_doy
-              , subq_1.metric_time__day
-              , subq_1.metric_time__week
-              , subq_1.metric_time__month
-              , subq_1.metric_time__quarter
-              , subq_1.metric_time__year
-              , subq_1.metric_time__extract_year
-              , subq_1.metric_time__extract_quarter
-              , subq_1.metric_time__extract_month
-              , subq_1.metric_time__extract_day
-              , subq_1.metric_time__extract_dow
-              , subq_1.metric_time__extract_doy
-              , subq_1.listing
-              , subq_1.guest
-              , subq_1.host
-              , subq_1.booking__listing
-              , subq_1.booking__guest
-              , subq_1.booking__host
-              , subq_1.is_instant
-              , subq_1.booking__is_instant
-              , subq_1.bookings
-              , subq_1.instant_bookings
-              , subq_1.booking_value
-              , subq_1.max_booking_value
-              , subq_1.min_booking_value
-              , subq_1.bookers
-              , subq_1.average_booking_value
-              , subq_1.referred_bookings
-              , subq_1.median_booking_value
-              , subq_1.booking_value_p99
-              , subq_1.discrete_booking_value_p99
-              , subq_1.approximate_continuous_booking_value_p99
-              , subq_1.approximate_discrete_booking_value_p99
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
             FROM (
-              -- Metric Time Dimension 'ds'
+              -- Read Elements From Semantic Model 'bookings_source'
               SELECT
-                subq_0.ds__day
-                , subq_0.ds__week
-                , subq_0.ds__month
-                , subq_0.ds__quarter
-                , subq_0.ds__year
-                , subq_0.ds__extract_year
-                , subq_0.ds__extract_quarter
-                , subq_0.ds__extract_month
-                , subq_0.ds__extract_day
-                , subq_0.ds__extract_dow
-                , subq_0.ds__extract_doy
-                , subq_0.ds_partitioned__day
-                , subq_0.ds_partitioned__week
-                , subq_0.ds_partitioned__month
-                , subq_0.ds_partitioned__quarter
-                , subq_0.ds_partitioned__year
-                , subq_0.ds_partitioned__extract_year
-                , subq_0.ds_partitioned__extract_quarter
-                , subq_0.ds_partitioned__extract_month
-                , subq_0.ds_partitioned__extract_day
-                , subq_0.ds_partitioned__extract_dow
-                , subq_0.ds_partitioned__extract_doy
-                , subq_0.paid_at__day
-                , subq_0.paid_at__week
-                , subq_0.paid_at__month
-                , subq_0.paid_at__quarter
-                , subq_0.paid_at__year
-                , subq_0.paid_at__extract_year
-                , subq_0.paid_at__extract_quarter
-                , subq_0.paid_at__extract_month
-                , subq_0.paid_at__extract_day
-                , subq_0.paid_at__extract_dow
-                , subq_0.paid_at__extract_doy
-                , subq_0.booking__ds__day
-                , subq_0.booking__ds__week
-                , subq_0.booking__ds__month
-                , subq_0.booking__ds__quarter
-                , subq_0.booking__ds__year
-                , subq_0.booking__ds__extract_year
-                , subq_0.booking__ds__extract_quarter
-                , subq_0.booking__ds__extract_month
-                , subq_0.booking__ds__extract_day
-                , subq_0.booking__ds__extract_dow
-                , subq_0.booking__ds__extract_doy
-                , subq_0.booking__ds_partitioned__day
-                , subq_0.booking__ds_partitioned__week
-                , subq_0.booking__ds_partitioned__month
-                , subq_0.booking__ds_partitioned__quarter
-                , subq_0.booking__ds_partitioned__year
-                , subq_0.booking__ds_partitioned__extract_year
-                , subq_0.booking__ds_partitioned__extract_quarter
-                , subq_0.booking__ds_partitioned__extract_month
-                , subq_0.booking__ds_partitioned__extract_day
-                , subq_0.booking__ds_partitioned__extract_dow
-                , subq_0.booking__ds_partitioned__extract_doy
-                , subq_0.booking__paid_at__day
-                , subq_0.booking__paid_at__week
-                , subq_0.booking__paid_at__month
-                , subq_0.booking__paid_at__quarter
-                , subq_0.booking__paid_at__year
-                , subq_0.booking__paid_at__extract_year
-                , subq_0.booking__paid_at__extract_quarter
-                , subq_0.booking__paid_at__extract_month
-                , subq_0.booking__paid_at__extract_day
-                , subq_0.booking__paid_at__extract_dow
-                , subq_0.booking__paid_at__extract_doy
-                , subq_0.ds__day AS metric_time__day
-                , subq_0.ds__week AS metric_time__week
-                , subq_0.ds__month AS metric_time__month
-                , subq_0.ds__quarter AS metric_time__quarter
-                , subq_0.ds__year AS metric_time__year
-                , subq_0.ds__extract_year AS metric_time__extract_year
-                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
-                , subq_0.ds__extract_month AS metric_time__extract_month
-                , subq_0.ds__extract_day AS metric_time__extract_day
-                , subq_0.ds__extract_dow AS metric_time__extract_dow
-                , subq_0.ds__extract_doy AS metric_time__extract_doy
-                , subq_0.listing
-                , subq_0.guest
-                , subq_0.host
-                , subq_0.booking__listing
-                , subq_0.booking__guest
-                , subq_0.booking__host
-                , subq_0.is_instant
-                , subq_0.booking__is_instant
-                , subq_0.bookings
-                , subq_0.instant_bookings
-                , subq_0.booking_value
-                , subq_0.max_booking_value
-                , subq_0.min_booking_value
-                , subq_0.bookers
-                , subq_0.average_booking_value
-                , subq_0.referred_bookings
-                , subq_0.median_booking_value
-                , subq_0.booking_value_p99
-                , subq_0.discrete_booking_value_p99
-                , subq_0.approximate_continuous_booking_value_p99
-                , subq_0.approximate_discrete_booking_value_p99
-              FROM (
-                -- Read Elements From Semantic Model 'bookings_source'
-                SELECT
-                  1 AS bookings
-                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-                  , bookings_source_src_28000.booking_value
-                  , bookings_source_src_28000.booking_value AS max_booking_value
-                  , bookings_source_src_28000.booking_value AS min_booking_value
-                  , bookings_source_src_28000.guest_id AS bookers
-                  , bookings_source_src_28000.booking_value AS average_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_payments
-                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-                  , bookings_source_src_28000.booking_value AS median_booking_value
-                  , bookings_source_src_28000.booking_value AS booking_value_p99
-                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
-                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
-                  , bookings_source_src_28000.is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
-                  , bookings_source_src_28000.is_instant AS booking__is_instant
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
-                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
-                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
-                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
-                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
-                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
-                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
-                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
-                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
-                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
-                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
-                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
-                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
-                  , bookings_source_src_28000.listing_id AS listing
-                  , bookings_source_src_28000.guest_id AS guest
-                  , bookings_source_src_28000.host_id AS host
-                  , bookings_source_src_28000.listing_id AS booking__listing
-                  , bookings_source_src_28000.guest_id AS booking__guest
-                  , bookings_source_src_28000.host_id AS booking__host
-                FROM ***************************.fct_bookings bookings_source_src_28000
-              ) subq_0
-            ) subq_1
-            WHERE booking__is_instant
-          ) subq_2
-        ) subq_3
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
         WHERE booking__is_instant
-      ) subq_4
+      ) subq_3
       GROUP BY
-        subq_4.metric_time__day
-        , subq_4.booking__is_instant
-    ) subq_5
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
     ON
-      subq_6.metric_time__day = subq_5.metric_time__day
-  ) subq_8
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
   WHERE booking__is_instant
-) subq_9
+) subq_8

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,10 +12,10 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_17.ds AS metric_time__day
-      , subq_15.booking__is_instant AS booking__is_instant
-      , subq_15.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_17
+      subq_16.ds AS metric_time__day
+      , subq_14.booking__is_instant AS booking__is_instant
+      , subq_14.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_16
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
       -- Aggregate Measures
@@ -38,16 +38,16 @@ FROM (
             , is_instant AS booking__is_instant
             , 1 AS bookings
           FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_11
+        ) subq_10
         WHERE booking__is_instant
-      ) subq_13
+      ) subq_12
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_15
+    ) subq_14
     ON
-      subq_17.ds = subq_15.metric_time__day
-  ) subq_18
+      subq_16.ds = subq_14.metric_time__day
+  ) subq_17
   WHERE booking__is_instant
-) subq_19
+) subq_18


### PR DESCRIPTION
Move categorical dimension filter pushdown to PredicatePushdownOptimizer

We are ready to move the categorical dimension filter predicate pushdown
out of the DataflowPlanBuilder and into the PredicatePushdownOptimizer.
This change makes the move with as close to parity on the existing pushdown
as possible, and adds some concrete tests of the optimizer now that it is
effecting changes on the DataflowPlan.

In theory, the outcome of this change should be that snapshots generated
from un-optimized DataflowPlans should no longer have an extra where
filter from the original build-time pushdown operation, while optimized
snapshots should be unchanged. In practice, the optimized snapshots still
have changes. These fit into two categories:

1. Subquery ID number changes caused by the removal of the extra subquery
in the non-optimized snapshots, since the ID numbers do not re-set between
the non-optimized and optimized runs.
2. Conversion metric rendering for query time filters now includes an
extra where constraint subquery due to an irrelevant pushdown operation. This is
caused by a difference in where the "disable pushdown for conversion metrics"
logic is applied - the optimizer cannot apply it until the join on conversion
node, while the original builder could effectively apply the change at compute
metric node level, and so we push down query-time filters one extra step. This
will be reverted when we remove the duplicated filters from the pushdown
operation.

This change also required fixes to a few bugs with the original tracking
implementation that only showed up when the full range of potential
snapshot updates had to be applied. In particular, a long-standing issue with
the previously never-called with_new_parents method of the CombineAggregatedOutputs
node has been resolved, and some missing or incorrectly applied checks to
prevent pushing time-based predicates down through offset windows and other
joins were addressed.