### PR TITLE
Use new `cumulative_type_params` fields

### DIFF
--- a/.changes/unreleased/Under the Hood-20240612-233459.yaml
+++ b/.changes/unreleased/Under the Hood-20240612-233459.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Added filtering for DWH validation tasks and saved query support
+time: 2024-06-12T23:34:59.094903-04:00
+custom:
+  Author: WilliamDee
+  Issue: "1271"

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,5 @@
-dbt-semantic-interfaces==0.6.0.dev2
+# dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
+dbt-semantic-interfaces>=0.5.0, <2.0.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -10,6 +10,7 @@ from dbt_semantic_interfaces.transformations.convert_count import ConvertCountTo
 from dbt_semantic_interfaces.transformations.convert_median import (
     ConvertMedianToPercentileRule,
 )
+from dbt_semantic_interfaces.transformations.cumulative_type_params import SetCumulativeTypeParamsRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
@@ -35,6 +36,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
             ConvertCountToSumRule(),
             ConvertMedianToPercentileRule(),
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
+            SetCumulativeTypeParamsRule(),
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -246,7 +246,10 @@ class ValidLinkableSpecResolver:
         metrics_to_check = [metric]
         while metrics_to_check:
             metric_to_check = metrics_to_check.pop()
-            if metric_to_check.type_params.window is not None or metric_to_check.type_params.grain_to_date is not None:
+            if (
+                metric_to_check.type_params.cumulative_type_params.window is not None
+                or metric_to_check.type_params.cumulative_type_params.grain_to_date is not None
+            ):
                 return True
             for input_metric in metric_to_check.input_metrics:
                 if input_metric.offset_window is not None or input_metric.offset_to_grain is not None:
@@ -497,9 +500,11 @@ class ValidLinkableSpecResolver:
                         dimension_type=DimensionType.TIME,
                         entity_links=(),
                         join_path=SemanticModelJoinPath(
-                            left_semantic_model_reference=measure_semantic_model.reference
-                            if measure_semantic_model
-                            else SemanticModelDerivation.VIRTUAL_SEMANTIC_MODEL_REFERENCE,
+                            left_semantic_model_reference=(
+                                measure_semantic_model.reference
+                                if measure_semantic_model
+                                else SemanticModelDerivation.VIRTUAL_SEMANTIC_MODEL_REFERENCE
+                            ),
                         ),
                         # Anything that's not at the base time granularity of the measure's aggregation time dimension
                         # should be considered derived.

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
@@ -79,7 +79,11 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         elif metric.type is MetricType.CUMULATIVE:
             if (
                 metric.type_params is not None
-                and (metric.type_params.window is not None or metric.type_params.grain_to_date is not None)
+                and metric.type_params.cumulative_type_params is not None
+                and (
+                    metric.type_params.cumulative_type_params.window is not None
+                    or metric.type_params.cumulative_type_params.grain_to_date is not None
+                )
                 and not query_includes_metric_time_or_agg_time_dimension
             ):
                 return MetricFlowQueryResolutionIssueSet.from_issue(

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/ambiguous_resolution_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/ambiguous_resolution_manifest/metrics.yaml
@@ -70,7 +70,8 @@ metric:
   type: cumulative
   type_params:
     measure: monthly_measure_0
-    window: 2 months
+    cumulative_type_params:
+      window: 2 months
 ---
 metric:
   name: derived_metric_with_common_filtered_metric_0

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_cumulative.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_cumulative.yaml
@@ -4,4 +4,5 @@ metric:
   type: cumulative
   type_params:
     measure: bookings
-    window: 7 days
+    cumulative_type_params:
+      window: 7 days

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_monthly_cumulative.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_monthly_cumulative.yaml
@@ -4,4 +4,5 @@ metric:
   type: cumulative
   type_params:
     measure: bookings_monthly
-    window: 3 month
+    cumulative_type_params:
+      window: 3 month

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -135,7 +135,8 @@ metric:
   type: cumulative
   type_params:
     measure: txn_revenue
-    window: 2 month
+    cumulative_type_params:
+      window: 2 month
 ---
 metric:
   name: "revenue_all_time"
@@ -150,7 +151,8 @@ metric:
   type: cumulative
   type_params:
     measure: bookers
-    window: 2 days
+    cumulative_type_params:
+      window: 2 days
 ---
 metric:
   name: "revenue_mtd"
@@ -158,7 +160,8 @@ metric:
   type: cumulative
   type_params:
     measure: txn_revenue
-    grain_to_date: month
+    cumulative_type_params:
+      grain_to_date: month
 ---
 metric:
   name: booking_fees
@@ -629,7 +632,8 @@ metric:
       name: bookers
       join_to_timespine: true
       fill_nulls_with: 0
-    window: 2 days
+    cumulative_type_params:
+      window: 2 days
 ---
 metric:
   name: bookings_growth_2_weeks_fill_nulls_with_0

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -130,7 +130,8 @@ METRICS_YAML = textwrap.dedent(
       type: cumulative
       type_params:
         measure: revenue
-        window: 7 days
+        cumulative_type_params:
+          window: 7 days
     ---
     metric:
       name: revenue_sub_10

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -495,8 +495,8 @@ class DataflowPlanBuilder:
             child_metric_offset_to_grain=metric_spec.offset_to_grain,
             cumulative_description=(
                 CumulativeMeasureDescription(
-                    cumulative_window=metric.type_params.window,
-                    cumulative_grain_to_date=metric.type_params.grain_to_date,
+                    cumulative_window=metric.type_params.cumulative_type_params.window,
+                    cumulative_grain_to_date=metric.type_params.cumulative_type_params.grain_to_date,
                 )
                 if metric.type is MetricType.CUMULATIVE
                 else None

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1055,9 +1055,9 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     spec=metric_time_dimension_spec,
                 )
             )
-            output_column_to_input_column[
-                metric_time_dimension_column_association.column_name
-            ] = matching_time_dimension_instance.associated_column.column_name
+            output_column_to_input_column[metric_time_dimension_column_association.column_name] = (
+                matching_time_dimension_instance.associated_column.column_name
+            )
 
         output_instance_set = InstanceSet(
             measure_instances=tuple(output_measure_instances),
@@ -1289,11 +1289,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             and len(time_spine_dataset.checked_sql_select_node.select_columns) == 1
         ), "Time spine dataset not configured properly. Expected exactly one column."
         original_time_spine_dim_instance = time_spine_dataset.instance_set.time_dimension_instances[0]
-        time_spine_column_select_expr: Union[
-            SqlColumnReferenceExpression, SqlDateTruncExpression
-        ] = SqlColumnReferenceExpression(
-            SqlColumnReference(
-                table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
+        time_spine_column_select_expr: Union[SqlColumnReferenceExpression, SqlDateTruncExpression] = (
+            SqlColumnReferenceExpression(
+                SqlColumnReference(
+                    table_alias=time_spine_alias, column_name=original_time_spine_dim_instance.spec.qualified_name
+                )
             )
         )
 

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATETIME_TRUNC(ds, day) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/BigQuery/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATETIME_TRUNC(ds, day) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Databricks/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/DuckDB/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Postgres/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Redshift/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Snowflake/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_metric_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_metric_tasks__query0.sql
@@ -1,12 +1,7 @@
--- Aggregate Measures
--- Compute Metrics via Expressions
 SELECT
   metric_time__day
   , SUM(count_dogs) AS count_dogs
 FROM (
-  -- Read Elements From Semantic Model 'animals'
-  -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['count_dogs', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
     , 1 AS count_dogs

--- a/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
+++ b/tests_metricflow/snapshots/test_data_warehouse_tasks.py/str/Trino/test_build_saved_query_tasks__query0.sql
@@ -1,0 +1,28 @@
+SELECT
+  metric_time__day
+  , listing__capacity_latest
+  , SUM(bookings) AS bookings
+  , SUM(instant_bookings) AS instant_bookings
+FROM (
+  SELECT
+    subq_2.metric_time__day AS metric_time__day
+    , listings_latest_src_10000.capacity AS listing__capacity_latest
+    , subq_2.bookings AS bookings
+    , subq_2.instant_bookings AS instant_bookings
+  FROM (
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    FROM ***************************.fct_bookings bookings_source_src_10000
+  ) subq_2
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_10000
+  ON
+    subq_2.listing = listings_latest_src_10000.listing_id
+) subq_7
+WHERE listing__capacity_latest > 3
+GROUP BY
+  metric_time__day
+  , listing__capacity_latest

--- a/tests_metricflow/validation/test_data_warehouse_tasks.py
+++ b/tests_metricflow/validation/test_data_warehouse_tasks.py
@@ -50,6 +50,11 @@ def test_build_semantic_model_tasks(  # noqa: D103
     tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(manifest=data_warehouse_validation_model)
     assert len(tasks) == len(data_warehouse_validation_model.semantic_models)
 
+    tasks = DataWarehouseTaskBuilder.gen_semantic_model_tasks(
+        manifest=data_warehouse_validation_model, semantic_model_filters=[]
+    )
+    assert len(tasks) == 0
+
 
 def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
@@ -115,6 +120,13 @@ def test_build_dimension_tasks(  # noqa: D103
     # 1 categorical dimension task, 1 time dimension task, 4 granularity based time dimension tasks, 6 date_part tasks
     assert len(tasks[0].on_fail_subtasks) == 12
 
+    tasks = DataWarehouseTaskBuilder.gen_dimension_tasks(
+        manifest=data_warehouse_validation_model,
+        sql_client=sql_client,
+        semantic_model_filters=[],
+    )
+    assert len(tasks) == 0
+
 
 def test_validate_dimensions(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
@@ -149,6 +161,11 @@ def test_build_entities_tasks(  # noqa: D103
     assert len(tasks) == 1  # on semantic model query with all entities
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each entity on the semantic model
 
+    tasks = DataWarehouseTaskBuilder.gen_entity_tasks(
+        manifest=data_warehouse_validation_model, sql_client=sql_client, semantic_model_filters=[]
+    )
+    assert len(tasks) == 0
+
 
 def test_validate_entities(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
@@ -182,6 +199,11 @@ def test_build_measure_tasks(  # noqa: D103
     )
     assert len(tasks) == 1  # on semantic model query with all measures
     assert len(tasks[0].on_fail_subtasks) == 1  # a sub task for each measure on the semantic model
+
+    tasks = DataWarehouseTaskBuilder.gen_measure_tasks(
+        manifest=data_warehouse_validation_model, sql_client=sql_client, semantic_model_filters=[]
+    )
+    assert len(tasks) == 0
 
 
 def test_validate_measures(  # noqa: D103
@@ -228,6 +250,13 @@ def test_build_metric_tasks(  # noqa: D103
         sql_engine=sql_client.sql_engine_type,
     )
 
+    tasks = DataWarehouseTaskBuilder.gen_metric_tasks(
+        manifest=data_warehouse_validation_model,
+        sql_client=sql_client,
+        metric_filters=[],
+    )
+    assert len(tasks) == 0
+
 
 def test_validate_metrics(  # noqa: D103
     dw_backed_warehouse_validation_model: PydanticSemanticManifest,
@@ -260,3 +289,31 @@ def test_validate_metrics(  # noqa: D103
     assert len(issues.all_issues) == 1
     assert len(issues.errors) == 1
     assert "Unable to query metric `count_cats`" in issues.errors[0].message
+
+
+@pytest.mark.sql_engine_snapshot
+def test_build_saved_query_tasks(  # noqa: D103
+    request: FixtureRequest,
+    simple_semantic_manifest: PydanticSemanticManifest,
+    sql_client: SqlClient,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    tasks = DataWarehouseTaskBuilder.gen_saved_query_tasks(
+        manifest=simple_semantic_manifest,
+        sql_client=sql_client,
+    )
+    assert len(tasks) == 2
+
+    tasks = DataWarehouseTaskBuilder.gen_saved_query_tasks(
+        manifest=simple_semantic_manifest, sql_client=sql_client, saved_query_filters=["p0_booking"]
+    )
+    assert len(tasks) == 1
+    (query_string, _params) = tasks[0].query_and_params_callable()
+
+    assert_sql_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        snapshot_id="query0",
+        sql=query_string,
+        sql_engine=sql_client.sql_engine_type,
+    )


### PR DESCRIPTION
Completes SL-2413
Consume new `cumulative_type_params` field instead of `type_params` cumulative fields. Eventually we will retire the `type_params` fields altogether. For now, we have a transformation that copies the fields from `type_params` to `cumulative_type_params`, if not yet set.