### PR TITLE
Remove duplicated WhereConstraintNodes in predicate pushdown

### DIFF
--- a/.changes/unreleased/Fixes-20240625-114914.yaml
+++ b/.changes/unreleased/Fixes-20240625-114914.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove extraneous where filter subqueries added by predicate pushdown
+time: 2024-06-25T11:49:14.837794-07:00
+custom:
+    Author: tlento
+    Issue: "1011"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -1602,7 +1602,9 @@ class DataflowPlanBuilder:
                 if set(filter_spec.linkable_specs).issubset(set(queried_linkable_specs.as_tuple))
             ]
             if len(queried_filter_specs) > 0:
-                output_node = WhereConstraintNode(parent_node=output_node, where_specs=queried_filter_specs)
+                output_node = WhereConstraintNode(
+                    parent_node=output_node, where_specs=queried_filter_specs, always_apply=True
+                )
 
             # TODO: this will break if you query by agg_time_dimension but apply a time constraint on metric_time.
             # To fix when enabling time range constraints for agg_time_dimension.

--- a/metricflow/dataflow/nodes/where_filter.py
+++ b/metricflow/dataflow/nodes/where_filter.py
@@ -66,14 +66,20 @@ class WhereConstraintNode(DataflowPlanNode):
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
-        return tuple(super().displayed_properties) + (DisplayedProperty("where_condition", self.where),)
+        properties = tuple(super().displayed_properties) + (DisplayedProperty("where_condition", self.where),)
+        if self.always_apply:
+            properties = properties + (DisplayedProperty("All filters always applied:", self.always_apply),)
+        return properties
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
-        return isinstance(other_node, self.__class__) and other_node.where == self.where
+        return (
+            isinstance(other_node, self.__class__)
+            and other_node.where == self.where
+            and other_node.always_apply == self.always_apply
+        )
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> WhereConstraintNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return WhereConstraintNode(
-            parent_node=new_parent_nodes[0],
-            where_specs=self.input_where_specs,
+            parent_node=new_parent_nodes[0], where_specs=self.input_where_specs, always_apply=self.always_apply
         )

--- a/metricflow/dataflow/nodes/where_filter.py
+++ b/metricflow/dataflow/nodes/where_filter.py
@@ -13,13 +13,27 @@ from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNode
 class WhereConstraintNode(DataflowPlanNode):
     """Remove rows using a WHERE clause."""
 
-    def __init__(  # noqa: D107
+    def __init__(
         self,
         parent_node: DataflowPlanNode,
         where_specs: Sequence[WhereFilterSpec],
+        always_apply: bool = False,
     ) -> None:
+        """Initializer.
+
+        WhereConstraintNodes must always have exactly one parent, since they always wrap a single subquery input.
+
+        The always_apply parameter serves as an indicator for a WhereConstraintNode that is added to a plan in order
+        to clean up null outputs from a pre-join filter. For example, when doing time spine joins to fill null values
+        for metric outputs sometimes that join will result in rows with null values for various dimension attributes.
+        By re-applying the filter expression after the join step we will discard those unexpected output rows created
+        by the join (rather than the underlying inputs). In this case, we must ensure that the filters defined in this
+        node are always applied at the moment this node is processed, regardless of whether or not they've been pushed
+        down through the DAG.
+        """
         self._where_specs = where_specs
         self.parent_node = parent_node
+        self.always_apply = always_apply
         super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
 
     @classmethod

--- a/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
+++ b/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
@@ -385,6 +385,13 @@ class PredicatePushdownOptimizer(
                 )
 
             if node.always_apply:
+                logger.log(
+                    level=self._log_level,
+                    msg=(
+                        "Applying original filter spec set based on node-level override directive. Additional specs "
+                        + f"appled:\n{[spec for spec in node.input_where_specs if spec not in filter_specs_to_apply]}"
+                    ),
+                )
                 optimized_node = OptimizeBranchResult(
                     optimized_branch=node.with_new_parents((optimized_parent.optimized_branch,))
                 )

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_32
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_36
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > DATE_SUB(CAST(subq_31.ds__day AS DATETIME), INTERVAL 7 day)
+            subq_27.ds__day > DATE_SUB(CAST(subq_30.ds__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_36
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > subq_31.ds__day - INTERVAL 7 day
+            subq_27.ds__day > subq_30.ds__day - INTERVAL 7 day
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > subq_31.ds__day - MAKE_INTERVAL(days => 7)
+            subq_27.ds__day > subq_30.ds__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > DATEADD(day, -7, subq_31.ds__day)
+            subq_27.ds__day > DATEADD(day, -7, subq_30.ds__day)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -6,40 +6,32 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day) AS metric_time__day
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_21.visits) AS visits
-    , MAX(subq_31.buys) AS buys
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day) AS metric_time__day
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_20.visits) AS visits
+    , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_17
-      WHERE visit__referrer_id = 'ref_id_01'
-    ) subq_19
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_17
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_21
+  ) subq_20
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -51,48 +43,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_24.visits) OVER (
+        FIRST_VALUE(subq_23.visits) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_24.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_23.visit__referrer_id) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_24.ds__day) OVER (
+        , FIRST_VALUE(subq_23.ds__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_24.metric_time__day) OVER (
+        , FIRST_VALUE(subq_23.metric_time__day) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_24.user) OVER (
+        , FIRST_VALUE(subq_23.user) OVER (
           PARTITION BY
-            subq_27.user
-            , subq_27.ds__day
-            , subq_27.mf_internal_uuid
-          ORDER BY subq_24.ds__day DESC
+            subq_26.user
+            , subq_26.ds__day
+            , subq_26.mf_internal_uuid
+          ORDER BY subq_23.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_27.mf_internal_uuid AS mf_internal_uuid
-        , subq_27.buys AS buys
+        , subq_26.mf_internal_uuid AS mf_internal_uuid
+        , subq_26.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -104,7 +96,7 @@ FROM (
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_24
+      ) subq_23
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -115,25 +107,25 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_27
+      ) subq_26
       ON
         (
-          subq_24.user = subq_27.user
+          subq_23.user = subq_26.user
         ) AND (
-          (subq_24.ds__day <= subq_27.ds__day)
+          (subq_23.ds__day <= subq_26.ds__day)
         )
-    ) subq_28
+    ) subq_27
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_31
+  ) subq_30
   ON
     (
-      subq_21.visit__referrer_id = subq_31.visit__referrer_id
+      subq_20.visit__referrer_id = subq_30.visit__referrer_id
     ) AND (
-      subq_21.metric_time__day = subq_31.metric_time__day
+      subq_20.metric_time__day = subq_30.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_21.metric_time__day, subq_31.metric_time__day)
-    , COALESCE(subq_21.visit__referrer_id, subq_31.visit__referrer_id)
-) subq_32
+    COALESCE(subq_20.metric_time__day, subq_30.metric_time__day)
+    , COALESCE(subq_20.visit__referrer_id, subq_30.visit__referrer_id)
+) subq_31

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -5,41 +5,34 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of INF
     -- Pass Only Elements: ['buys', 'visit__referrer_id']
@@ -50,40 +43,40 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -96,7 +89,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -107,19 +100,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
-          (subq_28.ds__day <= subq_31.ds__day)
+          (subq_27.ds__day <= subq_30.ds__day)
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
-    subq_24.visit__referrer_id = subq_35.visit__referrer_id
+    subq_23.visit__referrer_id = subq_34.visit__referrer_id
   GROUP BY
-    COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -6,45 +6,37 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day) AS metric_time__day
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id) AS visit__referrer_id
-    , MAX(subq_24.visits) AS visits
-    , MAX(subq_35.buys) AS buys
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day) AS metric_time__day
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id) AS visit__referrer_id
+    , MAX(subq_23.visits) AS visits
+    , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
+    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
+      -- Read Elements From Semantic Model 'visits_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , visit__referrer_id
-        , visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_19
-      WHERE (
-        metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) AND (
-        visit__referrer_id = 'ref_id_01'
-      )
-    ) subq_22
-    WHERE visit__referrer_id = 'ref_id_01'
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , referrer_id AS visit__referrer_id
+        , 1 AS visits
+      FROM ***************************.fct_visits visits_source_src_28000
+    ) subq_19
+    WHERE (
+      metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+    ) AND (
+      visit__referrer_id = 'ref_id_01'
+    )
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_24
+  ) subq_23
   FULL OUTER JOIN (
     -- Find conversions for user within the range of 7 day
     -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']
@@ -56,48 +48,48 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_28.visits) OVER (
+        FIRST_VALUE(subq_27.visits) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_28.visit__referrer_id) OVER (
+        , FIRST_VALUE(subq_27.visit__referrer_id) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_28.ds__day) OVER (
+        , FIRST_VALUE(subq_27.ds__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS ds__day
-        , FIRST_VALUE(subq_28.metric_time__day) OVER (
+        , FIRST_VALUE(subq_27.metric_time__day) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_28.user) OVER (
+        , FIRST_VALUE(subq_27.user) OVER (
           PARTITION BY
-            subq_31.user
-            , subq_31.ds__day
-            , subq_31.mf_internal_uuid
-          ORDER BY subq_28.ds__day DESC
+            subq_30.user
+            , subq_30.ds__day
+            , subq_30.mf_internal_uuid
+          ORDER BY subq_27.ds__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_31.mf_internal_uuid AS mf_internal_uuid
-        , subq_31.buys AS buys
+        , subq_30.mf_internal_uuid AS mf_internal_uuid
+        , subq_30.buys AS buys
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
@@ -111,7 +103,7 @@ FROM (
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
         WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-      ) subq_28
+      ) subq_27
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -122,29 +114,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_31
+      ) subq_30
       ON
         (
-          subq_28.user = subq_31.user
+          subq_27.user = subq_30.user
         ) AND (
           (
-            subq_28.ds__day <= subq_31.ds__day
+            subq_27.ds__day <= subq_30.ds__day
           ) AND (
-            subq_28.ds__day > DATE_ADD('day', -7, subq_31.ds__day)
+            subq_27.ds__day > DATE_ADD('day', -7, subq_30.ds__day)
           )
         )
-    ) subq_32
+    ) subq_31
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_35
+  ) subq_34
   ON
     (
-      subq_24.visit__referrer_id = subq_35.visit__referrer_id
+      subq_23.visit__referrer_id = subq_34.visit__referrer_id
     ) AND (
-      subq_24.metric_time__day = subq_35.metric_time__day
+      subq_23.metric_time__day = subq_34.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_24.metric_time__day, subq_35.metric_time__day)
-    , COALESCE(subq_24.visit__referrer_id, subq_35.visit__referrer_id)
-) subq_36
+    COALESCE(subq_23.metric_time__day, subq_34.metric_time__day)
+    , COALESCE(subq_23.visit__referrer_id, subq_34.visit__referrer_id)
+) subq_35

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -64,6 +64,7 @@
                     <!--       ),                                                                                   -->
                     <!--     ),                                                                                     -->
                     <!--   )                                                                                        -->
