### PR TITLE
Consume new `cumulative_type_params` fields

### DIFF
--- a/.changes/unreleased/Under the Hood-20240618-161241.yaml
+++ b/.changes/unreleased/Under the Hood-20240618-161241.yaml
@@ -1,0 +1,7 @@
+kind: Under the Hood
+body: Consume cumulative-specific metric type params from new cumulative_type_params
+  field.
+time: 2024-06-18T16:12:41.132445-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1293"

--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.6.0.dev2
+dbt-semantic-interfaces==0.6.1.dev0
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <1.11.0
 tabulate>=0.8.9

--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.6.1.dev0
+dbt-semantic-interfaces==0.6.1
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <1.11.0
 tabulate>=0.8.9

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 # dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
-dbt-semantic-interfaces==0.6.1.dev0 # Temp: pin to dev release to support cumulative_type_params in MF before they get released in prod.
+dbt-semantic-interfaces>=0.6.1, <2.0.0 # Temp: pin to dev release to support cumulative_type_params in MF before they get released in prod.
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 # dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
-dbt-semantic-interfaces>=0.6.1, <2.0.0 # Temp: pin to dev release to support cumulative_type_params in MF before they get released in prod.
+dbt-semantic-interfaces>=0.6.1, <2.0.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 # dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
-dbt-semantic-interfaces>=0.5.0, <2.0.0
+dbt-semantic-interfaces==0.6.1.dev0 # Temp: pin to dev release to support cumulative_type_params in MF before they get released in prod.
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -10,6 +10,7 @@ from dbt_semantic_interfaces.transformations.convert_count import ConvertCountTo
 from dbt_semantic_interfaces.transformations.convert_median import (
     ConvertMedianToPercentileRule,
 )
+from dbt_semantic_interfaces.transformations.cumulative_type_params import SetCumulativeTypeParamsRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
@@ -35,6 +36,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
             ConvertCountToSumRule(),
             ConvertMedianToPercentileRule(),
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
+            SetCumulativeTypeParamsRule(),
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)

--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -26,6 +26,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
     # The serialized object in the dbt project does not have all transformations applied to it at
     # this time, which causes failures with input measure resolution.
     # TODO: remove this transform call once the upstream changes are integrated into our dependency tree
