### PR TITLE
Add test to check dev dependencies between `metricflow` and `metricflow-semantics`

### DIFF
--- a/.github/workflows/ci-metricflow-unit-tests.yaml
+++ b/.github/workflows/ci-metricflow-unit-tests.yaml
@@ -84,3 +84,20 @@ jobs:
 
       - name: Test `metricflow` Package
         run: bash scripts/ci_tests/metricflow_package_test.sh
+
+
+  metricflow-project-configuration-tests:
+    name: MetricFlow Project Configuration Tests
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Check-out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Python ${{ inputs.python-version }} Environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: 3.12
+
+      - name: Check Dev Dependencies
+        run: hatch run dev-env:python scripts/ci_tests/metricflow_semantics_package_test.sh

--- a/scripts/ci_tests/dev_dependency_test.py
+++ b/scripts/ci_tests/dev_dependency_test.py
@@ -1,0 +1,35 @@
+"""Rough test to check that dev dependencies between `metricflow` and `metricflow-semantics` are the similar."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Sequence
+
+import tomllib
+
+TomlType = dict[str, Any]  # type: ignore[misc]
+
+
+def _get_dev_dependencies(toml_obj: TomlType) -> Sequence[str]:
+    return toml_obj["tool"]["hatch"]["envs"]["dev-env"]["dependencies"]
+
+
+def check_dev_dependencies() -> None:  # noqa: D103
+    with open("pyproject.toml", "rb") as fp:
+        metricflow_pyproject_toml = tomllib.load(fp)
+
+    with open("metricflow-semantics/pyproject.toml", "rb") as fp:
+        metricflow_semantics_pyproject_toml = tomllib.load(fp)
+    metricflow_dev_env_dependencies = set(_get_dev_dependencies(metricflow_pyproject_toml))
+    metricflow_semantics_dev_env_dependencies = set(_get_dev_dependencies(metricflow_semantics_pyproject_toml))
+
+    if not metricflow_dev_env_dependencies.issuperset(metricflow_semantics_dev_env_dependencies):
+        raise ValueError(
+            f"Dev dependencies of `metricflow` are not a superset of those listed in `metricflow-semantics`"
+            f"\n\n{metricflow_dev_env_dependencies=}"
+            f"\n\n{metricflow_semantics_dev_env_dependencies=}"
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(format="%(asctime)s - %(levelname)s -  %(message)s", level=logging.INFO)
+    check_dev_dependencies()


### PR DESCRIPTION
Since the dev dependencies between `metricflow` and `metricflow-semantics` no longer share a common file, this adds a rough CI check to verify that they are similar.