+                    <!-- All filters always applied: = True -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -9,8 +9,8 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_58.bookings) AS bookings
-      , MAX(subq_66.booking_value) AS booking_value
+      , MAX(subq_57.bookings) AS bookings
+      , MAX(subq_64.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value',]
@@ -22,15 +22,13 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          subq_36.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          listings_latest_src_28000.is_lux AS listing__is_lux_latest
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
           -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
           SELECT
             listing
-            , booking__is_instant
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -48,71 +46,55 @@ FROM (
         ON
           subq_36.listing = listings_latest_src_28000.listing_id
       ) subq_41
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+      WHERE listing__is_lux_latest
     ) subq_45
     CROSS JOIN (
-      -- Constrain Output with WHERE
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
       -- Pass Only Elements: ['bookings',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
-        SUM(bookings) AS bookings
+        SUM(subq_49.bookings) AS bookings
       FROM (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
         SELECT
-          subq_49.booking__is_instant AS booking__is_instant
-          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_49.bookings AS bookings
+          listing
+          , bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           SELECT
-            listing
-            , booking__is_instant
-            , bookings
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_47
-          WHERE booking__is_instant
-        ) subq_49
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_49.listing = listings_latest_src_28000.listing_id
-      ) subq_54
-      WHERE (listing__is_lux_latest) AND (booking__is_instant)
-    ) subq_58
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_47
+        WHERE booking__is_instant
+      ) subq_49
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_49.listing = listings_latest_src_28000.listing_id
+    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         SUM(booking_value) AS booking_value
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          booking__is_instant
+          is_instant AS booking__is_instant
           , booking_value
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            is_instant AS booking__is_instant
-            , booking_value
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_60
-        WHERE booking__is_instant
-      ) subq_62
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_59
       WHERE booking__is_instant
-    ) subq_66
-  ) subq_67
-) subq_68
+    ) subq_64
+  ) subq_65
+) subq_66

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -8,11 +8,12 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers']
   SELECT
-    subq_27.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+    subq_26.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
     , third_hop_table_src_22000.customer_third_hop_id AS third_hop_count
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -21,28 +22,19 @@ FROM (
       customer_id__customer_third_hop_id
       , SUM(customers_with_other_data) AS customer_id__customer_third_hop_id__paraguayan_customers
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
+      -- Read Elements From Semantic Model 'customer_other_data'
+      -- Metric Time Dimension 'acquired_ds'
       SELECT
-        customer_id__customer_third_hop_id
-        , customer_id__country
-        , customers_with_other_data
-      FROM (
-        -- Read Elements From Semantic Model 'customer_other_data'
-        -- Metric Time Dimension 'acquired_ds'
-        SELECT
-          customer_third_hop_id AS customer_id__customer_third_hop_id
-          , country AS customer_id__country
-          , 1 AS customers_with_other_data
-        FROM ***************************.customer_other_data customer_other_data_src_22000
-      ) subq_20
-      WHERE customer_id__country = 'paraguay'
-    ) subq_22
+        customer_third_hop_id AS customer_id__customer_third_hop_id
+        , country AS customer_id__country
+        , 1 AS customers_with_other_data
+      FROM ***************************.customer_other_data customer_other_data_src_22000
+    ) subq_20
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id
-  ) subq_27
+  ) subq_26
   ON
-    third_hop_table_src_22000.customer_third_hop_id = subq_27.customer_id__customer_third_hop_id
-) subq_29
+    third_hop_table_src_22000.customer_third_hop_id = subq_26.customer_id__customer_third_hop_id
+) subq_28
 WHERE customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers > 0

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -55,143 +55,108 @@
                         <!--   )                                                       -->
                         <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- distinct = False -->