+    # TODO: align rules between DSI, here, and MFS (if possible!)
     rules = (
         # Primary
         (LowerCaseNamesRule(),),

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -246,7 +246,10 @@ class ValidLinkableSpecResolver:
         metrics_to_check = [metric]
         while metrics_to_check:
             metric_to_check = metrics_to_check.pop()
-            if metric_to_check.type_params.window is not None or metric_to_check.type_params.grain_to_date is not None:
+            if metric_to_check.type_params.cumulative_type_params and (
+                metric_to_check.type_params.cumulative_type_params.window is not None
+                or metric_to_check.type_params.cumulative_type_params.grain_to_date is not None
+            ):
                 return True
             for input_metric in metric_to_check.input_metrics:
                 if input_metric.offset_window is not None or input_metric.offset_to_grain is not None:
@@ -497,9 +500,11 @@ class ValidLinkableSpecResolver:
                         dimension_type=DimensionType.TIME,
                         entity_links=(),
                         join_path=SemanticModelJoinPath(
-                            left_semantic_model_reference=measure_semantic_model.reference
-                            if measure_semantic_model
-                            else SemanticModelDerivation.VIRTUAL_SEMANTIC_MODEL_REFERENCE,
+                            left_semantic_model_reference=(
+                                measure_semantic_model.reference
+                                if measure_semantic_model
+                                else SemanticModelDerivation.VIRTUAL_SEMANTIC_MODEL_REFERENCE
+                            ),
                         ),
                         # Anything that's not at the base time granularity of the measure's aggregation time dimension
                         # should be considered derived.

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
@@ -79,7 +79,11 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         elif metric.type is MetricType.CUMULATIVE:
             if (
                 metric.type_params is not None
-                and (metric.type_params.window is not None or metric.type_params.grain_to_date is not None)
+                and metric.type_params.cumulative_type_params is not None
+                and (
+                    metric.type_params.cumulative_type_params.window is not None
+                    or metric.type_params.cumulative_type_params.grain_to_date is not None
+                )
                 and not query_includes_metric_time_or_agg_time_dimension
             ):
                 return MetricFlowQueryResolutionIssueSet.from_issue(

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/ambiguous_resolution_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/ambiguous_resolution_manifest/metrics.yaml
@@ -70,7 +70,8 @@ metric:
   type: cumulative
   type_params:
     measure: monthly_measure_0
-    window: 2 months
+    cumulative_type_params:
+      window: 2 months
 ---
 metric:
   name: derived_metric_with_common_filtered_metric_0

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_cumulative.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_cumulative.yaml
@@ -4,4 +4,5 @@ metric:
   type: cumulative
   type_params:
     measure: bookings
-    window: 7 days
+    cumulative_type_params:
+      window: 7 days

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_monthly_cumulative.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/extended_date_manifest/metrics/bookings_monthly_cumulative.yaml
@@ -4,4 +4,5 @@ metric:
   type: cumulative
   type_params:
     measure: bookings_monthly
-    window: 3 month
+    cumulative_type_params:
+      window: 3 month

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -137,6 +137,7 @@ metric:
     measure: txn_revenue
     cumulative_type_params:
       window: 2 month
+      period_agg: average
 ---
 metric:
   name: "revenue_all_time"
@@ -144,6 +145,8 @@ metric:
   type: cumulative
   type_params:
     measure: txn_revenue
+    cumulative_type_params:
+      period_agg: last
 ---
 metric:
   name: "every_two_days_bookers"

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -135,7 +135,8 @@ metric:
   type: cumulative
   type_params:
     measure: txn_revenue
-    window: 2 month
+    cumulative_type_params:
+      window: 2 month
 ---
 metric:
   name: "revenue_all_time"
@@ -158,7 +159,8 @@ metric:
   type: cumulative
   type_params:
     measure: txn_revenue
-    grain_to_date: month
+    cumulative_type_params:
+      grain_to_date: month
 ---
 metric:
   name: booking_fees
@@ -629,7 +631,8 @@ metric:
       name: bookers
       join_to_timespine: true
       fill_nulls_with: 0
-    window: 2 days
+    cumulative_type_params:
+      window: 2 days
 ---
 metric:
   name: bookings_growth_2_weeks_fill_nulls_with_0

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -130,7 +130,8 @@ METRICS_YAML = textwrap.dedent(
       type: cumulative
       type_params:
         measure: revenue
-        window: 7 days
+        cumulative_type_params:
+          window: 7 days
     ---
     metric:
       name: revenue_sub_10

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -495,8 +495,16 @@ class DataflowPlanBuilder:
             child_metric_offset_to_grain=metric_spec.offset_to_grain,
             cumulative_description=(
                 CumulativeMeasureDescription(
-                    cumulative_window=metric.type_params.window,
-                    cumulative_grain_to_date=metric.type_params.grain_to_date,
+                    cumulative_window=(
+                        metric.type_params.cumulative_type_params.window
+                        if metric.type_params.cumulative_type_params
+                        else None
+                    ),
+                    cumulative_grain_to_date=(
+                        metric.type_params.cumulative_type_params.grain_to_date
+                        if metric.type_params.cumulative_type_params
+                        else None
+                    ),
                 )
                 if metric.type is MetricType.CUMULATIVE
                 else None

--- a/metricflow/sql/sql_exprs.py
+++ b/metricflow/sql/sql_exprs.py
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.protocols.measure import MeasureAggregationParameters
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
+from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagNode, DisplayedProperty, NodeId
@@ -966,6 +967,18 @@ class SqlWindowFunction(Enum):
             return False
         else:
             assert_values_exhausted(self)
+
+    @classmethod
+    def get_window_function_for_period_agg(cls, period_agg: PeriodAggregation) -> SqlWindowFunction:
+        """Get the window function to use for given period agg option."""
+        if period_agg is PeriodAggregation.FIRST:
+            return cls.FIRST_VALUE
+        elif period_agg is PeriodAggregation.LAST:
+            return cls.LAST_VALUE
+        elif period_agg is PeriodAggregation.AVERAGE:
+            return cls.AVERAGE
+        else:
+            assert_values_exhausted(period_agg)
 
 
 @dataclass(frozen=True)

--- a/tests_metricflow/integration/test_cases/itest_cumulative_metric.yaml
+++ b/tests_metricflow/integration/test_cases/itest_cumulative_metric.yaml
@@ -428,7 +428,7 @@ integration_test:
       SELECT
         metric_time__week
         , metric_time__quarter
-        , FIRST_VALUE(revenue_all_time) OVER (
+        , LAST_VALUE(revenue_all_time) OVER (
           PARTITION BY metric_time__week, metric_time__quarter
           ORDER BY metric_time__day
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
@@ -467,7 +467,7 @@ integration_test:
       SELECT
         revenue_instance__ds__month
         , metric_time__week
-        , FIRST_VALUE(trailing_2_months_revenue) OVER (
+        , AVG(trailing_2_months_revenue) OVER (
           PARTITION BY revenue_instance__ds__month, metric_time__week
           ORDER BY metric_time__day
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
@@ -562,7 +562,7 @@ integration_test:
         SELECT
           metric_time__month
           , metric_time__year
-          , FIRST_VALUE(t2mr) OVER (
+          , AVG(t2mr) OVER (
             PARTITION BY metric_time__month, metric_time__year
             ORDER BY metric_time__day
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -623,7 +623,6 @@ def test_derived_cumulative_metric_with_non_default_grains(
 
 
 # TODO: write the following tests when unblocked
-# - Render each of the allowed period_aggs (both set in YAML & default)
 # - Query cumulative metric with non-day default_grain (using default grain and non-default grain)
 # - Query 2 metrics with different default_grains using metric_time (no grain specified)
 # - If default grain is WEEK, query with a higher grain (check that we still get correct values)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         metric_time__day
         , metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       metric_time__day
       , metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     subq_7.metric_time__week
     , subq_7.metric_time__quarter
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY
         subq_7.metric_time__week
         , subq_7.metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   SELECT
     metric_time__week
     , metric_time__quarter
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY
         metric_time__week
         , metric_time__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__week
-    , FIRST_VALUE(subq_7.revenue_all_time) OVER (
+    , LAST_VALUE(subq_7.revenue_all_time) OVER (
       PARTITION BY subq_7.metric_time__week
       ORDER BY subq_7.metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,7 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__week
-    , FIRST_VALUE(revenue_all_time) OVER (
+    , LAST_VALUE(revenue_all_time) OVER (
       PARTITION BY metric_time__week
       ORDER BY metric_time__day
       ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -11,11 +11,7 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       subq_7.metric_time__week
-      , FIRST_VALUE(subq_7.t2mr) OVER (
-        PARTITION BY subq_7.metric_time__week
-        ORDER BY subq_7.metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(subq_7.t2mr) OVER (PARTITION BY subq_7.metric_time__week) AS t2mr
     FROM (
       -- Compute Metrics via Expressions
       SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -11,19 +11,14 @@ FROM (
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , FIRST_VALUE(t2mr) OVER (
-        PARTITION BY metric_time__week
-        ORDER BY metric_time__day
-        ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-      ) AS t2mr
+      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_12.metric_time__week AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS t2mr
       FROM (
         -- Time Spine

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -8,18 +8,19 @@ FROM (
     metric_time__week
     , t2mr
   FROM (
+    -- Compute Metrics via Expressions
     -- Window Function for Metric Re-aggregation
     SELECT
       metric_time__week
-      , AVG(t2mr) OVER (PARTITION BY metric_time__week) AS t2mr
+      , AVG(txn_revenue) OVER (PARTITION BY metric_time__week) AS t2mr
     FROM (
       -- Join Self Over Time Range
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
-      -- Compute Metrics via Expressions
       SELECT
-        subq_12.metric_time__week AS metric_time__week
-        , SUM(revenue_src_28000.revenue) AS t2mr
+        subq_12.metric_time__day AS metric_time__day
+        , subq_12.metric_time__week AS metric_time__week
+        , SUM(revenue_src_28000.revenue) AS txn_revenue
       FROM (
         -- Time Spine
         SELECT
@@ -41,7 +42,7 @@ FROM (
       GROUP BY
         subq_12.metric_time__day
         , subq_12.metric_time__week
-    ) subq_17
+    ) subq_16
   ) subq_18
   GROUP BY
     metric_time__week

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
@@ -6,11 +6,7 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     subq_7.metric_time__year
-    , FIRST_VALUE(subq_7.trailing_2_months_revenue) OVER (
-      PARTITION BY subq_7.metric_time__year
-      ORDER BY subq_7.metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(subq_7.trailing_2_months_revenue) OVER (PARTITION BY subq_7.metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Compute Metrics via Expressions
     SELECT

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -3,18 +3,19 @@ SELECT
   metric_time__year
   , trailing_2_months_revenue
 FROM (
+  -- Compute Metrics via Expressions
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
+    , AVG(txn_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
-    -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__year AS metric_time__year
-      , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
+      subq_11.metric_time__day AS metric_time__day
+      , subq_11.metric_time__year AS metric_time__year
+      , SUM(revenue_src_28000.revenue) AS txn_revenue
     FROM (
       -- Time Spine
       SELECT
@@ -36,7 +37,7 @@ FROM (
     GROUP BY
       subq_11.metric_time__day
       , subq_11.metric_time__year
-  ) subq_16
+  ) subq_15
 ) subq_17
 GROUP BY
   metric_time__year

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -6,19 +6,14 @@ FROM (
   -- Window Function for Metric Re-aggregation
   SELECT
     metric_time__year
-    , FIRST_VALUE(trailing_2_months_revenue) OVER (
-      PARTITION BY metric_time__year
-      ORDER BY metric_time__day
-      ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
-    ) AS trailing_2_months_revenue
+    , AVG(trailing_2_months_revenue) OVER (PARTITION BY metric_time__year) AS trailing_2_months_revenue
   FROM (
     -- Join Self Over Time Range
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_11.metric_time__year AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
     FROM (
       -- Time Spine


### PR DESCRIPTION
Completes SL-2413

Consume new `cumulative_type_params` fields (`window` and `grain_to_date`) instead of `type_params` cumulative fields. Eventually we will retire the `type_params` fields altogether. For now, we have a transformation that copies the fields from `type_params` to `cumulative_type_params`, if not yet set. This ensures that we only need to consume the new fields here.

This is the last step needed to enable non-default granularities for cumulative metrics in MF 🥳