### PR TITLE
Use mantle-friendly DSI deps in `metricflow-semantics`

### DIFF
--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,5 @@
-dbt-semantic-interfaces>=0.5.0, <0.7.0 # Should match what is supported in dbt-mantle.
+
+dbt-semantic-interfaces>=0.5.0, <2.0.0 # dbt-mantle depends on metricflow-semantics, so DSI must always point to a production version here.
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,4 @@
-dbt-semantic-interfaces==0.6.0.dev2
+dbt-semantic-interfaces>=0.5.0, <0.7.0 # Should match what is supported in dbt-mantle.
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
-
-dbt-semantic-interfaces>=0.5.0, <2.0.0 # dbt-mantle depends on metricflow-semantics, so DSI must always point to a production version here.
+# dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
+dbt-semantic-interfaces>=0.5.0, <2.0.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0


### PR DESCRIPTION
We can't rely on a dev version of DSI in mantle. Since mantle depends on `metricflow-semantics`, we can't point to a dev version there.