-                        <WhereConstraintNode>
-                            <!-- description = 'Constrain Output with WHERE' -->
-                            <!-- node_id = NodeId(id_str='wcc_2') -->
-                            <!-- where_condition =                                               -->
-                            <!--   WhereFilterSpec(                                              -->
-                            <!--     where_sql="visit__referrer_id = '123456'",                  -->
-                            <!--     bind_parameters=SqlBindParameters(),                        -->
-                            <!--     linkable_specs=(                                            -->
-                            <!--       DimensionSpec(                                            -->
-                            <!--         element_name='referrer_id',                             -->
-                            <!--         entity_links=(EntityReference(element_name='visit'),),  -->
-                            <!--       ),                                                        -->
-                            <!--     ),                                                          -->
-                            <!--     linkable_elements=(                                         -->
-                            <!--       LinkableDimension(                                        -->
-                            <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                            <!--           semantic_model_name='visits_source',                  -->
-                            <!--         ),                                                      -->
-                            <!--         element_name='referrer_id',                             -->
-                            <!--         dimension_type=CATEGORICAL,                             -->
-                            <!--         entity_links=(EntityReference(element_name='visit'),),  -->
-                            <!--         join_path=SemanticModelJoinPath(                        -->
-                            <!--           left_semantic_model_reference=SemanticModelReference( -->
-                            <!--             semantic_model_name='visits_source',                -->
-                            <!--           ),                                                    -->
-                            <!--         ),                                                      -->
-                            <!--         properties=frozenset('LOCAL',),                         -->
-                            <!--       ),                                                        -->
-                            <!--     ),                                                          -->
-                            <!--   )                                                             -->
-                            <FilterElementsNode>
-                                <!-- description =                                                                         -->
-                                <!--   ("Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', " -->
-                                <!--    "'metric_time__day']")                                                             -->
-                                <!-- node_id = NodeId(id_str='pfe_12') -->
-                                <!-- include_spec = MeasureSpec(element_name='visits') -->
-                                <!-- include_spec =                                            -->
-                                <!--   DimensionSpec(                                          -->
-                                <!--     element_name='home_state_latest',                     -->
-                                <!--     entity_links=(EntityReference(element_name='user'),), -->
-                                <!--   )                                                       -->
-                                <!-- include_spec =                                             -->
-                                <!--   DimensionSpec(                                           -->
-                                <!--     element_name='referrer_id',                            -->
-                                <!--     entity_links=(EntityReference(element_name='visit'),), -->
-                                <!--   )                                                        -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                <!-- distinct = False -->
-                                <JoinOnEntitiesNode>
-                                    <!-- description = 'Join Standard Outputs' -->
-                                    <!-- node_id = NodeId(id_str='jso_3') -->
-                                    <!-- join0_for_node_id_pfe_11 =                                  -->
-                                    <!--   JoinDescription(                                          -->
-                                    <!--     join_node=FilterElementsNode(node_id=pfe_11),           -->
-                                    <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
-                                    <!--     join_type=LEFT_OUTER,                                   -->
-                                    <!--   )                                                         -->
-                                    <FilterElementsNode>
-                                        <!-- description =                                              -->
-                                        <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', " -->
-                                        <!--    "'metric_time__day', 'user']")                          -->
-                                        <!-- node_id = NodeId(id_str='pfe_10') -->
-                                        <!-- include_spec = MeasureSpec(element_name='visits') -->
-                                        <!-- include_spec =                                             -->
-                                        <!--   DimensionSpec(                                           -->
-                                        <!--     element_name='referrer_id',                            -->
-                                        <!--     entity_links=(EntityReference(element_name='visit'),), -->
-                                        <!--   )                                                        -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                        <!-- include_spec = LinklessEntitySpec(element_name='user') -->
-                                        <!-- distinct = False -->
-                                        <WhereConstraintNode>
-                                            <!-- description = 'Constrain Output with WHERE' -->
-                                            <!-- node_id = NodeId(id_str='wcc_1') -->
-                                            <!-- where_condition =                                               -->
-                                            <!--   WhereFilterSpec(                                              -->
-                                            <!--     where_sql="visit__referrer_id = '123456'",                  -->
-                                            <!--     bind_parameters=SqlBindParameters(),                        -->
-                                            <!--     linkable_specs=(                                            -->
-                                            <!--       DimensionSpec(                                            -->
-                                            <!--         element_name='referrer_id',                             -->
-                                            <!--         entity_links=(                                          -->
-                                            <!--           EntityReference(                                      -->
-                                            <!--             element_name='visit',                               -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--       ),                                                        -->
-                                            <!--     ),                                                          -->
-                                            <!--     linkable_elements=(                                         -->
-                                            <!--       LinkableDimension(                                        -->
-                                            <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                            <!--           semantic_model_name='visits_source',                  -->
-                                            <!--         ),                                                      -->
-                                            <!--         element_name='referrer_id',                             -->
-                                            <!--         dimension_type=CATEGORICAL,                             -->
-                                            <!--         entity_links=(                                          -->
-                                            <!--           EntityReference(                                      -->
-                                            <!--             element_name='visit',                               -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--         join_path=SemanticModelJoinPath(                        -->
-                                            <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                            <!--             semantic_model_name='visits_source',                -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--         properties=frozenset('LOCAL',),                         -->
-                                            <!--       ),                                                        -->
-                                            <!--     ),                                                          -->
-                                            <!--   )                                                             -->
-                                            <MetricTimeDimensionTransformNode>
-                                                <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_0') -->
-                                                <!-- aggregation_time_dimension = 'ds' -->
-                                                <ReadSqlSourceNode>
-                                                    <!-- description = "Read From SemanticModelDataSet('visits_source')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_0') -->
-                                                    <!-- data_set = SemanticModelDataSet('visits_source') -->
-                                                </ReadSqlSourceNode>
-                                            </MetricTimeDimensionTransformNode>
-                                        </WhereConstraintNode>
-                                    </FilterElementsNode>
-                                    <FilterElementsNode>
-                                        <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                                        <!-- node_id = NodeId(id_str='pfe_11') -->
-                                        <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
-                                        <!-- include_spec = LinklessEntitySpec(element_name='user') -->
-                                        <!-- distinct = False -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('users_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
-                                            <!-- data_set = SemanticModelDataSet('users_latest') -->
-                                        </ReadSqlSourceNode>
-                                    </FilterElementsNode>
-                                </JoinOnEntitiesNode>
-                            </FilterElementsNode>
-                        </WhereConstraintNode>
+                        <FilterElementsNode>
+                            <!-- description =                                                                         -->
+                            <!--   ("Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', " -->
+                            <!--    "'metric_time__day']")                                                             -->
+                            <!-- node_id = NodeId(id_str='pfe_12') -->
+                            <!-- include_spec = MeasureSpec(element_name='visits') -->
+                            <!-- include_spec =                                            -->
+                            <!--   DimensionSpec(                                          -->
+                            <!--     element_name='home_state_latest',                     -->
+                            <!--     entity_links=(EntityReference(element_name='user'),), -->
+                            <!--   )                                                       -->
+                            <!-- include_spec =                                             -->
+                            <!--   DimensionSpec(                                           -->
+                            <!--     element_name='referrer_id',                            -->
+                            <!--     entity_links=(EntityReference(element_name='visit'),), -->
+                            <!--   )                                                        -->
+                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- distinct = False -->
+                            <JoinOnEntitiesNode>
+                                <!-- description = 'Join Standard Outputs' -->
+                                <!-- node_id = NodeId(id_str='jso_3') -->
+                                <!-- join0_for_node_id_pfe_11 =                                  -->
+                                <!--   JoinDescription(                                          -->
+                                <!--     join_node=FilterElementsNode(node_id=pfe_11),           -->
+                                <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
+                                <!--     join_type=LEFT_OUTER,                                   -->
+                                <!--   )                                                         -->
+                                <FilterElementsNode>
+                                    <!-- description =                                                                  -->
+                                    <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', " -->
+                                    <!--    "'user']")                                                                  -->
+                                    <!-- node_id = NodeId(id_str='pfe_10') -->
+                                    <!-- include_spec = MeasureSpec(element_name='visits') -->
+                                    <!-- include_spec =                                             -->
+                                    <!--   DimensionSpec(                                           -->
+                                    <!--     element_name='referrer_id',                            -->
+                                    <!--     entity_links=(EntityReference(element_name='visit'),), -->
+                                    <!--   )                                                        -->
+                                    <!-- include_spec =                                                        -->
+                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='user') -->
+                                    <!-- distinct = False -->
+                                    <WhereConstraintNode>
+                                        <!-- description = 'Constrain Output with WHERE' -->
+                                        <!-- node_id = NodeId(id_str='wcc_1') -->
+                                        <!-- where_condition =                                               -->
+                                        <!--   WhereFilterSpec(                                              -->
+                                        <!--     where_sql="visit__referrer_id = '123456'",                  -->
+                                        <!--     bind_parameters=SqlBindParameters(),                        -->
+                                        <!--     linkable_specs=(                                            -->
+                                        <!--       DimensionSpec(                                            -->
+                                        <!--         element_name='referrer_id',                             -->
+                                        <!--         entity_links=(EntityReference(element_name='visit'),),  -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--     linkable_elements=(                                         -->
+                                        <!--       LinkableDimension(                                        -->
+                                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                                        <!--           semantic_model_name='visits_source',                  -->
+                                        <!--         ),                                                      -->
+                                        <!--         element_name='referrer_id',                             -->
+                                        <!--         dimension_type=CATEGORICAL,                             -->
+                                        <!--         entity_links=(                                          -->
+                                        <!--           EntityReference(                                      -->
+                                        <!--             element_name='visit',                               -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
+                                        <!--         join_path=SemanticModelJoinPath(                        -->
+                                        <!--           left_semantic_model_reference=SemanticModelReference( -->
+                                        <!--             semantic_model_name='visits_source',                -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
+                                        <!--         properties=frozenset('LOCAL',),                         -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--   )                                                             -->
+                                        <MetricTimeDimensionTransformNode>
+                                            <!-- description = "Metric Time Dimension 'ds'" -->
+                                            <!-- node_id = NodeId(id_str='sma_0') -->
+                                            <!-- aggregation_time_dimension = 'ds' -->
+                                            <ReadSqlSourceNode>
+                                                <!-- description = "Read From SemanticModelDataSet('visits_source')" -->
+                                                <!-- node_id = NodeId(id_str='rss_0') -->
+                                                <!-- data_set = SemanticModelDataSet('visits_source') -->
+                                            </ReadSqlSourceNode>
+                                        </MetricTimeDimensionTransformNode>
+                                    </WhereConstraintNode>
+                                </FilterElementsNode>
+                                <FilterElementsNode>
+                                    <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
+                                    <!-- node_id = NodeId(id_str='pfe_11') -->
+                                    <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
+                                    <!-- include_spec = LinklessEntitySpec(element_name='user') -->
+                                    <!-- distinct = False -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('users_latest')" -->
+                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- data_set = SemanticModelDataSet('users_latest') -->
+                                    </ReadSqlSourceNode>
+                                </FilterElementsNode>
+                            </JoinOnEntitiesNode>
+                        </FilterElementsNode>
                     </FilterElementsNode>
                 </AggregateMeasuresNode>
                 <AggregateMeasuresNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -51,156 +51,121 @@
                     <!--   )                                                          -->
                     <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                     <!-- distinct = False -->
-                    <WhereConstraintNode>
-                        <!-- description = 'Constrain Output with WHERE' -->
-                        <!-- node_id = NodeId(id_str='wcc_2') -->
-                        <!-- where_condition =                                                -->
-                        <!--   WhereFilterSpec(                                               -->
-                        <!--     where_sql='booking__is_instant',                             -->
-                        <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--     linkable_elements=(                                          -->
-                        <!--       LinkableDimension(                                         -->
-                        <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                        <!--           semantic_model_name='bookings_source',                 -->
-                        <!--         ),                                                       -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         dimension_type=CATEGORICAL,                              -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--         join_path=SemanticModelJoinPath(                         -->
-                        <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                        <!--             semantic_model_name='bookings_source',               -->
-                        <!--           ),                                                     -->
-                        <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--   )                                                              -->
-                        <FilterElementsNode>
-                            <!-- description =                                                                           -->
-                            <!--   ("Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', " -->
-                            <!--    "'metric_time__day']")                                                               -->
-                            <!-- node_id = NodeId(id_str='pfe_6') -->
-                            <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                            <!-- include_spec =                                               -->
-                            <!--   DimensionSpec(                                             -->
-                            <!--     element_name='country_latest',                           -->
-                            <!--     entity_links=(EntityReference(element_name='listing'),), -->
-                            <!--   )                                                          -->
-                            <!-- include_spec =                                               -->
-                            <!--   DimensionSpec(                                             -->
-                            <!--     element_name='is_instant',                               -->
-                            <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                            <!-- distinct = False -->
-                            <JoinOnEntitiesNode>
-                                <!-- description = 'Join Standard Outputs' -->
-                                <!-- node_id = NodeId(id_str='jso_1') -->
-                                <!-- join0_for_node_id_pfe_5 =                                      -->
-                                <!--   JoinDescription(                                             -->
-                                <!--     join_node=FilterElementsNode(node_id=pfe_5),               -->
-                                <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
-                                <!--     join_type=LEFT_OUTER,                                      -->
-                                <!--   )                                                            -->
-                                <FilterElementsNode>
-                                    <!-- description =                                                                    -->
-                                    <!--   ("Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', " -->
-                                    <!--    "'listing']")                                                                 -->
-                                    <!-- node_id = NodeId(id_str='pfe_4') -->
-                                    <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                                    <!-- include_spec =                                               -->
-                                    <!--   DimensionSpec(                                             -->
-                                    <!--     element_name='is_instant',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                    <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                    <!-- distinct = False -->
-                                    <JoinOverTimeRangeNode>
-                                        <!-- description = 'Join Self Over Time Range' -->
-                                        <!-- node_id = NodeId(id_str='jotr_1') -->
-                                        <!-- queried_agg_time_dimension_specs =                                       -->
-                                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
-                                        <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
-                                        <WhereConstraintNode>
-                                            <!-- description = 'Constrain Output with WHERE' -->
-                                            <!-- node_id = NodeId(id_str='wcc_1') -->
-                                            <!-- where_condition =                                               -->
-                                            <!--   WhereFilterSpec(                                              -->
-                                            <!--     where_sql='booking__is_instant',                            -->
-                                            <!--     bind_parameters=SqlBindParameters(),                        -->
-                                            <!--     linkable_specs=(                                            -->
-                                            <!--       DimensionSpec(                                            -->
-                                            <!--         element_name='is_instant',                              -->
-                                            <!--         entity_links=(                                          -->
-                                            <!--           EntityReference(                                      -->
-                                            <!--             element_name='booking',                             -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--       ),                                                        -->
-                                            <!--     ),                                                          -->
-                                            <!--     linkable_elements=(                                         -->
-                                            <!--       LinkableDimension(                                        -->
-                                            <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                            <!--           semantic_model_name='bookings_source',                -->
-                                            <!--         ),                                                      -->
-                                            <!--         element_name='is_instant',                              -->
-                                            <!--         dimension_type=CATEGORICAL,                             -->
-                                            <!--         entity_links=(                                          -->
-                                            <!--           EntityReference(                                      -->
-                                            <!--             element_name='booking',                             -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--         join_path=SemanticModelJoinPath(                        -->
-                                            <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                            <!--             semantic_model_name='bookings_source',              -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--         properties=frozenset('LOCAL',),                         -->
-                                            <!--       ),                                                        -->
-                                            <!--     ),                                                          -->
-                                            <!--   )                                                             -->
-                                            <MetricTimeDimensionTransformNode>
-                                                <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_0') -->
-                                                <!-- aggregation_time_dimension = 'ds' -->
-                                                <ReadSqlSourceNode>
-                                                    <!-- description =                                         -->
-                                                    <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_0') -->
-                                                    <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                                </ReadSqlSourceNode>
-                                            </MetricTimeDimensionTransformNode>
-                                        </WhereConstraintNode>
-                                    </JoinOverTimeRangeNode>
-                                </FilterElementsNode>
-                                <FilterElementsNode>
-                                    <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                    <!-- node_id = NodeId(id_str='pfe_5') -->
-                                    <!-- include_spec = DimensionSpec(element_name='country_latest') -->
-                                    <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                    <!-- distinct = False -->
-                                    <MetricTimeDimensionTransformNode>
-                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
-                                        <!-- aggregation_time_dimension = 'ds' -->
-                                        <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
-                                            <!-- data_set = SemanticModelDataSet('listings_latest') -->
-                                        </ReadSqlSourceNode>
-                                    </MetricTimeDimensionTransformNode>
-                                </FilterElementsNode>
-                            </JoinOnEntitiesNode>
-                        </FilterElementsNode>
-                    </WhereConstraintNode>
+                    <FilterElementsNode>
+                        <!-- description =                                                                           -->
+                        <!--   ("Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', " -->
+                        <!--    "'metric_time__day']")                                                               -->
+                        <!-- node_id = NodeId(id_str='pfe_6') -->
+                        <!-- include_spec = MeasureSpec(element_name='bookers') -->
+                        <!-- include_spec =                                               -->
+                        <!--   DimensionSpec(                                             -->
+                        <!--     element_name='country_latest',                           -->
+                        <!--     entity_links=(EntityReference(element_name='listing'),), -->
+                        <!--   )                                                          -->
+                        <!-- include_spec =                                               -->
+                        <!--   DimensionSpec(                                             -->
+                        <!--     element_name='is_instant',                               -->
+                        <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                        <!--   )                                                          -->
+                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- distinct = False -->
+                        <JoinOnEntitiesNode>
+                            <!-- description = 'Join Standard Outputs' -->
+                            <!-- node_id = NodeId(id_str='jso_1') -->
+                            <!-- join0_for_node_id_pfe_5 =                                      -->
+                            <!--   JoinDescription(                                             -->
+                            <!--     join_node=FilterElementsNode(node_id=pfe_5),               -->
+                            <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
+                            <!--     join_type=LEFT_OUTER,                                      -->
+                            <!--   )                                                            -->
+                            <FilterElementsNode>
+                                <!-- description =                                                                    -->
+                                <!--   ("Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', " -->
+                                <!--    "'listing']")                                                                 -->
+                                <!-- node_id = NodeId(id_str='pfe_4') -->
+                                <!-- include_spec = MeasureSpec(element_name='bookers') -->
+                                <!-- include_spec =                                               -->
+                                <!--   DimensionSpec(                                             -->
+                                <!--     element_name='is_instant',                               -->
+                                <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                <!--   )                                                          -->
+                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                <!-- distinct = False -->
+                                <JoinOverTimeRangeNode>
+                                    <!-- description = 'Join Self Over Time Range' -->
+                                    <!-- node_id = NodeId(id_str='jotr_1') -->
+                                    <!-- queried_agg_time_dimension_specs =                                       -->
+                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                    <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                                    <WhereConstraintNode>
+                                        <!-- description = 'Constrain Output with WHERE' -->
+                                        <!-- node_id = NodeId(id_str='wcc_1') -->
+                                        <!-- where_condition =                                               -->
+                                        <!--   WhereFilterSpec(                                              -->
+                                        <!--     where_sql='booking__is_instant',                            -->
+                                        <!--     bind_parameters=SqlBindParameters(),                        -->
+                                        <!--     linkable_specs=(                                            -->
+                                        <!--       DimensionSpec(                                            -->
+                                        <!--         element_name='is_instant',                              -->
+                                        <!--         entity_links=(                                          -->
+                                        <!--           EntityReference(element_name='booking'),              -->
+                                        <!--         ),                                                      -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--     linkable_elements=(                                         -->
+                                        <!--       LinkableDimension(                                        -->
+                                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                                        <!--           semantic_model_name='bookings_source',                -->
+                                        <!--         ),                                                      -->
+                                        <!--         element_name='is_instant',                              -->
+                                        <!--         dimension_type=CATEGORICAL,                             -->
+                                        <!--         entity_links=(                                          -->
+                                        <!--           EntityReference(                                      -->
+                                        <!--             element_name='booking',                             -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
+                                        <!--         join_path=SemanticModelJoinPath(                        -->
+                                        <!--           left_semantic_model_reference=SemanticModelReference( -->
+                                        <!--             semantic_model_name='bookings_source',              -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
+                                        <!--         properties=frozenset('LOCAL',),                         -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--   )                                                             -->
+                                        <MetricTimeDimensionTransformNode>
+                                            <!-- description = "Metric Time Dimension 'ds'" -->
+                                            <!-- node_id = NodeId(id_str='sma_0') -->
+                                            <!-- aggregation_time_dimension = 'ds' -->
+                                            <ReadSqlSourceNode>
+                                                <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                                <!-- node_id = NodeId(id_str='rss_0') -->
+                                                <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                            </ReadSqlSourceNode>
+                                        </MetricTimeDimensionTransformNode>
+                                    </WhereConstraintNode>
+                                </JoinOverTimeRangeNode>
+                            </FilterElementsNode>
+                            <FilterElementsNode>
+                                <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
+                                <!-- node_id = NodeId(id_str='pfe_5') -->
+                                <!-- include_spec = DimensionSpec(element_name='country_latest') -->
+                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                <!-- distinct = False -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = "Metric Time Dimension 'ds'" -->
+                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- aggregation_time_dimension = 'ds' -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
+                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </JoinOnEntitiesNode>
+                    </FilterElementsNode>
                 </FilterElementsNode>
             </AggregateMeasuresNode>
         </ComputeMetricsNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -102,151 +102,120 @@
                                 <!--   )                                                          -->
                                 <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                                 <!-- distinct = False -->
-                                <WhereConstraintNode>
-                                    <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_3') -->
-                                    <!-- where_condition =                                                -->
-                                    <!--   WhereFilterSpec(                                               -->
-                                    <!--     where_sql='booking__is_instant',                             -->
-                                    <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--     linkable_elements=(                                          -->
-                                    <!--       LinkableDimension(                                         -->
-                                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                                    <!--           semantic_model_name='bookings_source',                 -->
-                                    <!--         ),                                                       -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         dimension_type=CATEGORICAL,                              -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--         join_path=SemanticModelJoinPath(                         -->
-                                    <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                                    <!--             semantic_model_name='bookings_source',               -->
-                                    <!--           ),                                                     -->
-                                    <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--   )                                                              -->
-                                    <FilterElementsNode>
-                                        <!-- description =                                                     -->
-                                        <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
-                                        <!--    "'booking__is_instant', 'metric_time__day']")                  -->
-                                        <!-- node_id = NodeId(id_str='pfe_10') -->
-                                        <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                        <!-- include_spec =                                               -->
-                                        <!--   DimensionSpec(                                             -->
-                                        <!--     element_name='country_latest',                           -->
-                                        <!--     entity_links=(EntityReference(element_name='listing'),), -->
-                                        <!--   )                                                          -->
-                                        <!-- include_spec =                                               -->
-                                        <!--   DimensionSpec(                                             -->
-                                        <!--     element_name='is_instant',                               -->
-                                        <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                        <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                        <!-- distinct = False -->
-                                        <JoinOnEntitiesNode>
-                                            <!-- description = 'Join Standard Outputs' -->
-                                            <!-- node_id = NodeId(id_str='jso_2') -->
-                                            <!-- join0_for_node_id_pfe_9 =                                      -->
-                                            <!--   JoinDescription(                                             -->
-                                            <!--     join_node=FilterElementsNode(node_id=pfe_9),               -->
-                                            <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
-                                            <!--     join_type=LEFT_OUTER,                                      -->
-                                            <!--   )                                                            -->
-                                            <FilterElementsNode>
-                                                <!-- description =                                                 -->
-                                                <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
-                                                <!--    "'metric_time__day', 'listing']")                          -->
-                                                <!-- node_id = NodeId(id_str='pfe_8') -->
-                                                <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                                <!-- include_spec =                                               -->
-                                                <!--   DimensionSpec(                                             -->
-                                                <!--     element_name='is_instant',                               -->
-                                                <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                                <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                                <!-- distinct = False -->
-                                                <WhereConstraintNode>
-                                                    <!-- description = 'Constrain Output with WHERE' -->
-                                                    <!-- node_id = NodeId(id_str='wcc_2') -->
-                                                    <!-- where_condition =                                               -->
-                                                    <!--   WhereFilterSpec(                                              -->
-                                                    <!--     where_sql='booking__is_instant',                            -->
-                                                    <!--     bind_parameters=SqlBindParameters(),                        -->
-                                                    <!--     linkable_specs=(                                            -->
-                                                    <!--       DimensionSpec(                                            -->
-                                                    <!--         element_name='is_instant',                              -->
-                                                    <!--         entity_links=(                                          -->
-                                                    <!--           EntityReference(                                      -->
-                                                    <!--             element_name='booking',                             -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--       ),                                                        -->
-                                                    <!--     ),                                                          -->
-                                                    <!--     linkable_elements=(                                         -->
-                                                    <!--       LinkableDimension(                                        -->
-                                                    <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                                    <!--           semantic_model_name='bookings_source',                -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         element_name='is_instant',                              -->
-                                                    <!--         dimension_type=CATEGORICAL,                             -->
-                                                    <!--         entity_links=(                                          -->
-                                                    <!--           EntityReference(                                      -->
-                                                    <!--             element_name='booking',                             -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         join_path=SemanticModelJoinPath(                        -->
-                                                    <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                                    <!--             semantic_model_name='bookings_source',              -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         properties=frozenset('LOCAL',),                         -->
-                                                    <!--       ),                                                        -->
-                                                    <!--     ),                                                          -->
-                                                    <!--   )                                                             -->
-                                                    <MetricTimeDimensionTransformNode>
-                                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                                        <!-- node_id = NodeId(id_str='sma_0') -->
-                                                        <!-- aggregation_time_dimension = 'ds' -->
-                                                        <ReadSqlSourceNode>
-                                                            <!-- description =                                         -->
-                                                            <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                            <!-- node_id = NodeId(id_str='rss_0') -->
-                                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                                        </ReadSqlSourceNode>
-                                                    </MetricTimeDimensionTransformNode>
-                                                </WhereConstraintNode>
-                                            </FilterElementsNode>
-                                            <FilterElementsNode>
-                                                <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                                <!-- node_id = NodeId(id_str='pfe_9') -->
-                                                <!-- include_spec = DimensionSpec(element_name='country_latest') -->
-                                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                                <!-- distinct = False -->
+                                <FilterElementsNode>
+                                    <!-- description =                                                     -->
+                                    <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
+                                    <!--    "'booking__is_instant', 'metric_time__day']")                  -->
+                                    <!-- node_id = NodeId(id_str='pfe_10') -->
+                                    <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                    <!-- include_spec =                                               -->
+                                    <!--   DimensionSpec(                                             -->
+                                    <!--     element_name='country_latest',                           -->
+                                    <!--     entity_links=(EntityReference(element_name='listing'),), -->
+                                    <!--   )                                                          -->
+                                    <!-- include_spec =                                               -->
+                                    <!--   DimensionSpec(                                             -->
+                                    <!--     element_name='is_instant',                               -->
+                                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                    <!--   )                                                          -->
+                                    <!-- include_spec =                                                        -->
+                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- distinct = False -->
+                                    <JoinOnEntitiesNode>
+                                        <!-- description = 'Join Standard Outputs' -->
+                                        <!-- node_id = NodeId(id_str='jso_2') -->
+                                        <!-- join0_for_node_id_pfe_9 =                                      -->
+                                        <!--   JoinDescription(                                             -->
+                                        <!--     join_node=FilterElementsNode(node_id=pfe_9),               -->
+                                        <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
+                                        <!--     join_type=LEFT_OUTER,                                      -->
+                                        <!--   )                                                            -->
+                                        <FilterElementsNode>
+                                            <!-- description =                                                 -->
+                                            <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
+                                            <!--    "'metric_time__day', 'listing']")                          -->
+                                            <!-- node_id = NodeId(id_str='pfe_8') -->
+                                            <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                            <!-- include_spec =                                               -->
+                                            <!--   DimensionSpec(                                             -->
+                                            <!--     element_name='is_instant',                               -->
+                                            <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                            <!--   )                                                          -->
+                                            <!-- include_spec =                                                        -->
+                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                            <!-- distinct = False -->
+                                            <WhereConstraintNode>
+                                                <!-- description = 'Constrain Output with WHERE' -->
+                                                <!-- node_id = NodeId(id_str='wcc_2') -->
+                                                <!-- where_condition =                                               -->
+                                                <!--   WhereFilterSpec(                                              -->
+                                                <!--     where_sql='booking__is_instant',                            -->
+                                                <!--     bind_parameters=SqlBindParameters(),                        -->
+                                                <!--     linkable_specs=(                                            -->
+                                                <!--       DimensionSpec(                                            -->
+                                                <!--         element_name='is_instant',                              -->
+                                                <!--         entity_links=(                                          -->
+                                                <!--           EntityReference(                                      -->
+                                                <!--             element_name='booking',                             -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--     linkable_elements=(                                         -->
+                                                <!--       LinkableDimension(                                        -->
+                                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                                                <!--           semantic_model_name='bookings_source',                -->
+                                                <!--         ),                                                      -->
+                                                <!--         element_name='is_instant',                              -->
+                                                <!--         dimension_type=CATEGORICAL,                             -->
+                                                <!--         entity_links=(                                          -->
+                                                <!--           EntityReference(                                      -->
+                                                <!--             element_name='booking',                             -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--         join_path=SemanticModelJoinPath(                        -->
+                                                <!--           left_semantic_model_reference=SemanticModelReference( -->
+                                                <!--             semantic_model_name='bookings_source',              -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--         properties=frozenset('LOCAL',),                         -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--   )                                                             -->
                                                 <MetricTimeDimensionTransformNode>
                                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                                    <!-- node_id = NodeId(id_str='sma_0') -->
                                                     <!-- aggregation_time_dimension = 'ds' -->
                                                     <ReadSqlSourceNode>
                                                         <!-- description =                                         -->
-                                                        <!--   "Read From SemanticModelDataSet('listings_latest')" -->
-                                                        <!-- node_id = NodeId(id_str='rss_1') -->
-                                                        <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                                        <!--   "Read From SemanticModelDataSet('bookings_source')" -->
+                                                        <!-- node_id = NodeId(id_str='rss_0') -->
+                                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                                     </ReadSqlSourceNode>
                                                 </MetricTimeDimensionTransformNode>
-                                            </FilterElementsNode>
-                                        </JoinOnEntitiesNode>
-                                    </FilterElementsNode>
-                                </WhereConstraintNode>
+                                            </WhereConstraintNode>
+                                        </FilterElementsNode>
+                                        <FilterElementsNode>
+                                            <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
+                                            <!-- node_id = NodeId(id_str='pfe_9') -->
+                                            <!-- include_spec = DimensionSpec(element_name='country_latest') -->
+                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                            <!-- distinct = False -->
+                                            <MetricTimeDimensionTransformNode>
+                                                <!-- description = "Metric Time Dimension 'ds'" -->
+                                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                                <!-- aggregation_time_dimension = 'ds' -->
+                                                <ReadSqlSourceNode>
+                                                    <!-- description =                                         -->
+                                                    <!--   "Read From SemanticModelDataSet('listings_latest')" -->
+                                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                                    <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                                </ReadSqlSourceNode>
+                                            </MetricTimeDimensionTransformNode>
+                                        </FilterElementsNode>
+                                    </JoinOnEntitiesNode>
+                                </FilterElementsNode>
                             </FilterElementsNode>
                         </AggregateMeasuresNode>
                     </JoinToTimeSpineNode>
@@ -317,7 +286,7 @@
                                 <!-- distinct = False -->
                                 <WhereConstraintNode>
                                     <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_4') -->
+                                    <!-- node_id = NodeId(id_str='wcc_3') -->
                                     <!-- where_condition =                                                -->
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -107,6 +107,7 @@
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
+                        <!-- All filters always applied: = True -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
@@ -299,6 +300,7 @@
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
+                        <!-- All filters always applied: = True -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_2') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -107,6 +107,7 @@
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
+                        <!-- All filters always applied: = True -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_3') -->
@@ -307,6 +308,7 @@
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
+                        <!-- All filters always applied: = True -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_5') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -79,7 +79,7 @@
                     <!--   )                                                                  -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
-                        <!-- node_id = NodeId(id_str='wcc_6') -->
+                        <!-- node_id = NodeId(id_str='wcc_5') -->
                         <!-- where_condition =                                                -->
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
@@ -120,151 +120,120 @@
                             <AggregateMeasuresNode>
                                 <!-- description = 'Aggregate Measures' -->
                                 <!-- node_id = NodeId(id_str='am_2') -->
-                                <WhereConstraintNode>
-                                    <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_5') -->
-                                    <!-- where_condition =                                                -->
-                                    <!--   WhereFilterSpec(                                               -->
-                                    <!--     where_sql='booking__is_instant',                             -->
-                                    <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--     linkable_elements=(                                          -->
-                                    <!--       LinkableDimension(                                         -->
-                                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                                    <!--           semantic_model_name='bookings_source',                 -->
-                                    <!--         ),                                                       -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         dimension_type=CATEGORICAL,                              -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--         join_path=SemanticModelJoinPath(                         -->
-                                    <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                                    <!--             semantic_model_name='bookings_source',               -->
-                                    <!--           ),                                                     -->
-                                    <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
-                                    <!--   )                                                              -->
-                                    <FilterElementsNode>
-                                        <!-- description =                                                     -->
-                                        <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
-                                        <!--    "'booking__is_instant', 'metric_time__day']")                  -->
-                                        <!-- node_id = NodeId(id_str='pfe_8') -->
-                                        <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                        <!-- include_spec =                                               -->
-                                        <!--   DimensionSpec(                                             -->
-                                        <!--     element_name='country_latest',                           -->
-                                        <!--     entity_links=(EntityReference(element_name='listing'),), -->
-                                        <!--   )                                                          -->
-                                        <!-- include_spec =                                               -->
-                                        <!--   DimensionSpec(                                             -->
-                                        <!--     element_name='is_instant',                               -->
-                                        <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                        <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                        <!-- distinct = False -->
-                                        <JoinOnEntitiesNode>
-                                            <!-- description = 'Join Standard Outputs' -->
-                                            <!-- node_id = NodeId(id_str='jso_2') -->
-                                            <!-- join0_for_node_id_pfe_7 =                                      -->
-                                            <!--   JoinDescription(                                             -->
-                                            <!--     join_node=FilterElementsNode(node_id=pfe_7),               -->
-                                            <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
-                                            <!--     join_type=LEFT_OUTER,                                      -->
-                                            <!--   )                                                            -->
-                                            <FilterElementsNode>
-                                                <!-- description =                                                 -->
-                                                <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
-                                                <!--    "'metric_time__day', 'listing']")                          -->
-                                                <!-- node_id = NodeId(id_str='pfe_6') -->
-                                                <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                                <!-- include_spec =                                               -->
-                                                <!--   DimensionSpec(                                             -->
-                                                <!--     element_name='is_instant',                               -->
-                                                <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                                <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                                <!-- distinct = False -->
-                                                <WhereConstraintNode>
-                                                    <!-- description = 'Constrain Output with WHERE' -->
-                                                    <!-- node_id = NodeId(id_str='wcc_4') -->
-                                                    <!-- where_condition =                                               -->
-                                                    <!--   WhereFilterSpec(                                              -->
-                                                    <!--     where_sql='booking__is_instant',                            -->
-                                                    <!--     bind_parameters=SqlBindParameters(),                        -->
-                                                    <!--     linkable_specs=(                                            -->
-                                                    <!--       DimensionSpec(                                            -->
-                                                    <!--         element_name='is_instant',                              -->
-                                                    <!--         entity_links=(                                          -->
-                                                    <!--           EntityReference(                                      -->
-                                                    <!--             element_name='booking',                             -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--       ),                                                        -->
-                                                    <!--     ),                                                          -->
-                                                    <!--     linkable_elements=(                                         -->
-                                                    <!--       LinkableDimension(                                        -->
-                                                    <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                                    <!--           semantic_model_name='bookings_source',                -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         element_name='is_instant',                              -->
-                                                    <!--         dimension_type=CATEGORICAL,                             -->
-                                                    <!--         entity_links=(                                          -->
-                                                    <!--           EntityReference(                                      -->
-                                                    <!--             element_name='booking',                             -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         join_path=SemanticModelJoinPath(                        -->
-                                                    <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                                    <!--             semantic_model_name='bookings_source',              -->
-                                                    <!--           ),                                                    -->
-                                                    <!--         ),                                                      -->
-                                                    <!--         properties=frozenset('LOCAL',),                         -->
-                                                    <!--       ),                                                        -->
-                                                    <!--     ),                                                          -->
-                                                    <!--   )                                                             -->
-                                                    <MetricTimeDimensionTransformNode>
-                                                        <!-- description = "Metric Time Dimension 'ds'" -->
-                                                        <!-- node_id = NodeId(id_str='sma_0') -->
-                                                        <!-- aggregation_time_dimension = 'ds' -->
-                                                        <ReadSqlSourceNode>
-                                                            <!-- description =                                         -->
-                                                            <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                            <!-- node_id = NodeId(id_str='rss_0') -->
-                                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                                        </ReadSqlSourceNode>
-                                                    </MetricTimeDimensionTransformNode>
-                                                </WhereConstraintNode>
-                                            </FilterElementsNode>
-                                            <FilterElementsNode>
-                                                <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                                <!-- node_id = NodeId(id_str='pfe_7') -->
-                                                <!-- include_spec = DimensionSpec(element_name='country_latest') -->
-                                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                                <!-- distinct = False -->
+                                <FilterElementsNode>
+                                    <!-- description =                                                     -->
+                                    <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
+                                    <!--    "'booking__is_instant', 'metric_time__day']")                  -->
+                                    <!-- node_id = NodeId(id_str='pfe_8') -->
+                                    <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                    <!-- include_spec =                                               -->
+                                    <!--   DimensionSpec(                                             -->
+                                    <!--     element_name='country_latest',                           -->
+                                    <!--     entity_links=(EntityReference(element_name='listing'),), -->
+                                    <!--   )                                                          -->
+                                    <!-- include_spec =                                               -->
+                                    <!--   DimensionSpec(                                             -->
+                                    <!--     element_name='is_instant',                               -->
+                                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                    <!--   )                                                          -->
+                                    <!-- include_spec =                                                        -->
+                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- distinct = False -->
+                                    <JoinOnEntitiesNode>
+                                        <!-- description = 'Join Standard Outputs' -->
+                                        <!-- node_id = NodeId(id_str='jso_2') -->
+                                        <!-- join0_for_node_id_pfe_7 =                                      -->
+                                        <!--   JoinDescription(                                             -->
+                                        <!--     join_node=FilterElementsNode(node_id=pfe_7),               -->
+                                        <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
+                                        <!--     join_type=LEFT_OUTER,                                      -->
+                                        <!--   )                                                            -->
+                                        <FilterElementsNode>
+                                            <!-- description =                                                 -->
+                                            <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
+                                            <!--    "'metric_time__day', 'listing']")                          -->
+                                            <!-- node_id = NodeId(id_str='pfe_6') -->
+                                            <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                            <!-- include_spec =                                               -->
+                                            <!--   DimensionSpec(                                             -->
+                                            <!--     element_name='is_instant',                               -->
+                                            <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                            <!--   )                                                          -->
+                                            <!-- include_spec =                                                        -->
+                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                            <!-- distinct = False -->
+                                            <WhereConstraintNode>
+                                                <!-- description = 'Constrain Output with WHERE' -->
+                                                <!-- node_id = NodeId(id_str='wcc_4') -->
+                                                <!-- where_condition =                                               -->
+                                                <!--   WhereFilterSpec(                                              -->
+                                                <!--     where_sql='booking__is_instant',                            -->
+                                                <!--     bind_parameters=SqlBindParameters(),                        -->
+                                                <!--     linkable_specs=(                                            -->
+                                                <!--       DimensionSpec(                                            -->
+                                                <!--         element_name='is_instant',                              -->
+                                                <!--         entity_links=(                                          -->
+                                                <!--           EntityReference(                                      -->
+                                                <!--             element_name='booking',                             -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--     linkable_elements=(                                         -->
+                                                <!--       LinkableDimension(                                        -->
+                                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                                                <!--           semantic_model_name='bookings_source',                -->
+                                                <!--         ),                                                      -->
+                                                <!--         element_name='is_instant',                              -->
+                                                <!--         dimension_type=CATEGORICAL,                             -->
+                                                <!--         entity_links=(                                          -->
+                                                <!--           EntityReference(                                      -->
+                                                <!--             element_name='booking',                             -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--         join_path=SemanticModelJoinPath(                        -->
+                                                <!--           left_semantic_model_reference=SemanticModelReference( -->
+                                                <!--             semantic_model_name='bookings_source',              -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
+                                                <!--         properties=frozenset('LOCAL',),                         -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--   )                                                             -->
                                                 <MetricTimeDimensionTransformNode>
                                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                                    <!-- node_id = NodeId(id_str='sma_0') -->
                                                     <!-- aggregation_time_dimension = 'ds' -->
                                                     <ReadSqlSourceNode>
                                                         <!-- description =                                         -->
-                                                        <!--   "Read From SemanticModelDataSet('listings_latest')" -->
-                                                        <!-- node_id = NodeId(id_str='rss_1') -->
-                                                        <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                                        <!--   "Read From SemanticModelDataSet('bookings_source')" -->
+                                                        <!-- node_id = NodeId(id_str='rss_0') -->
+                                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                                     </ReadSqlSourceNode>
                                                 </MetricTimeDimensionTransformNode>
-                                            </FilterElementsNode>
-                                        </JoinOnEntitiesNode>
-                                    </FilterElementsNode>
-                                </WhereConstraintNode>
+                                            </WhereConstraintNode>
+                                        </FilterElementsNode>
+                                        <FilterElementsNode>
+                                            <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
+                                            <!-- node_id = NodeId(id_str='pfe_7') -->
+                                            <!-- include_spec = DimensionSpec(element_name='country_latest') -->
+                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                            <!-- distinct = False -->
+                                            <MetricTimeDimensionTransformNode>
+                                                <!-- description = "Metric Time Dimension 'ds'" -->
+                                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                                <!-- aggregation_time_dimension = 'ds' -->
+                                                <ReadSqlSourceNode>
+                                                    <!-- description =                                         -->
+                                                    <!--   "Read From SemanticModelDataSet('listings_latest')" -->
+                                                    <!-- node_id = NodeId(id_str='rss_1') -->
+                                                    <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                                </ReadSqlSourceNode>
+                                            </MetricTimeDimensionTransformNode>
+                                        </FilterElementsNode>
+                                    </JoinOnEntitiesNode>
+                                </FilterElementsNode>
                             </AggregateMeasuresNode>
                         </JoinToTimeSpineNode>
                     </WhereConstraintNode>
@@ -310,7 +279,7 @@
                     <!--   )                                                                    -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
-                        <!-- node_id = NodeId(id_str='wcc_8') -->
+                        <!-- node_id = NodeId(id_str='wcc_7') -->
                         <!-- where_condition =                                                -->
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
@@ -353,7 +322,7 @@
                                 <!-- node_id = NodeId(id_str='am_3') -->
                                 <WhereConstraintNode>
                                     <!-- description = 'Constrain Output with WHERE' -->
-                                    <!-- node_id = NodeId(id_str='wcc_7') -->
+                                    <!-- node_id = NodeId(id_str='wcc_6') -->
                                     <!-- where_condition =                                                -->
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -92,151 +92,118 @@
                             <!--   )                                                          -->
                             <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                             <!-- distinct = False -->
-                            <WhereConstraintNode>
-                                <!-- description = 'Constrain Output with WHERE' -->
-                                <!-- node_id = NodeId(id_str='wcc_3') -->
-                                <!-- where_condition =                                                -->
-                                <!--   WhereFilterSpec(                                               -->
-                                <!--     where_sql='booking__is_instant',                             -->
-                                <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
-                                <!--     linkable_elements=(                                          -->
-                                <!--       LinkableDimension(                                         -->
-                                <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                                <!--           semantic_model_name='bookings_source',                 -->
-                                <!--         ),                                                       -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         dimension_type=CATEGORICAL,                              -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--         join_path=SemanticModelJoinPath(                         -->
-                                <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                                <!--             semantic_model_name='bookings_source',               -->
-                                <!--           ),                                                     -->
-                                <!--         ),                                                       -->
-                                <!--         properties=frozenset('LOCAL',),                          -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
-                                <!--   )                                                              -->
-                                <FilterElementsNode>
-                                    <!-- description =                                                     -->
-                                    <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
-                                    <!--    "'booking__is_instant', 'metric_time__day']")                  -->
-                                    <!-- node_id = NodeId(id_str='pfe_10') -->
-                                    <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                               -->
-                                    <!--   DimensionSpec(                                             -->
-                                    <!--     element_name='country_latest',                           -->
-                                    <!--     entity_links=(EntityReference(element_name='listing'),), -->
-                                    <!--   )                                                          -->
-                                    <!-- include_spec =                                               -->
-                                    <!--   DimensionSpec(                                             -->
-                                    <!--     element_name='is_instant',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                    <!-- distinct = False -->
-                                    <JoinOnEntitiesNode>
-                                        <!-- description = 'Join Standard Outputs' -->
-                                        <!-- node_id = NodeId(id_str='jso_2') -->
-                                        <!-- join0_for_node_id_pfe_9 =                                      -->
-                                        <!--   JoinDescription(                                             -->
-                                        <!--     join_node=FilterElementsNode(node_id=pfe_9),               -->
-                                        <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
-                                        <!--     join_type=LEFT_OUTER,                                      -->
-                                        <!--   )                                                            -->
-                                        <FilterElementsNode>
-                                            <!-- description =                                                 -->
-                                            <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
-                                            <!--    "'metric_time__day', 'listing']")                          -->
-                                            <!-- node_id = NodeId(id_str='pfe_8') -->
-                                            <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                            <!-- include_spec =                                               -->
-                                            <!--   DimensionSpec(                                             -->
-                                            <!--     element_name='is_instant',                               -->
-                                            <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                            <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                            <!-- distinct = False -->
-                                            <WhereConstraintNode>
-                                                <!-- description = 'Constrain Output with WHERE' -->
-                                                <!-- node_id = NodeId(id_str='wcc_2') -->
-                                                <!-- where_condition =                                               -->
-                                                <!--   WhereFilterSpec(                                              -->
-                                                <!--     where_sql='booking__is_instant',                            -->
-                                                <!--     bind_parameters=SqlBindParameters(),                        -->
-                                                <!--     linkable_specs=(                                            -->
-                                                <!--       DimensionSpec(                                            -->
-                                                <!--         element_name='is_instant',                              -->
-                                                <!--         entity_links=(                                          -->
-                                                <!--           EntityReference(                                      -->
-                                                <!--             element_name='booking',                             -->
-                                                <!--           ),                                                    -->
-                                                <!--         ),                                                      -->
-                                                <!--       ),                                                        -->
-                                                <!--     ),                                                          -->
-                                                <!--     linkable_elements=(                                         -->
-                                                <!--       LinkableDimension(                                        -->
-                                                <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                                <!--           semantic_model_name='bookings_source',                -->
-                                                <!--         ),                                                      -->
-                                                <!--         element_name='is_instant',                              -->
-                                                <!--         dimension_type=CATEGORICAL,                             -->
-                                                <!--         entity_links=(                                          -->
-                                                <!--           EntityReference(                                      -->
-                                                <!--             element_name='booking',                             -->
-                                                <!--           ),                                                    -->
-                                                <!--         ),                                                      -->
-                                                <!--         join_path=SemanticModelJoinPath(                        -->
-                                                <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                                <!--             semantic_model_name='bookings_source',              -->
-                                                <!--           ),                                                    -->
-                                                <!--         ),                                                      -->
-                                                <!--         properties=frozenset('LOCAL',),                         -->
-                                                <!--       ),                                                        -->
-                                                <!--     ),                                                          -->
-                                                <!--   )                                                             -->
-                                                <MetricTimeDimensionTransformNode>
-                                                    <!-- description = "Metric Time Dimension 'ds'" -->
-                                                    <!-- node_id = NodeId(id_str='sma_0') -->
-                                                    <!-- aggregation_time_dimension = 'ds' -->
-                                                    <ReadSqlSourceNode>
-                                                        <!-- description =                                         -->
-                                                        <!--   "Read From SemanticModelDataSet('bookings_source')" -->
-                                                        <!-- node_id = NodeId(id_str='rss_0') -->
-                                                        <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                                    </ReadSqlSourceNode>
-                                                </MetricTimeDimensionTransformNode>
-                                            </WhereConstraintNode>
-                                        </FilterElementsNode>
-                                        <FilterElementsNode>
-                                            <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                            <!-- node_id = NodeId(id_str='pfe_9') -->
-                                            <!-- include_spec = DimensionSpec(element_name='country_latest') -->
-                                            <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                            <!-- distinct = False -->
+                            <FilterElementsNode>
+                                <!-- description =                                                     -->
+                                <!--   ("Pass Only Elements: ['bookings', 'listing__country_latest', " -->
+                                <!--    "'booking__is_instant', 'metric_time__day']")                  -->
+                                <!-- node_id = NodeId(id_str='pfe_10') -->
+                                <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                <!-- include_spec =                                               -->
+                                <!--   DimensionSpec(                                             -->
+                                <!--     element_name='country_latest',                           -->
+                                <!--     entity_links=(EntityReference(element_name='listing'),), -->
+                                <!--   )                                                          -->
+                                <!-- include_spec =                                               -->
+                                <!--   DimensionSpec(                                             -->
+                                <!--     element_name='is_instant',                               -->
+                                <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                <!--   )                                                          -->
+                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- distinct = False -->
+                                <JoinOnEntitiesNode>
+                                    <!-- description = 'Join Standard Outputs' -->
+                                    <!-- node_id = NodeId(id_str='jso_2') -->
+                                    <!-- join0_for_node_id_pfe_9 =                                      -->
+                                    <!--   JoinDescription(                                             -->
+                                    <!--     join_node=FilterElementsNode(node_id=pfe_9),               -->
+                                    <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
+                                    <!--     join_type=LEFT_OUTER,                                      -->
+                                    <!--   )                                                            -->
+                                    <FilterElementsNode>
+                                        <!-- description =                                                 -->
+                                        <!--   ("Pass Only Elements: ['bookings', 'booking__is_instant', " -->
+                                        <!--    "'metric_time__day', 'listing']")                          -->
+                                        <!-- node_id = NodeId(id_str='pfe_8') -->
+                                        <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                        <!-- include_spec =                                               -->
+                                        <!--   DimensionSpec(                                             -->
+                                        <!--     element_name='is_instant',                               -->
+                                        <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                        <!--   )                                                          -->
+                                        <!-- include_spec =                                                        -->
+                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                        <!-- distinct = False -->
+                                        <WhereConstraintNode>
+                                            <!-- description = 'Constrain Output with WHERE' -->
+                                            <!-- node_id = NodeId(id_str='wcc_2') -->
+                                            <!-- where_condition =                                               -->
+                                            <!--   WhereFilterSpec(                                              -->
+                                            <!--     where_sql='booking__is_instant',                            -->
+                                            <!--     bind_parameters=SqlBindParameters(),                        -->
+                                            <!--     linkable_specs=(                                            -->
+                                            <!--       DimensionSpec(                                            -->
+                                            <!--         element_name='is_instant',                              -->
+                                            <!--         entity_links=(                                          -->
+                                            <!--           EntityReference(                                      -->
+                                            <!--             element_name='booking',                             -->
+                                            <!--           ),                                                    -->
+                                            <!--         ),                                                      -->
+                                            <!--       ),                                                        -->
+                                            <!--     ),                                                          -->
+                                            <!--     linkable_elements=(                                         -->
+                                            <!--       LinkableDimension(                                        -->
+                                            <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                                            <!--           semantic_model_name='bookings_source',                -->
+                                            <!--         ),                                                      -->
+                                            <!--         element_name='is_instant',                              -->
+                                            <!--         dimension_type=CATEGORICAL,                             -->
+                                            <!--         entity_links=(                                          -->
+                                            <!--           EntityReference(                                      -->
+                                            <!--             element_name='booking',                             -->
+                                            <!--           ),                                                    -->
+                                            <!--         ),                                                      -->
+                                            <!--         join_path=SemanticModelJoinPath(                        -->
+                                            <!--           left_semantic_model_reference=SemanticModelReference( -->
+                                            <!--             semantic_model_name='bookings_source',              -->
+                                            <!--           ),                                                    -->
+                                            <!--         ),                                                      -->
+                                            <!--         properties=frozenset('LOCAL',),                         -->
+                                            <!--       ),                                                        -->
+                                            <!--     ),                                                          -->
+                                            <!--   )                                                             -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                                <!-- node_id = NodeId(id_str='sma_1') -->
+                                                <!-- node_id = NodeId(id_str='sma_0') -->
                                                 <!-- aggregation_time_dimension = 'ds' -->
                                                 <ReadSqlSourceNode>
                                                     <!-- description =                                         -->
-                                                    <!--   "Read From SemanticModelDataSet('listings_latest')" -->
-                                                    <!-- node_id = NodeId(id_str='rss_1') -->
-                                                    <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                                    <!--   "Read From SemanticModelDataSet('bookings_source')" -->
+                                                    <!-- node_id = NodeId(id_str='rss_0') -->
+                                                    <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                                 </ReadSqlSourceNode>
                                             </MetricTimeDimensionTransformNode>
-                                        </FilterElementsNode>
-                                    </JoinOnEntitiesNode>
-                                </FilterElementsNode>
-                            </WhereConstraintNode>
+                                        </WhereConstraintNode>
+                                    </FilterElementsNode>
+                                    <FilterElementsNode>
+                                        <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
+                                        <!-- node_id = NodeId(id_str='pfe_9') -->
+                                        <!-- include_spec = DimensionSpec(element_name='country_latest') -->
+                                        <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                        <!-- distinct = False -->
+                                        <MetricTimeDimensionTransformNode>
+                                            <!-- description = "Metric Time Dimension 'ds'" -->
+                                            <!-- node_id = NodeId(id_str='sma_1') -->
+                                            <!-- aggregation_time_dimension = 'ds' -->
+                                            <ReadSqlSourceNode>
+                                                <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
+                                                <!-- node_id = NodeId(id_str='rss_1') -->
+                                                <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                            </ReadSqlSourceNode>
+                                        </MetricTimeDimensionTransformNode>
+                                    </FilterElementsNode>
+                                </JoinOnEntitiesNode>
+                            </FilterElementsNode>
                         </FilterElementsNode>
                     </AggregateMeasuresNode>
                 </ComputeMetricsNode>
@@ -296,7 +263,7 @@
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
-                                <!-- node_id = NodeId(id_str='wcc_4') -->
+                                <!-- node_id = NodeId(id_str='wcc_3') -->
                                 <!-- where_condition =                                                -->
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
@@ -50,141 +50,103 @@
                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                     <!--   )                                                          -->
                     <!-- distinct = False -->
-                    <WhereConstraintNode>
-                        <!-- description = 'Constrain Output with WHERE' -->
-                        <!-- node_id = NodeId(id_str='wcc_2') -->
-                        <!-- where_condition =                                                -->
-                        <!--   WhereFilterSpec(                                               -->
-                        <!--     where_sql='booking__is_instant',                             -->
-                        <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--     linkable_elements=(                                          -->
-                        <!--       LinkableDimension(                                         -->
-                        <!--         defined_in_semantic_model=SemanticModelReference(        -->
-                        <!--           semantic_model_name='bookings_source',                 -->
-                        <!--         ),                                                       -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         dimension_type=CATEGORICAL,                              -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--         join_path=SemanticModelJoinPath(                         -->
-                        <!--           left_semantic_model_reference=SemanticModelReference(  -->
-                        <!--             semantic_model_name='bookings_source',               -->
-                        <!--           ),                                                     -->
-                        <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--   )                                                              -->
-                        <FilterElementsNode>
-                            <!-- description =                                                                          -->
-                            <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']" -->
-                            <!-- node_id = NodeId(id_str='pfe_6') -->
-                            <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec =                                               -->
-                            <!--   DimensionSpec(                                             -->
-                            <!--     element_name='country_latest',                           -->
-                            <!--     entity_links=(EntityReference(element_name='listing'),), -->
-                            <!--   )                                                          -->
-                            <!-- include_spec =                                               -->
-                            <!--   DimensionSpec(                                             -->
-                            <!--     element_name='is_instant',                               -->
-                            <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--   )                                                          -->
-                            <!-- distinct = False -->
-                            <JoinOnEntitiesNode>
-                                <!-- description = 'Join Standard Outputs' -->
-                                <!-- node_id = NodeId(id_str='jso_1') -->
-                                <!-- join0_for_node_id_pfe_5 =                                      -->
-                                <!--   JoinDescription(                                             -->
-                                <!--     join_node=FilterElementsNode(node_id=pfe_5),               -->
-                                <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
-                                <!--     join_type=LEFT_OUTER,                                      -->
-                                <!--   )                                                            -->
-                                <FilterElementsNode>
-                                    <!-- description =                                                          -->
-                                    <!--   "Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']" -->
-                                    <!-- node_id = NodeId(id_str='pfe_4') -->
-                                    <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                               -->
-                                    <!--   DimensionSpec(                                             -->
-                                    <!--     element_name='is_instant',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--   )                                                          -->
-                                    <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                    <!-- distinct = False -->
-                                    <WhereConstraintNode>
-                                        <!-- description = 'Constrain Output with WHERE' -->
-                                        <!-- node_id = NodeId(id_str='wcc_1') -->
-                                        <!-- where_condition =                                               -->
-                                        <!--   WhereFilterSpec(                                              -->
-                                        <!--     where_sql='booking__is_instant',                            -->
-                                        <!--     bind_parameters=SqlBindParameters(),                        -->
-                                        <!--     linkable_specs=(                                            -->
-                                        <!--       DimensionSpec(                                            -->
-                                        <!--         element_name='is_instant',                              -->
-                                        <!--         entity_links=(                                          -->
-                                        <!--           EntityReference(element_name='booking'),              -->
-                                        <!--         ),                                                      -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
-                                        <!--     linkable_elements=(                                         -->
-                                        <!--       LinkableDimension(                                        -->
-                                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
-                                        <!--           semantic_model_name='bookings_source',                -->
-                                        <!--         ),                                                      -->
-                                        <!--         element_name='is_instant',                              -->
-                                        <!--         dimension_type=CATEGORICAL,                             -->
-                                        <!--         entity_links=(                                          -->
-                                        <!--           EntityReference(                                      -->
-                                        <!--             element_name='booking',                             -->
-                                        <!--           ),                                                    -->
-                                        <!--         ),                                                      -->
-                                        <!--         join_path=SemanticModelJoinPath(                        -->
-                                        <!--           left_semantic_model_reference=SemanticModelReference( -->
-                                        <!--             semantic_model_name='bookings_source',              -->
-                                        <!--           ),                                                    -->
-                                        <!--         ),                                                      -->
-                                        <!--         properties=frozenset('LOCAL',),                         -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
-                                        <!--   )                                                             -->
-                                        <MetricTimeDimensionTransformNode>
-                                            <!-- description = "Metric Time Dimension 'ds'" -->
-                                            <!-- node_id = NodeId(id_str='sma_0') -->
-                                            <!-- aggregation_time_dimension = 'ds' -->
-                                            <ReadSqlSourceNode>
-                                                <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
-                                                <!-- node_id = NodeId(id_str='rss_0') -->
-                                                <!-- data_set = SemanticModelDataSet('bookings_source') -->
-                                            </ReadSqlSourceNode>
-                                        </MetricTimeDimensionTransformNode>
-                                    </WhereConstraintNode>
-                                </FilterElementsNode>
-                                <FilterElementsNode>
-                                    <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                    <!-- node_id = NodeId(id_str='pfe_5') -->
-                                    <!-- include_spec = DimensionSpec(element_name='country_latest') -->
-                                    <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
-                                    <!-- distinct = False -->
+                    <FilterElementsNode>
+                        <!-- description =                                                                          -->
+                        <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']" -->
+                        <!-- node_id = NodeId(id_str='pfe_6') -->
+                        <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                        <!-- include_spec =                                               -->
+                        <!--   DimensionSpec(                                             -->
+                        <!--     element_name='country_latest',                           -->
+                        <!--     entity_links=(EntityReference(element_name='listing'),), -->
+                        <!--   )                                                          -->
+                        <!-- include_spec =                                               -->
+                        <!--   DimensionSpec(                                             -->
+                        <!--     element_name='is_instant',                               -->
+                        <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                        <!--   )                                                          -->
+                        <!-- distinct = False -->
+                        <JoinOnEntitiesNode>
+                            <!-- description = 'Join Standard Outputs' -->
+                            <!-- node_id = NodeId(id_str='jso_1') -->
+                            <!-- join0_for_node_id_pfe_5 =                                      -->
+                            <!--   JoinDescription(                                             -->
+                            <!--     join_node=FilterElementsNode(node_id=pfe_5),               -->
+                            <!--     join_on_entity=LinklessEntitySpec(element_name='listing'), -->
+                            <!--     join_type=LEFT_OUTER,                                      -->
+                            <!--   )                                                            -->
+                            <FilterElementsNode>
+                                <!-- description = "Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']" -->
+                                <!-- node_id = NodeId(id_str='pfe_4') -->
+                                <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                <!-- include_spec =                                               -->
+                                <!--   DimensionSpec(                                             -->
+                                <!--     element_name='is_instant',                               -->
+                                <!--     entity_links=(EntityReference(element_name='booking'),), -->
+                                <!--   )                                                          -->
+                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                <!-- distinct = False -->
+                                <WhereConstraintNode>
+                                    <!-- description = 'Constrain Output with WHERE' -->
+                                    <!-- node_id = NodeId(id_str='wcc_1') -->
+                                    <!-- where_condition =                                                -->
+                                    <!--   WhereFilterSpec(                                               -->
+                                    <!--     where_sql='booking__is_instant',                             -->
+                                    <!--     bind_parameters=SqlBindParameters(),                         -->
+                                    <!--     linkable_specs=(                                             -->
+                                    <!--       DimensionSpec(                                             -->
+                                    <!--         element_name='is_instant',                               -->
+                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_elements=(                                          -->
+                                    <!--       LinkableDimension(                                         -->
+                                    <!--         defined_in_semantic_model=SemanticModelReference(        -->
+                                    <!--           semantic_model_name='bookings_source',                 -->
+                                    <!--         ),                                                       -->
+                                    <!--         element_name='is_instant',                               -->
+                                    <!--         dimension_type=CATEGORICAL,                              -->
+                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
+                                    <!--         join_path=SemanticModelJoinPath(                         -->
+                                    <!--           left_semantic_model_reference=SemanticModelReference(  -->
+                                    <!--             semantic_model_name='bookings_source',               -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
+                                    <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--   )                                                              -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='sma_1') -->
+                                        <!-- node_id = NodeId(id_str='sma_0') -->
                                         <!-- aggregation_time_dimension = 'ds' -->
                                         <ReadSqlSourceNode>
-                                            <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
-                                            <!-- node_id = NodeId(id_str='rss_1') -->
-                                            <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                            <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                            <!-- node_id = NodeId(id_str='rss_0') -->
+                                            <!-- data_set = SemanticModelDataSet('bookings_source') -->
                                         </ReadSqlSourceNode>
                                     </MetricTimeDimensionTransformNode>
-                                </FilterElementsNode>
-                            </JoinOnEntitiesNode>
-                        </FilterElementsNode>
-                    </WhereConstraintNode>
+                                </WhereConstraintNode>
+                            </FilterElementsNode>
+                            <FilterElementsNode>
+                                <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
+                                <!-- node_id = NodeId(id_str='pfe_5') -->
+                                <!-- include_spec = DimensionSpec(element_name='country_latest') -->
+                                <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
+                                <!-- distinct = False -->
+                                <MetricTimeDimensionTransformNode>
+                                    <!-- description = "Metric Time Dimension 'ds'" -->
+                                    <!-- node_id = NodeId(id_str='sma_1') -->
+                                    <!-- aggregation_time_dimension = 'ds' -->
+                                    <ReadSqlSourceNode>
+                                        <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
+                                        <!-- node_id = NodeId(id_str='rss_1') -->
+                                        <!-- data_set = SemanticModelDataSet('listings_latest') -->
+                                    </ReadSqlSourceNode>
+                                </MetricTimeDimensionTransformNode>
+                            </FilterElementsNode>
+                        </JoinOnEntitiesNode>
+                    </FilterElementsNode>
                 </FilterElementsNode>
             </AggregateMeasuresNode>
         </ComputeMetricsNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
     metric_time__day
-) subq_26
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.average_booking_value) AS average_booking_value
-    , MAX(subq_25.max_booking_value) AS max_booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.average_booking_value) AS average_booking_value
+    , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , average_booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value AS average_booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , booking_value AS average_booking_value
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,43 +1,32 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  user__home_state_latest
-  , SUM(listings) AS listings
+  users_latest_src_28000.home_state_latest AS user__home_state_latest
+  , SUM(subq_13.listings) AS listings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
   SELECT
-    subq_13.listing__is_lux_latest AS listing__is_lux_latest
-    , subq_13.listing__capacity_latest AS listing__capacity_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
-    , subq_13.listings AS listings
+    subq_11.user
+    , listings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+    -- Read Elements From Semantic Model 'listings_latest'
+    -- Metric Time Dimension 'ds'
     SELECT
-      subq_11.user
-      , listing__is_lux_latest
-      , listing__capacity_latest
-      , listings
-    FROM (
-      -- Read Elements From Semantic Model 'listings_latest'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        user_id AS user
-        , is_lux AS listing__is_lux_latest
-        , capacity AS listing__capacity_latest
-        , 1 AS listings
-      FROM ***************************.dim_listings_latest listings_latest_src_28000
-    ) subq_11
-    WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-  ) subq_13
-  LEFT OUTER JOIN
-    ***************************.dim_users_latest users_latest_src_28000
-  ON
-    subq_13.user = users_latest_src_28000.user_id
-) subq_17
-WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+      user_id AS user
+      , is_lux AS listing__is_lux_latest
+      , capacity AS listing__capacity_latest
+      , 1 AS listings
+    FROM ***************************.dim_listings_latest listings_latest_src_28000
+  ) subq_11
+  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
+) subq_13
+LEFT OUTER JOIN
+  ***************************.dim_users_latest users_latest_src_28000
+ON
+  subq_13.user = users_latest_src_28000.user_id
 GROUP BY
-  user__home_state_latest
+  users_latest_src_28000.home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,40 +1,31 @@
--- Constrain Output with WHERE
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listing__country_latest
-  , SUM(bookings) AS bookings
+  listings_latest_src_28000.country AS listing__country_latest
+  , SUM(subq_14.bookings) AS bookings
 FROM (
-  -- Join Standard Outputs
-  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+  -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
   SELECT
-    subq_14.booking__is_instant AS booking__is_instant
-    , listings_latest_src_28000.country AS listing__country_latest
-    , subq_14.bookings AS bookings
+    listing
+    , bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      listing
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        listing_id AS listing
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_12
-    WHERE booking__is_instant
-  ) subq_14
-  LEFT OUTER JOIN
-    ***************************.dim_listings_latest listings_latest_src_28000
-  ON
-    subq_14.listing = listings_latest_src_28000.listing_id
-) subq_19
-WHERE booking__is_instant
+      listing_id AS listing
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_12
+  WHERE booking__is_instant
+) subq_14
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_14.listing = listings_latest_src_28000.listing_id
 GROUP BY
-  listing__country_latest
+  listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
     metric_time__day
-) subq_26
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATETIME_TRUNC(ds, day) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_distinct_values__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_distinct_values__plan0_optimized.sql
@@ -4,17 +4,11 @@
 SELECT
   listing__country_latest
 FROM (
-  -- Constrain Output with WHERE
+  -- Read Elements From Semantic Model 'listings_latest'
   SELECT
-    listing__country_latest
-  FROM (
-    -- Read Elements From Semantic Model 'listings_latest'
-    SELECT
-      country AS listing__country_latest
-    FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_3
-  WHERE listing__country_latest = 'us'
-) subq_4
+    country AS listing__country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+) subq_3
 WHERE listing__country_latest = 'us'
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -5,11 +5,12 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day) AS metric_time__day
-    , MAX(subq_20.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
-    , MAX(subq_25.booking_value) AS booking_value
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day) AS metric_time__day
+    , MAX(subq_19.booking_value_with_is_instant_constraint) AS booking_value_with_is_instant_constraint
+    , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -17,27 +18,18 @@ FROM (
       metric_time__day
       , SUM(booking_value) AS booking_value_with_is_instant_constraint
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
         , booking_value
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , booking_value
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_14
-      WHERE booking__is_instant
-    ) subq_16
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_14
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_20
+  ) subq_19
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -50,9 +42,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_25
+  ) subq_24
   ON
-    subq_20.metric_time__day = subq_25.metric_time__day
+    subq_19.metric_time__day = subq_24.metric_time__day
   GROUP BY
-    COALESCE(subq_20.metric_time__day, subq_25.metric_time__day)
-) subq_26
+    COALESCE(subq_19.metric_time__day, subq_24.metric_time__day)
+) subq_25

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,6 +4,7 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
+  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -11,24 +12,15 @@ FROM (
     metric_time__day
     , SUM(bookings) AS delayed_bookings
   FROM (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
     SELECT
-      metric_time__day
-      , booking__is_instant
-      , bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , is_instant AS booking__is_instant
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_8
-    WHERE NOT booking__is_instant
-  ) subq_10
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , is_instant AS booking__is_instant
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_8
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day
-) subq_14
+) subq_13

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -5,38 +5,30 @@ SELECT
 FROM (
   -- Join to Time Spine Dataset
   SELECT
-    subq_17.ds AS metric_time__day
-    , subq_15.bookings AS bookings
-  FROM ***************************.mf_time_spine subq_17
+    subq_16.ds AS metric_time__day
+    , subq_14.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
       SELECT
-        metric_time__day
-        , booking__is_instant
-        , bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , is_instant AS booking__is_instant
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
-      WHERE booking__is_instant
-    ) subq_12
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
     WHERE booking__is_instant
     GROUP BY
       metric_time__day
-  ) subq_15
+  ) subq_14
   ON
-    subq_17.ds = subq_15.metric_time__day
-) subq_18
+    subq_16.ds = subq_14.metric_time__day
+) subq_17

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -12,42 +12,34 @@ FROM (
   FROM (
     -- Join to Time Spine Dataset
     SELECT
-      subq_16.ds AS metric_time__day
-      , subq_14.booking__is_instant AS booking__is_instant
-      , subq_14.bookings AS bookings
-    FROM ***************************.mf_time_spine subq_16
+      subq_15.ds AS metric_time__day
+      , subq_13.booking__is_instant AS booking__is_instant
+      , subq_13.bookings AS bookings
+    FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , booking__is_instant
         , SUM(bookings) AS bookings
       FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
         SELECT
-          metric_time__day
-          , booking__is_instant
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_10
-        WHERE booking__is_instant
-      ) subq_12
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_10
       WHERE booking__is_instant
       GROUP BY
         metric_time__day
         , booking__is_instant
-    ) subq_14
+    ) subq_13
     ON
-      subq_16.ds = subq_14.metric_time__day
-  ) subq_17
+      subq_15.ds = subq_13.metric_time__day
+  ) subq_16
   WHERE booking__is_instant
-) subq_18
+) subq_17


### PR DESCRIPTION
The original implementation of predicate pushdown generated duplicated
where filter constraints, applying it once as a result of pushdown and
again in the original where constraint node.

This change removes the duplication, and does so at the level of the
individual filter spec. Logically, this means the following:

1. If all filter specs for a where constraint node can be pushed down,
the node itself will be moved past the join.
2. If some filter specs for a where constraint node can be pushed down,
the node itself will remain in place, but it will only apply the filters
that cannot be pushed down.
3. Any WhereConstraintNode added to the DataflowPlan for the purposes of
cleaning up spurious rows added as the result of an outer join, such as
we have in one particular JoinToTimeSpineNode scenario, must be annotated
to indicate that we should apply that constraint filter no matter what.

This change updates all of our logic to ensure that we effectively apply
each where filter exactly once within a branch in the DAG, and only re-apply
filters where explicitly requested at build time.

Note this change is all based on certain assumptions about how the
DataflowPlanBuilder constructs the plan. Specifically, we assume that we will
never need to re-apply filters upstream of a node unless otherwise
indicated. If we start to do fancy things with nesting where constraints
or swapping join sides - particularly if we push groupable metric filters
to an inner join or if we begin adding query time constraints outside of
an aggregated output join - this could get dodgy. Conversion metrics are
of particular concern here.