### PR TITLE
Relax pydantic dependency range to allow for 2.x installs

### DIFF
--- a/.changes/unreleased/Dependencies-20240624-182325.yaml
+++ b/.changes/unreleased/Dependencies-20240624-182325.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Allow pydantic 2.x installations
+time: 2024-06-24T18:23:25.370934-07:00
+custom:
+    Author: tlento
+    Issue: "1299"

--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2>=3.1.3
 dbt-semantic-interfaces==0.6.1
 more-itertools>=8.10.0, <10.2.0
-pydantic>=1.10.0, <1.11.0
+pydantic>=1.10.0, <3.0
 tabulate>=0.8.9
 typing_extensions>=4.4, <5.0

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -7,7 +7,7 @@ from dataclasses import fields, is_dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sized, Union
 
-from pydantic import BaseModel
+from dsi_pydantic_shim import BaseModel
 
 from metricflow_semantics.mf_logging.formatting import indent
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -27,7 +27,7 @@ ignore_missing_imports = True
 [mypy-databricks]
 ignore_missing_imports = True
 
-[mypy-dbt_metadata_client.*]
+[mypy-dsi_pydantic_shim]
 ignore_missing_imports = True
 
 [mypy-google.*]


### PR DESCRIPTION
MetricFlow has a single dependency point on pydantic but all we
use it for is our pretty printer. Since all of the objects we
pass through there are, in practice, Pydantic 1.x objects loaded
via the dsi_pydantic_shim, we simply re-use that package element
from the dbt-semantic-interfaces installation and thereby ensure
we're loading the same base model.

This build state was tested via linting (which ran on a pydantic
1.10.x install) and unit tests (which ran on a pydantic 2.7.x install).
