### PR TITLE
Add `extra-hatch-configuration` to the cache config in Github workflows

### DIFF
--- a/.github/actions/setup-python-env/action.yaml
+++ b/.github/actions/setup-python-env/action.yaml
@@ -37,6 +37,7 @@ runs:
       key: >-
         python_location: "${{ env.pythonLocation }}" AND
         pyproject_hash: "${{ hashFiles('pyproject.toml') }}" AND
+        extra_hatch_configuration_hash: "${{ hashFiles('**/extra-hatch-configuration/*') }}" AND
         precommit_config_hash: "${{ hashFiles('.pre-commit-config.yaml') }}" AND
         linux_release: "${{ env.LINUX_RELEASE }}"
 


### PR DESCRIPTION
Since the files in `extra-hatch-configuration` are used to specify project dependencies, updates to those files should affect how the environment is cached in Github workflows.