### PR TITLE
Add SQL rendering tests for pushdown edge cases

### DIFF
--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS FLOAT64) / CAST(NULLIF(subq_27.visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM visits_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM visits_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, day) AS visit__ds__day
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, isoweek) AS visit__ds__week
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, month) AS visit__ds__month
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, quarter) AS visit__ds__quarter
+                    , DATETIME_TRUNC(visits_source_src_28000.ds, year) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM visits_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM visits_source_src_28000.ds) - 1) AS visit__ds__extract_dow
+                    , EXTRACT(dayofyear FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATETIME_TRUNC(users_latest_src_28000.ds, day) AS ds_latest__day
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS ds_latest__week
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS ds_latest__month
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS ds_latest__quarter
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS ds_latest__extract_dow
+                  , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, day) AS user__ds_latest__day
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS user__ds_latest__week
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS user__ds_latest__month
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS user__ds_latest__quarter
+                  , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS user__ds_latest__extract_dow
+                  , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      metric_time__day
+      , user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, day) AS ds__day
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, isoweek) AS ds__week
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, month) AS ds__month
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM visits_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM visits_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, day) AS visit__ds__day
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, isoweek) AS visit__ds__week
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, month) AS visit__ds__month
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, quarter) AS visit__ds__quarter
+                        , DATETIME_TRUNC(visits_source_src_28000.ds, year) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM visits_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM visits_source_src_28000.ds) - 1) AS visit__ds__extract_dow
+                        , EXTRACT(dayofyear FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATETIME_TRUNC(users_latest_src_28000.ds, day) AS ds_latest__day
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS ds_latest__week
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS ds_latest__month
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS ds_latest__quarter
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS ds_latest__extract_dow
+                        , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, day) AS user__ds_latest__day
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS user__ds_latest__week
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS user__ds_latest__month
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS user__ds_latest__quarter
+                        , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS user__ds_latest__extract_dow
+                        , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , GENERATE_UUID() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, day) AS ds__day
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, isoweek) AS ds__week
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, month) AS ds__month
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, quarter) AS ds__quarter
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, year) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM buys_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM buys_source_src_28000.ds) - 1) AS ds__extract_dow
+                      , EXTRACT(dayofyear FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, day) AS buy__ds__day
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, isoweek) AS buy__ds__week
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, month) AS buy__ds__month
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, quarter) AS buy__ds__quarter
+                      , DATETIME_TRUNC(buys_source_src_28000.ds, year) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM buys_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM buys_source_src_28000.ds) - 1) AS buy__ds__extract_dow
+                      , EXTRACT(dayofyear FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > DATE_SUB(CAST(subq_18.ds__day AS DATETIME), INTERVAL 7 day)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATETIME_TRUNC(users_latest_src_28000.ds, day) AS ds_latest__day
+              , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS ds_latest__week
+              , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS ds_latest__month
+              , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS ds_latest__quarter
+              , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS ds_latest__extract_dow
+              , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATETIME_TRUNC(users_latest_src_28000.ds, day) AS user__ds_latest__day
+              , DATETIME_TRUNC(users_latest_src_28000.ds, isoweek) AS user__ds_latest__week
+              , DATETIME_TRUNC(users_latest_src_28000.ds, month) AS user__ds_latest__month
+              , DATETIME_TRUNC(users_latest_src_28000.ds, quarter) AS user__ds_latest__quarter
+              , DATETIME_TRUNC(users_latest_src_28000.ds, year) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , IF(EXTRACT(dayofweek FROM users_latest_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM users_latest_src_28000.ds) - 1) AS user__ds_latest__extract_dow
+              , EXTRACT(dayofyear FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      metric_time__day
+      , user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , user__home_state_latest
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      metric_time__day
+      , user__home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATETIME_TRUNC(ds, day) AS ds__day
+            , DATETIME_TRUNC(ds, day) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATETIME_TRUNC(ds, day) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , GENERATE_UUID() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > DATE_SUB(CAST(subq_46.ds__day AS DATETIME), INTERVAL 7 day)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      metric_time__day
+      , user__home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , user__home_state_latest
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                    , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                    , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > DATE_SUB(CAST(subq_2.metric_time__day AS DATETIME), INTERVAL 2 day)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    metric_time__day
+    , listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > DATE_SUB(CAST(subq_18.ds AS DATETIME), INTERVAL 2 day)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATETIME_TRUNC(subq_17.metric_time__day, isoweek) AS metric_time__week
+                      , DATETIME_TRUNC(subq_17.metric_time__day, month) AS metric_time__month
+                      , DATETIME_TRUNC(subq_17.metric_time__day, quarter) AS metric_time__quarter
+                      , DATETIME_TRUNC(subq_17.metric_time__day, year) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , IF(EXTRACT(dayofweek FROM subq_17.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_17.metric_time__day) - 1) AS metric_time__extract_dow
+                      , EXTRACT(dayofyear FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                          , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                          , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      DATE_SUB(CAST(subq_17.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                        , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                        , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , listing__country_latest
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATETIME_TRUNC(ds, day) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATETIME_TRUNC(ds, day) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              DATE_SUB(CAST(subq_52.ds AS DATETIME), INTERVAL 14 day) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , listing__country_latest
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                  , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                  , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                  , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                  , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATETIME_TRUNC(ds, day) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                      , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                      , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        metric_time__day
+        , listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATETIME_TRUNC(subq_14.metric_time__day, isoweek) AS metric_time__week
+                    , DATETIME_TRUNC(subq_14.metric_time__day, month) AS metric_time__month
+                    , DATETIME_TRUNC(subq_14.metric_time__day, quarter) AS metric_time__quarter
+                    , DATETIME_TRUNC(subq_14.metric_time__day, year) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , IF(EXTRACT(dayofweek FROM subq_14.metric_time__day) = 1, 7, EXTRACT(dayofweek FROM subq_14.metric_time__day) - 1) AS metric_time__extract_dow
+                    , EXTRACT(dayofyear FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                        , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                        , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    DATE_SUB(CAST(subq_14.metric_time__day AS DATETIME), INTERVAL 14 day) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS ds__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS ds__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS ds__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS ds__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS ds__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS created_at__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS created_at__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS created_at__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS created_at__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS created_at__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__ds__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__ds__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__ds__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__ds__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__ds__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, day) AS listing__created_at__day
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, isoweek) AS listing__created_at__week
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, month) AS listing__created_at__month
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, quarter) AS listing__created_at__quarter
+                      , DATETIME_TRUNC(listings_latest_src_28000.created_at, year) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , IF(EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) = 1, 7, EXTRACT(dayofweek FROM listings_latest_src_28000.created_at) - 1) AS listing__created_at__extract_dow
+                      , EXTRACT(dayofyear FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        metric_time__day
+        , listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , listing__country_latest
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATETIME_TRUNC(ds, day) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          DATE_SUB(CAST(subq_43.ds AS DATETIME), INTERVAL 14 day) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    metric_time__day
+    , listing__country_latest
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS booking__ds__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, isoweek) AS booking__ds__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, month) AS booking__ds__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, quarter) AS booking__ds__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds, year) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds) - 1) AS booking__ds__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, day) AS booking__ds_partitioned__day
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, isoweek) AS booking__ds_partitioned__week
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, month) AS booking__ds_partitioned__month
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, quarter) AS booking__ds_partitioned__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.ds_partitioned, year) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.ds_partitioned) - 1) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, day) AS booking__paid_at__day
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, isoweek) AS booking__paid_at__week
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, month) AS booking__paid_at__month
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, quarter) AS booking__paid_at__quarter
+                , DATETIME_TRUNC(bookings_source_src_28000.paid_at, year) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , IF(EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) = 1, 7, EXTRACT(dayofweek FROM bookings_source_src_28000.paid_at) - 1) AS booking__paid_at__extract_dow
+                , EXTRACT(dayofyear FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        metric_time__day
+        , booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATETIME_TRUNC(ds, day) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM visits_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM visits_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , UUID() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM buys_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM buys_source_src_28000.ds) AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > DATEADD(day, -7, subq_18.ds__day)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , EXTRACT(DAYOFWEEK_ISO FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , UUID() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > DATEADD(day, -7, subq_46.ds__day)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM subq_17.metric_time__day) AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      DATEADD(day, -14, subq_17.metric_time__day) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              DATEADD(day, -14, subq_52.ds) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , EXTRACT(DAYOFWEEK_ISO FROM subq_14.metric_time__day) AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    DATEADD(day, -14, subq_14.metric_time__day) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(DAYOFWEEK_ISO FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          DATEADD(day, -14, subq_43.ds) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAYOFWEEK_ISO FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM visits_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , EXTRACT(isodow FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM visits_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , EXTRACT(isodow FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , GEN_RANDOM_UUID() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM buys_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , EXTRACT(isodow FROM buys_source_src_28000.ds) AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > subq_18.ds__day - INTERVAL 7 day
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , GEN_RANDOM_UUID() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > subq_46.ds__day - INTERVAL 7 day
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > subq_2.metric_time__day - INTERVAL 2 day
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > subq_18.ds - INTERVAL 2 day
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , EXTRACT(isodow FROM subq_17.metric_time__day) AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      subq_17.metric_time__day - INTERVAL 14 day = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              subq_52.ds - INTERVAL 14 day = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , EXTRACT(isodow FROM subq_14.metric_time__day) AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_14.metric_time__day - INTERVAL 14 day = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          subq_43.ds - INTERVAL 14 day = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM visits_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , EXTRACT(isodow FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM visits_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , EXTRACT(isodow FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , GEN_RANDOM_UUID() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM buys_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , EXTRACT(isodow FROM buys_source_src_28000.ds) AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > subq_18.ds__day - MAKE_INTERVAL(days => 7)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , EXTRACT(isodow FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , EXTRACT(isodow FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , GEN_RANDOM_UUID() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > subq_46.ds__day - MAKE_INTERVAL(days => 7)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > subq_2.metric_time__day - MAKE_INTERVAL(days => 2)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > subq_18.ds - MAKE_INTERVAL(days => 2)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , EXTRACT(isodow FROM subq_17.metric_time__day) AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      subq_17.metric_time__day - MAKE_INTERVAL(days => 14) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              subq_52.ds - MAKE_INTERVAL(days => 14) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , EXTRACT(isodow FROM subq_14.metric_time__day) AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_14.metric_time__day - MAKE_INTERVAL(days => 14) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(isodow FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          subq_43.ds - MAKE_INTERVAL(days => 14) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(isodow FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE PRECISION) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM visits_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM visits_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM visits_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM visits_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM visits_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM visits_source_src_28000.ds) END AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM visits_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM visits_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM visits_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM visits_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM visits_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM visits_source_src_28000.ds) END AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM buys_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM buys_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM buys_source_src_28000.ds) END AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM buys_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM buys_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM buys_source_src_28000.ds) END AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > DATEADD(day, -7, subq_18.ds__day)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , CASE WHEN EXTRACT(dow FROM users_latest_src_28000.ds) = 0 THEN EXTRACT(dow FROM users_latest_src_28000.ds) + 7 ELSE EXTRACT(dow FROM users_latest_src_28000.ds) END AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > DATEADD(day, -7, subq_46.ds__day)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , CASE WHEN EXTRACT(dow FROM subq_17.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_17.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_17.metric_time__day) END AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      DATEADD(day, -14, subq_17.metric_time__day) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              DATEADD(day, -14, subq_52.ds) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , CASE WHEN EXTRACT(dow FROM subq_14.metric_time__day) = 0 THEN EXTRACT(dow FROM subq_14.metric_time__day) + 7 ELSE EXTRACT(dow FROM subq_14.metric_time__day) END AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    DATEADD(day, -14, subq_14.metric_time__day) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , CASE WHEN EXTRACT(dow FROM listings_latest_src_28000.created_at) = 0 THEN EXTRACT(dow FROM listings_latest_src_28000.created_at) + 7 ELSE EXTRACT(dow FROM listings_latest_src_28000.created_at) END AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          DATEADD(day, -14, subq_43.ds) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds) END AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.ds_partitioned) END AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , CASE WHEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) = 0 THEN EXTRACT(dow FROM bookings_source_src_28000.paid_at) + 7 ELSE EXTRACT(dow FROM bookings_source_src_28000.paid_at) END AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM visits_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM visits_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , UUID_STRING() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(dayofweekiso FROM buys_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , EXTRACT(dayofweekiso FROM buys_source_src_28000.ds) AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > DATEADD(day, -7, subq_18.ds__day)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , EXTRACT(dayofweekiso FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , UUID_STRING() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > DATEADD(day, -7, subq_46.ds__day)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > DATEADD(day, -2, subq_2.metric_time__day)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , EXTRACT(dayofweekiso FROM subq_17.metric_time__day) AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      DATEADD(day, -14, subq_17.metric_time__day) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              DATEADD(day, -14, subq_52.ds) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , EXTRACT(dayofweekiso FROM subq_14.metric_time__day) AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    DATEADD(day, -14, subq_14.metric_time__day) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(dayofweekiso FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          DATEADD(day, -14, subq_43.ds) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(dayofweekiso FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0.sql
@@ -1,0 +1,632 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.user__home_state_latest
+  , CAST(subq_27.buys AS DOUBLE) / CAST(NULLIF(subq_27.visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_9.visits) AS visits
+    , MAX(subq_26.buys) AS buys
+  FROM (
+    -- Aggregate Measures
+    SELECT
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+      , SUM(subq_8.visits) AS visits
+    FROM (
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.user__home_state_latest
+        , subq_7.visits
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.visit__referrer_id
+          , subq_6.user__home_state_latest
+          , subq_6.visits
+        FROM (
+          -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+          SELECT
+            subq_5.metric_time__day
+            , subq_5.visit__referrer_id
+            , subq_5.user__home_state_latest
+            , subq_5.visits
+          FROM (
+            -- Join Standard Outputs
+            SELECT
+              subq_2.metric_time__day AS metric_time__day
+              , subq_2.user AS user
+              , subq_2.visit__referrer_id AS visit__referrer_id
+              , subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.visits AS visits
+            FROM (
+              -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+              SELECT
+                subq_1.metric_time__day
+                , subq_1.user
+                , subq_1.visit__referrer_id
+                , subq_1.visits
+              FROM (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.visit__ds__day
+                  , subq_0.visit__ds__week
+                  , subq_0.visit__ds__month
+                  , subq_0.visit__ds__quarter
+                  , subq_0.visit__ds__year
+                  , subq_0.visit__ds__extract_year
+                  , subq_0.visit__ds__extract_quarter
+                  , subq_0.visit__ds__extract_month
+                  , subq_0.visit__ds__extract_day
+                  , subq_0.visit__ds__extract_dow
+                  , subq_0.visit__ds__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.user
+                  , subq_0.session
+                  , subq_0.visit__user
+                  , subq_0.visit__session
+                  , subq_0.referrer_id
+                  , subq_0.visit__referrer_id
+                  , subq_0.visits
+                  , subq_0.visitors
+                FROM (
+                  -- Read Elements From Semantic Model 'visits_source'
+                  SELECT
+                    1 AS visits
+                    , visits_source_src_28000.user_id AS visitors
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM visits_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                    , visits_source_src_28000.referrer_id
+                    , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                    , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                    , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                    , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                    , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                    , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                    , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                    , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                    , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                    , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                    , visits_source_src_28000.referrer_id AS visit__referrer_id
+                    , visits_source_src_28000.user_id AS user
+                    , visits_source_src_28000.session_id AS session
+                    , visits_source_src_28000.user_id AS visit__user
+                    , visits_source_src_28000.session_id AS visit__session
+                  FROM ***************************.fct_visits visits_source_src_28000
+                ) subq_0
+              ) subq_1
+            ) subq_2
+            LEFT OUTER JOIN (
+              -- Pass Only Elements: ['home_state_latest', 'user']
+              SELECT
+                subq_3.user
+                , subq_3.home_state_latest
+              FROM (
+                -- Read Elements From Semantic Model 'users_latest'
+                SELECT
+                  DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest
+                  , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                  , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                  , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                  , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                  , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                  , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                  , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                  , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                  , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                  , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                  , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                  , users_latest_src_28000.user_id AS user
+                FROM ***************************.dim_users_latest users_latest_src_28000
+              ) subq_3
+            ) subq_4
+            ON
+              subq_2.user = subq_4.user
+          ) subq_5
+        ) subq_6
+        WHERE visit__referrer_id = '123456'
+      ) subq_7
+    ) subq_8
+    GROUP BY
+      subq_8.metric_time__day
+      , subq_8.user__home_state_latest
+  ) subq_9
+  FULL OUTER JOIN (
+    -- Aggregate Measures
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+      , SUM(subq_25.buys) AS buys
+    FROM (
+      -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.user__home_state_latest
+        , subq_24.buys
+      FROM (
+        -- Join Standard Outputs
+        SELECT
+          subq_21.metric_time__day AS metric_time__day
+          , subq_21.user AS user
+          , subq_21.visit__referrer_id AS visit__referrer_id
+          , subq_23.home_state_latest AS user__home_state_latest
+          , subq_21.buys AS buys
+        FROM (
+          -- Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day', 'user']
+          SELECT
+            subq_20.metric_time__day
+            , subq_20.user
+            , subq_20.visit__referrer_id
+            , subq_20.buys
+          FROM (
+            -- Find conversions for user within the range of 7 day
+            SELECT
+              subq_19.ds__day
+              , subq_19.metric_time__day
+              , subq_19.user
+              , subq_19.visit__referrer_id
+              , subq_19.user__home_state_latest
+              , subq_19.buys
+              , subq_19.visits
+            FROM (
+              -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+              SELECT DISTINCT
+                FIRST_VALUE(subq_15.visits) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visits
+                , FIRST_VALUE(subq_15.visit__referrer_id) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS visit__referrer_id
+                , FIRST_VALUE(subq_15.user__home_state_latest) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user__home_state_latest
+                , FIRST_VALUE(subq_15.ds__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS ds__day
+                , FIRST_VALUE(subq_15.metric_time__day) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS metric_time__day
+                , FIRST_VALUE(subq_15.user) OVER (
+                  PARTITION BY
+                    subq_18.user
+                    , subq_18.ds__day
+                    , subq_18.mf_internal_uuid
+                  ORDER BY subq_15.ds__day DESC
+                  ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+                ) AS user
+                , subq_18.mf_internal_uuid AS mf_internal_uuid
+                , subq_18.buys AS buys
+              FROM (
+                -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+                SELECT
+                  subq_14.ds__day
+                  , subq_14.metric_time__day
+                  , subq_14.user
+                  , subq_14.visit__referrer_id
+                  , subq_14.user__home_state_latest
+                  , subq_14.visits
+                FROM (
+                  -- Join Standard Outputs
+                  SELECT
+                    subq_11.ds__day AS ds__day
+                    , subq_11.ds__week AS ds__week
+                    , subq_11.ds__month AS ds__month
+                    , subq_11.ds__quarter AS ds__quarter
+                    , subq_11.ds__year AS ds__year
+                    , subq_11.ds__extract_year AS ds__extract_year
+                    , subq_11.ds__extract_quarter AS ds__extract_quarter
+                    , subq_11.ds__extract_month AS ds__extract_month
+                    , subq_11.ds__extract_day AS ds__extract_day
+                    , subq_11.ds__extract_dow AS ds__extract_dow
+                    , subq_11.ds__extract_doy AS ds__extract_doy
+                    , subq_11.visit__ds__day AS visit__ds__day
+                    , subq_11.visit__ds__week AS visit__ds__week
+                    , subq_11.visit__ds__month AS visit__ds__month
+                    , subq_11.visit__ds__quarter AS visit__ds__quarter
+                    , subq_11.visit__ds__year AS visit__ds__year
+                    , subq_11.visit__ds__extract_year AS visit__ds__extract_year
+                    , subq_11.visit__ds__extract_quarter AS visit__ds__extract_quarter
+                    , subq_11.visit__ds__extract_month AS visit__ds__extract_month
+                    , subq_11.visit__ds__extract_day AS visit__ds__extract_day
+                    , subq_11.visit__ds__extract_dow AS visit__ds__extract_dow
+                    , subq_11.visit__ds__extract_doy AS visit__ds__extract_doy
+                    , subq_11.metric_time__day AS metric_time__day
+                    , subq_11.metric_time__week AS metric_time__week
+                    , subq_11.metric_time__month AS metric_time__month
+                    , subq_11.metric_time__quarter AS metric_time__quarter
+                    , subq_11.metric_time__year AS metric_time__year
+                    , subq_11.metric_time__extract_year AS metric_time__extract_year
+                    , subq_11.metric_time__extract_quarter AS metric_time__extract_quarter
+                    , subq_11.metric_time__extract_month AS metric_time__extract_month
+                    , subq_11.metric_time__extract_day AS metric_time__extract_day
+                    , subq_11.metric_time__extract_dow AS metric_time__extract_dow
+                    , subq_11.metric_time__extract_doy AS metric_time__extract_doy
+                    , subq_11.user AS user
+                    , subq_11.session AS session
+                    , subq_11.visit__user AS visit__user
+                    , subq_11.visit__session AS visit__session
+                    , subq_11.referrer_id AS referrer_id
+                    , subq_11.visit__referrer_id AS visit__referrer_id
+                    , subq_13.home_state_latest AS user__home_state_latest
+                    , subq_11.visits AS visits
+                    , subq_11.visitors AS visitors
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_10.ds__day
+                      , subq_10.ds__week
+                      , subq_10.ds__month
+                      , subq_10.ds__quarter
+                      , subq_10.ds__year
+                      , subq_10.ds__extract_year
+                      , subq_10.ds__extract_quarter
+                      , subq_10.ds__extract_month
+                      , subq_10.ds__extract_day
+                      , subq_10.ds__extract_dow
+                      , subq_10.ds__extract_doy
+                      , subq_10.visit__ds__day
+                      , subq_10.visit__ds__week
+                      , subq_10.visit__ds__month
+                      , subq_10.visit__ds__quarter
+                      , subq_10.visit__ds__year
+                      , subq_10.visit__ds__extract_year
+                      , subq_10.visit__ds__extract_quarter
+                      , subq_10.visit__ds__extract_month
+                      , subq_10.visit__ds__extract_day
+                      , subq_10.visit__ds__extract_dow
+                      , subq_10.visit__ds__extract_doy
+                      , subq_10.ds__day AS metric_time__day
+                      , subq_10.ds__week AS metric_time__week
+                      , subq_10.ds__month AS metric_time__month
+                      , subq_10.ds__quarter AS metric_time__quarter
+                      , subq_10.ds__year AS metric_time__year
+                      , subq_10.ds__extract_year AS metric_time__extract_year
+                      , subq_10.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_10.ds__extract_month AS metric_time__extract_month
+                      , subq_10.ds__extract_day AS metric_time__extract_day
+                      , subq_10.ds__extract_dow AS metric_time__extract_dow
+                      , subq_10.ds__extract_doy AS metric_time__extract_doy
+                      , subq_10.user
+                      , subq_10.session
+                      , subq_10.visit__user
+                      , subq_10.visit__session
+                      , subq_10.referrer_id
+                      , subq_10.visit__referrer_id
+                      , subq_10.visits
+                      , subq_10.visitors
+                    FROM (
+                      -- Read Elements From Semantic Model 'visits_source'
+                      SELECT
+                        1 AS visits
+                        , visits_source_src_28000.user_id AS visitors
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM visits_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS ds__extract_doy
+                        , visits_source_src_28000.referrer_id
+                        , DATE_TRUNC('day', visits_source_src_28000.ds) AS visit__ds__day
+                        , DATE_TRUNC('week', visits_source_src_28000.ds) AS visit__ds__week
+                        , DATE_TRUNC('month', visits_source_src_28000.ds) AS visit__ds__month
+                        , DATE_TRUNC('quarter', visits_source_src_28000.ds) AS visit__ds__quarter
+                        , DATE_TRUNC('year', visits_source_src_28000.ds) AS visit__ds__year
+                        , EXTRACT(year FROM visits_source_src_28000.ds) AS visit__ds__extract_year
+                        , EXTRACT(quarter FROM visits_source_src_28000.ds) AS visit__ds__extract_quarter
+                        , EXTRACT(month FROM visits_source_src_28000.ds) AS visit__ds__extract_month
+                        , EXTRACT(day FROM visits_source_src_28000.ds) AS visit__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM visits_source_src_28000.ds) AS visit__ds__extract_dow
+                        , EXTRACT(doy FROM visits_source_src_28000.ds) AS visit__ds__extract_doy
+                        , visits_source_src_28000.referrer_id AS visit__referrer_id
+                        , visits_source_src_28000.user_id AS user
+                        , visits_source_src_28000.session_id AS session
+                        , visits_source_src_28000.user_id AS visit__user
+                        , visits_source_src_28000.session_id AS visit__session
+                      FROM ***************************.fct_visits visits_source_src_28000
+                    ) subq_10
+                  ) subq_11
+                  LEFT OUTER JOIN (
+                    -- Pass Only Elements: ['home_state_latest', 'user']
+                    SELECT
+                      subq_12.user
+                      , subq_12.home_state_latest
+                    FROM (
+                      -- Read Elements From Semantic Model 'users_latest'
+                      SELECT
+                        DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest
+                        , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+                        , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+                        , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+                        , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+                        , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+                        , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+                        , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+                        , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+                        , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+                        , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+                        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+                        , users_latest_src_28000.user_id AS user
+                      FROM ***************************.dim_users_latest users_latest_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    subq_11.user = subq_13.user
+                ) subq_14
+              ) subq_15
+              INNER JOIN (
+                -- Add column with generated UUID
+                SELECT
+                  subq_17.ds__day
+                  , subq_17.ds__week
+                  , subq_17.ds__month
+                  , subq_17.ds__quarter
+                  , subq_17.ds__year
+                  , subq_17.ds__extract_year
+                  , subq_17.ds__extract_quarter
+                  , subq_17.ds__extract_month
+                  , subq_17.ds__extract_day
+                  , subq_17.ds__extract_dow
+                  , subq_17.ds__extract_doy
+                  , subq_17.buy__ds__day
+                  , subq_17.buy__ds__week
+                  , subq_17.buy__ds__month
+                  , subq_17.buy__ds__quarter
+                  , subq_17.buy__ds__year
+                  , subq_17.buy__ds__extract_year
+                  , subq_17.buy__ds__extract_quarter
+                  , subq_17.buy__ds__extract_month
+                  , subq_17.buy__ds__extract_day
+                  , subq_17.buy__ds__extract_dow
+                  , subq_17.buy__ds__extract_doy
+                  , subq_17.metric_time__day
+                  , subq_17.metric_time__week
+                  , subq_17.metric_time__month
+                  , subq_17.metric_time__quarter
+                  , subq_17.metric_time__year
+                  , subq_17.metric_time__extract_year
+                  , subq_17.metric_time__extract_quarter
+                  , subq_17.metric_time__extract_month
+                  , subq_17.metric_time__extract_day
+                  , subq_17.metric_time__extract_dow
+                  , subq_17.metric_time__extract_doy
+                  , subq_17.user
+                  , subq_17.session_id
+                  , subq_17.buy__user
+                  , subq_17.buy__session_id
+                  , subq_17.buys
+                  , subq_17.buyers
+                  , uuid() AS mf_internal_uuid
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_16.ds__day
+                    , subq_16.ds__week
+                    , subq_16.ds__month
+                    , subq_16.ds__quarter
+                    , subq_16.ds__year
+                    , subq_16.ds__extract_year
+                    , subq_16.ds__extract_quarter
+                    , subq_16.ds__extract_month
+                    , subq_16.ds__extract_day
+                    , subq_16.ds__extract_dow
+                    , subq_16.ds__extract_doy
+                    , subq_16.buy__ds__day
+                    , subq_16.buy__ds__week
+                    , subq_16.buy__ds__month
+                    , subq_16.buy__ds__quarter
+                    , subq_16.buy__ds__year
+                    , subq_16.buy__ds__extract_year
+                    , subq_16.buy__ds__extract_quarter
+                    , subq_16.buy__ds__extract_month
+                    , subq_16.buy__ds__extract_day
+                    , subq_16.buy__ds__extract_dow
+                    , subq_16.buy__ds__extract_doy
+                    , subq_16.ds__day AS metric_time__day
+                    , subq_16.ds__week AS metric_time__week
+                    , subq_16.ds__month AS metric_time__month
+                    , subq_16.ds__quarter AS metric_time__quarter
+                    , subq_16.ds__year AS metric_time__year
+                    , subq_16.ds__extract_year AS metric_time__extract_year
+                    , subq_16.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_16.ds__extract_month AS metric_time__extract_month
+                    , subq_16.ds__extract_day AS metric_time__extract_day
+                    , subq_16.ds__extract_dow AS metric_time__extract_dow
+                    , subq_16.ds__extract_doy AS metric_time__extract_doy
+                    , subq_16.user
+                    , subq_16.session_id
+                    , subq_16.buy__user
+                    , subq_16.buy__session_id
+                    , subq_16.buys
+                    , subq_16.buyers
+                  FROM (
+                    -- Read Elements From Semantic Model 'buys_source'
+                    SELECT
+                      1 AS buys
+                      , buys_source_src_28000.user_id AS buyers
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM buys_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', buys_source_src_28000.ds) AS buy__ds__day
+                      , DATE_TRUNC('week', buys_source_src_28000.ds) AS buy__ds__week
+                      , DATE_TRUNC('month', buys_source_src_28000.ds) AS buy__ds__month
+                      , DATE_TRUNC('quarter', buys_source_src_28000.ds) AS buy__ds__quarter
+                      , DATE_TRUNC('year', buys_source_src_28000.ds) AS buy__ds__year
+                      , EXTRACT(year FROM buys_source_src_28000.ds) AS buy__ds__extract_year
+                      , EXTRACT(quarter FROM buys_source_src_28000.ds) AS buy__ds__extract_quarter
+                      , EXTRACT(month FROM buys_source_src_28000.ds) AS buy__ds__extract_month
+                      , EXTRACT(day FROM buys_source_src_28000.ds) AS buy__ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM buys_source_src_28000.ds) AS buy__ds__extract_dow
+                      , EXTRACT(doy FROM buys_source_src_28000.ds) AS buy__ds__extract_doy
+                      , buys_source_src_28000.user_id AS user
+                      , buys_source_src_28000.session_id
+                      , buys_source_src_28000.user_id AS buy__user
+                      , buys_source_src_28000.session_id AS buy__session_id
+                    FROM ***************************.fct_buys buys_source_src_28000
+                  ) subq_16
+                ) subq_17
+              ) subq_18
+              ON
+                (
+                  subq_15.user = subq_18.user
+                ) AND (
+                  (
+                    subq_15.ds__day <= subq_18.ds__day
+                  ) AND (
+                    subq_15.ds__day > DATE_ADD('day', -7, subq_18.ds__day)
+                  )
+                )
+            ) subq_19
+          ) subq_20
+        ) subq_21
+        LEFT OUTER JOIN (
+          -- Pass Only Elements: ['home_state_latest', 'user']
+          SELECT
+            subq_22.user
+            , subq_22.home_state_latest
+          FROM (
+            -- Read Elements From Semantic Model 'users_latest'
+            SELECT
+              DATE_TRUNC('day', users_latest_src_28000.ds) AS ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS ds_latest__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest
+              , DATE_TRUNC('day', users_latest_src_28000.ds) AS user__ds_latest__day
+              , DATE_TRUNC('week', users_latest_src_28000.ds) AS user__ds_latest__week
+              , DATE_TRUNC('month', users_latest_src_28000.ds) AS user__ds_latest__month
+              , DATE_TRUNC('quarter', users_latest_src_28000.ds) AS user__ds_latest__quarter
+              , DATE_TRUNC('year', users_latest_src_28000.ds) AS user__ds_latest__year
+              , EXTRACT(year FROM users_latest_src_28000.ds) AS user__ds_latest__extract_year
+              , EXTRACT(quarter FROM users_latest_src_28000.ds) AS user__ds_latest__extract_quarter
+              , EXTRACT(month FROM users_latest_src_28000.ds) AS user__ds_latest__extract_month
+              , EXTRACT(day FROM users_latest_src_28000.ds) AS user__ds_latest__extract_day
+              , EXTRACT(DAY_OF_WEEK FROM users_latest_src_28000.ds) AS user__ds_latest__extract_dow
+              , EXTRACT(doy FROM users_latest_src_28000.ds) AS user__ds_latest__extract_doy
+              , users_latest_src_28000.home_state_latest AS user__home_state_latest
+              , users_latest_src_28000.user_id AS user
+            FROM ***************************.dim_users_latest users_latest_src_28000
+          ) subq_22
+        ) subq_23
+        ON
+          subq_21.user = subq_23.user
+      ) subq_24
+    ) subq_25
+    GROUP BY
+      subq_25.metric_time__day
+      , subq_25.user__home_state_latest
+  ) subq_26
+  ON
+    (
+      subq_9.user__home_state_latest = subq_26.user__home_state_latest
+    ) AND (
+      subq_9.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_9.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_9.user__home_state_latest, subq_26.user__home_state_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -1,0 +1,175 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , user__home_state_latest
+  , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest) AS user__home_state_latest
+    , MAX(subq_37.visits) AS visits
+    , MAX(subq_54.buys) AS buys
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_31.visits) AS visits
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      SELECT
+        metric_time__day
+        , subq_29.user
+        , visits
+      FROM (
+        -- Read Elements From Semantic Model 'visits_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , user_id AS user
+          , referrer_id AS visit__referrer_id
+          , 1 AS visits
+        FROM ***************************.fct_visits visits_source_src_28000
+      ) subq_29
+      WHERE visit__referrer_id = '123456'
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_31.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_31.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_37
+  FULL OUTER JOIN (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      subq_47.metric_time__day AS metric_time__day
+      , users_latest_src_28000.home_state_latest AS user__home_state_latest
+      , SUM(subq_47.buys) AS buys
+    FROM (
+      -- Dedupe the fanout with mf_internal_uuid in the conversion data set
+      SELECT DISTINCT
+        FIRST_VALUE(subq_43.visits) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visits
+        , FIRST_VALUE(subq_43.visit__referrer_id) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS visit__referrer_id
+        , FIRST_VALUE(subq_43.user__home_state_latest) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user__home_state_latest
+        , FIRST_VALUE(subq_43.ds__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS ds__day
+        , FIRST_VALUE(subq_43.metric_time__day) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS metric_time__day
+        , FIRST_VALUE(subq_43.user) OVER (
+          PARTITION BY
+            subq_46.user
+            , subq_46.ds__day
+            , subq_46.mf_internal_uuid
+          ORDER BY subq_43.ds__day DESC
+          ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+        ) AS user
+        , subq_46.mf_internal_uuid AS mf_internal_uuid
+        , subq_46.buys AS buys
+      FROM (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', 'ds__day', 'metric_time__day', 'user']
+        SELECT
+          subq_39.ds__day AS ds__day
+          , subq_39.metric_time__day AS metric_time__day
+          , subq_39.user AS user
+          , subq_39.visit__referrer_id AS visit__referrer_id
+          , users_latest_src_28000.home_state_latest AS user__home_state_latest
+          , subq_39.visits AS visits
+        FROM (
+          -- Read Elements From Semantic Model 'visits_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS ds__day
+            , DATE_TRUNC('day', ds) AS metric_time__day
+            , user_id AS user
+            , referrer_id AS visit__referrer_id
+            , 1 AS visits
+          FROM ***************************.fct_visits visits_source_src_28000
+        ) subq_39
+        LEFT OUTER JOIN
+          ***************************.dim_users_latest users_latest_src_28000
+        ON
+          subq_39.user = users_latest_src_28000.user_id
+      ) subq_43
+      INNER JOIN (
+        -- Read Elements From Semantic Model 'buys_source'
+        -- Metric Time Dimension 'ds'
+        -- Add column with generated UUID
+        SELECT
+          DATE_TRUNC('day', ds) AS ds__day
+          , user_id AS user
+          , 1 AS buys
+          , uuid() AS mf_internal_uuid
+        FROM ***************************.fct_buys buys_source_src_28000
+      ) subq_46
+      ON
+        (
+          subq_43.user = subq_46.user
+        ) AND (
+          (
+            subq_43.ds__day <= subq_46.ds__day
+          ) AND (
+            subq_43.ds__day > DATE_ADD('day', -7, subq_46.ds__day)
+          )
+        )
+    ) subq_47
+    LEFT OUTER JOIN
+      ***************************.dim_users_latest users_latest_src_28000
+    ON
+      subq_47.user = users_latest_src_28000.user_id
+    GROUP BY
+      subq_47.metric_time__day
+      , users_latest_src_28000.home_state_latest
+  ) subq_54
+  ON
+    (
+      subq_37.user__home_state_latest = subq_54.user__home_state_latest
+    ) AND (
+      subq_37.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_37.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_37.user__home_state_latest, subq_54.user__home_state_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,505 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_13.metric_time__day
+  , subq_13.listing__country_latest
+  , subq_13.bookers AS every_two_days_bookers
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+    , COUNT(DISTINCT subq_12.bookers) AS bookers
+  FROM (
+    -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+    SELECT
+      subq_11.metric_time__day
+      , subq_11.listing__country_latest
+      , subq_11.bookers
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_10.metric_time__day
+        , subq_10.booking__is_instant
+        , subq_10.listing__country_latest
+        , subq_10.bookers
+      FROM (
+        -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.booking__is_instant
+          , subq_9.listing__country_latest
+          , subq_9.bookers
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_5.metric_time__day AS metric_time__day
+            , subq_5.listing AS listing
+            , subq_5.booking__is_instant AS booking__is_instant
+            , subq_8.country_latest AS listing__country_latest
+            , subq_5.bookers AS bookers
+          FROM (
+            -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_4.metric_time__day
+              , subq_4.listing
+              , subq_4.booking__is_instant
+              , subq_4.bookers
+            FROM (
+              -- Join Self Over Time Range
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_1.ds__day AS ds__day
+                , subq_1.ds__week AS ds__week
+                , subq_1.ds__month AS ds__month
+                , subq_1.ds__quarter AS ds__quarter
+                , subq_1.ds__year AS ds__year
+                , subq_1.ds__extract_year AS ds__extract_year
+                , subq_1.ds__extract_quarter AS ds__extract_quarter
+                , subq_1.ds__extract_month AS ds__extract_month
+                , subq_1.ds__extract_day AS ds__extract_day
+                , subq_1.ds__extract_dow AS ds__extract_dow
+                , subq_1.ds__extract_doy AS ds__extract_doy
+                , subq_1.ds_partitioned__day AS ds_partitioned__day
+                , subq_1.ds_partitioned__week AS ds_partitioned__week
+                , subq_1.ds_partitioned__month AS ds_partitioned__month
+                , subq_1.ds_partitioned__quarter AS ds_partitioned__quarter
+                , subq_1.ds_partitioned__year AS ds_partitioned__year
+                , subq_1.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                , subq_1.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                , subq_1.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                , subq_1.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                , subq_1.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                , subq_1.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                , subq_1.paid_at__day AS paid_at__day
+                , subq_1.paid_at__week AS paid_at__week
+                , subq_1.paid_at__month AS paid_at__month
+                , subq_1.paid_at__quarter AS paid_at__quarter
+                , subq_1.paid_at__year AS paid_at__year
+                , subq_1.paid_at__extract_year AS paid_at__extract_year
+                , subq_1.paid_at__extract_quarter AS paid_at__extract_quarter
+                , subq_1.paid_at__extract_month AS paid_at__extract_month
+                , subq_1.paid_at__extract_day AS paid_at__extract_day
+                , subq_1.paid_at__extract_dow AS paid_at__extract_dow
+                , subq_1.paid_at__extract_doy AS paid_at__extract_doy
+                , subq_1.booking__ds__day AS booking__ds__day
+                , subq_1.booking__ds__week AS booking__ds__week
+                , subq_1.booking__ds__month AS booking__ds__month
+                , subq_1.booking__ds__quarter AS booking__ds__quarter
+                , subq_1.booking__ds__year AS booking__ds__year
+                , subq_1.booking__ds__extract_year AS booking__ds__extract_year
+                , subq_1.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                , subq_1.booking__ds__extract_month AS booking__ds__extract_month
+                , subq_1.booking__ds__extract_day AS booking__ds__extract_day
+                , subq_1.booking__ds__extract_dow AS booking__ds__extract_dow
+                , subq_1.booking__ds__extract_doy AS booking__ds__extract_doy
+                , subq_1.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                , subq_1.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                , subq_1.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                , subq_1.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                , subq_1.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                , subq_1.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                , subq_1.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                , subq_1.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                , subq_1.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                , subq_1.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                , subq_1.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                , subq_1.booking__paid_at__day AS booking__paid_at__day
+                , subq_1.booking__paid_at__week AS booking__paid_at__week
+                , subq_1.booking__paid_at__month AS booking__paid_at__month
+                , subq_1.booking__paid_at__quarter AS booking__paid_at__quarter
+                , subq_1.booking__paid_at__year AS booking__paid_at__year
+                , subq_1.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                , subq_1.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                , subq_1.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                , subq_1.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                , subq_1.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                , subq_1.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                , subq_1.metric_time__week AS metric_time__week
+                , subq_1.metric_time__month AS metric_time__month
+                , subq_1.metric_time__quarter AS metric_time__quarter
+                , subq_1.metric_time__year AS metric_time__year
+                , subq_1.metric_time__extract_year AS metric_time__extract_year
+                , subq_1.metric_time__extract_quarter AS metric_time__extract_quarter
+                , subq_1.metric_time__extract_month AS metric_time__extract_month
+                , subq_1.metric_time__extract_day AS metric_time__extract_day
+                , subq_1.metric_time__extract_dow AS metric_time__extract_dow
+                , subq_1.metric_time__extract_doy AS metric_time__extract_doy
+                , subq_1.listing AS listing
+                , subq_1.guest AS guest
+                , subq_1.host AS host
+                , subq_1.booking__listing AS booking__listing
+                , subq_1.booking__guest AS booking__guest
+                , subq_1.booking__host AS booking__host
+                , subq_1.is_instant AS is_instant
+                , subq_1.booking__is_instant AS booking__is_instant
+                , subq_1.bookings AS bookings
+                , subq_1.instant_bookings AS instant_bookings
+                , subq_1.booking_value AS booking_value
+                , subq_1.max_booking_value AS max_booking_value
+                , subq_1.min_booking_value AS min_booking_value
+                , subq_1.bookers AS bookers
+                , subq_1.average_booking_value AS average_booking_value
+                , subq_1.referred_bookings AS referred_bookings
+                , subq_1.median_booking_value AS median_booking_value
+                , subq_1.booking_value_p99 AS booking_value_p99
+                , subq_1.discrete_booking_value_p99 AS discrete_booking_value_p99
+                , subq_1.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                , subq_1.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+              FROM (
+                -- Time Spine
+                SELECT
+                  subq_3.ds AS metric_time__day
+                FROM ***************************.mf_time_spine subq_3
+              ) subq_2
+              INNER JOIN (
+                -- Metric Time Dimension 'ds'
+                SELECT
+                  subq_0.ds__day
+                  , subq_0.ds__week
+                  , subq_0.ds__month
+                  , subq_0.ds__quarter
+                  , subq_0.ds__year
+                  , subq_0.ds__extract_year
+                  , subq_0.ds__extract_quarter
+                  , subq_0.ds__extract_month
+                  , subq_0.ds__extract_day
+                  , subq_0.ds__extract_dow
+                  , subq_0.ds__extract_doy
+                  , subq_0.ds_partitioned__day
+                  , subq_0.ds_partitioned__week
+                  , subq_0.ds_partitioned__month
+                  , subq_0.ds_partitioned__quarter
+                  , subq_0.ds_partitioned__year
+                  , subq_0.ds_partitioned__extract_year
+                  , subq_0.ds_partitioned__extract_quarter
+                  , subq_0.ds_partitioned__extract_month
+                  , subq_0.ds_partitioned__extract_day
+                  , subq_0.ds_partitioned__extract_dow
+                  , subq_0.ds_partitioned__extract_doy
+                  , subq_0.paid_at__day
+                  , subq_0.paid_at__week
+                  , subq_0.paid_at__month
+                  , subq_0.paid_at__quarter
+                  , subq_0.paid_at__year
+                  , subq_0.paid_at__extract_year
+                  , subq_0.paid_at__extract_quarter
+                  , subq_0.paid_at__extract_month
+                  , subq_0.paid_at__extract_day
+                  , subq_0.paid_at__extract_dow
+                  , subq_0.paid_at__extract_doy
+                  , subq_0.booking__ds__day
+                  , subq_0.booking__ds__week
+                  , subq_0.booking__ds__month
+                  , subq_0.booking__ds__quarter
+                  , subq_0.booking__ds__year
+                  , subq_0.booking__ds__extract_year
+                  , subq_0.booking__ds__extract_quarter
+                  , subq_0.booking__ds__extract_month
+                  , subq_0.booking__ds__extract_day
+                  , subq_0.booking__ds__extract_dow
+                  , subq_0.booking__ds__extract_doy
+                  , subq_0.booking__ds_partitioned__day
+                  , subq_0.booking__ds_partitioned__week
+                  , subq_0.booking__ds_partitioned__month
+                  , subq_0.booking__ds_partitioned__quarter
+                  , subq_0.booking__ds_partitioned__year
+                  , subq_0.booking__ds_partitioned__extract_year
+                  , subq_0.booking__ds_partitioned__extract_quarter
+                  , subq_0.booking__ds_partitioned__extract_month
+                  , subq_0.booking__ds_partitioned__extract_day
+                  , subq_0.booking__ds_partitioned__extract_dow
+                  , subq_0.booking__ds_partitioned__extract_doy
+                  , subq_0.booking__paid_at__day
+                  , subq_0.booking__paid_at__week
+                  , subq_0.booking__paid_at__month
+                  , subq_0.booking__paid_at__quarter
+                  , subq_0.booking__paid_at__year
+                  , subq_0.booking__paid_at__extract_year
+                  , subq_0.booking__paid_at__extract_quarter
+                  , subq_0.booking__paid_at__extract_month
+                  , subq_0.booking__paid_at__extract_day
+                  , subq_0.booking__paid_at__extract_dow
+                  , subq_0.booking__paid_at__extract_doy
+                  , subq_0.ds__day AS metric_time__day
+                  , subq_0.ds__week AS metric_time__week
+                  , subq_0.ds__month AS metric_time__month
+                  , subq_0.ds__quarter AS metric_time__quarter
+                  , subq_0.ds__year AS metric_time__year
+                  , subq_0.ds__extract_year AS metric_time__extract_year
+                  , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                  , subq_0.ds__extract_month AS metric_time__extract_month
+                  , subq_0.ds__extract_day AS metric_time__extract_day
+                  , subq_0.ds__extract_dow AS metric_time__extract_dow
+                  , subq_0.ds__extract_doy AS metric_time__extract_doy
+                  , subq_0.listing
+                  , subq_0.guest
+                  , subq_0.host
+                  , subq_0.booking__listing
+                  , subq_0.booking__guest
+                  , subq_0.booking__host
+                  , subq_0.is_instant
+                  , subq_0.booking__is_instant
+                  , subq_0.bookings
+                  , subq_0.instant_bookings
+                  , subq_0.booking_value
+                  , subq_0.max_booking_value
+                  , subq_0.min_booking_value
+                  , subq_0.bookers
+                  , subq_0.average_booking_value
+                  , subq_0.referred_bookings
+                  , subq_0.median_booking_value
+                  , subq_0.booking_value_p99
+                  , subq_0.discrete_booking_value_p99
+                  , subq_0.approximate_continuous_booking_value_p99
+                  , subq_0.approximate_discrete_booking_value_p99
+                FROM (
+                  -- Read Elements From Semantic Model 'bookings_source'
+                  SELECT
+                    1 AS bookings
+                    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                    , bookings_source_src_28000.booking_value
+                    , bookings_source_src_28000.booking_value AS max_booking_value
+                    , bookings_source_src_28000.booking_value AS min_booking_value
+                    , bookings_source_src_28000.guest_id AS bookers
+                    , bookings_source_src_28000.booking_value AS average_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_payments
+                    , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                    , bookings_source_src_28000.booking_value AS median_booking_value
+                    , bookings_source_src_28000.booking_value AS booking_value_p99
+                    , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                    , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                    , bookings_source_src_28000.is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                    , bookings_source_src_28000.is_instant AS booking__is_instant
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                    , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                    , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                    , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                    , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                    , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                    , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                    , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                    , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                    , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                    , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                    , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                    , bookings_source_src_28000.listing_id AS listing
+                    , bookings_source_src_28000.guest_id AS guest
+                    , bookings_source_src_28000.host_id AS host
+                    , bookings_source_src_28000.listing_id AS booking__listing
+                    , bookings_source_src_28000.guest_id AS booking__guest
+                    , bookings_source_src_28000.host_id AS booking__host
+                  FROM ***************************.fct_bookings bookings_source_src_28000
+                ) subq_0
+              ) subq_1
+              ON
+                (
+                  subq_1.metric_time__day <= subq_2.metric_time__day
+                ) AND (
+                  subq_1.metric_time__day > DATE_ADD('day', -2, subq_2.metric_time__day)
+                )
+            ) subq_4
+          ) subq_5
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_7.listing
+              , subq_7.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_6.ds__day
+                , subq_6.ds__week
+                , subq_6.ds__month
+                , subq_6.ds__quarter
+                , subq_6.ds__year
+                , subq_6.ds__extract_year
+                , subq_6.ds__extract_quarter
+                , subq_6.ds__extract_month
+                , subq_6.ds__extract_day
+                , subq_6.ds__extract_dow
+                , subq_6.ds__extract_doy
+                , subq_6.created_at__day
+                , subq_6.created_at__week
+                , subq_6.created_at__month
+                , subq_6.created_at__quarter
+                , subq_6.created_at__year
+                , subq_6.created_at__extract_year
+                , subq_6.created_at__extract_quarter
+                , subq_6.created_at__extract_month
+                , subq_6.created_at__extract_day
+                , subq_6.created_at__extract_dow
+                , subq_6.created_at__extract_doy
+                , subq_6.listing__ds__day
+                , subq_6.listing__ds__week
+                , subq_6.listing__ds__month
+                , subq_6.listing__ds__quarter
+                , subq_6.listing__ds__year
+                , subq_6.listing__ds__extract_year
+                , subq_6.listing__ds__extract_quarter
+                , subq_6.listing__ds__extract_month
+                , subq_6.listing__ds__extract_day
+                , subq_6.listing__ds__extract_dow
+                , subq_6.listing__ds__extract_doy
+                , subq_6.listing__created_at__day
+                , subq_6.listing__created_at__week
+                , subq_6.listing__created_at__month
+                , subq_6.listing__created_at__quarter
+                , subq_6.listing__created_at__year
+                , subq_6.listing__created_at__extract_year
+                , subq_6.listing__created_at__extract_quarter
+                , subq_6.listing__created_at__extract_month
+                , subq_6.listing__created_at__extract_day
+                , subq_6.listing__created_at__extract_dow
+                , subq_6.listing__created_at__extract_doy
+                , subq_6.ds__day AS metric_time__day
+                , subq_6.ds__week AS metric_time__week
+                , subq_6.ds__month AS metric_time__month
+                , subq_6.ds__quarter AS metric_time__quarter
+                , subq_6.ds__year AS metric_time__year
+                , subq_6.ds__extract_year AS metric_time__extract_year
+                , subq_6.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_6.ds__extract_month AS metric_time__extract_month
+                , subq_6.ds__extract_day AS metric_time__extract_day
+                , subq_6.ds__extract_dow AS metric_time__extract_dow
+                , subq_6.ds__extract_doy AS metric_time__extract_doy
+                , subq_6.listing
+                , subq_6.user
+                , subq_6.listing__user
+                , subq_6.country_latest
+                , subq_6.is_lux_latest
+                , subq_6.capacity_latest
+                , subq_6.listing__country_latest
+                , subq_6.listing__is_lux_latest
+                , subq_6.listing__capacity_latest
+                , subq_6.listings
+                , subq_6.largest_listing
+                , subq_6.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_6
+            ) subq_7
+          ) subq_8
+          ON
+            subq_5.listing = subq_8.listing
+        ) subq_9
+      ) subq_10
+      WHERE booking__is_instant
+    ) subq_11
+  ) subq_12
+  GROUP BY
+    subq_12.metric_time__day
+    , subq_12.listing__country_latest
+) subq_13

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,49 @@
+-- Join Standard Outputs
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  subq_20.metric_time__day AS metric_time__day
+  , listings_latest_src_28000.country AS listing__country_latest
+  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+FROM (
+  -- Join Self Over Time Range
+  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  SELECT
+    subq_18.ds AS metric_time__day
+    , subq_16.listing AS listing
+    , subq_16.bookers AS bookers
+  FROM ***************************.mf_time_spine subq_18
+  INNER JOIN (
+    -- Constrain Output with WHERE
+    SELECT
+      metric_time__day
+      , listing
+      , bookers
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , listing_id AS listing
+        , is_instant AS booking__is_instant
+        , guest_id AS bookers
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_15
+    WHERE booking__is_instant
+  ) subq_16
+  ON
+    (
+      subq_16.metric_time__day <= subq_18.ds
+    ) AND (
+      subq_16.metric_time__day > DATE_ADD('day', -2, subq_18.ds)
+    )
+) subq_20
+LEFT OUTER JOIN
+  ***************************.dim_listings_latest listings_latest_src_28000
+ON
+  subq_20.listing = listings_latest_src_28000.listing_id
+GROUP BY
+  subq_20.metric_time__day
+  , listings_latest_src_28000.country

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -1,0 +1,948 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_33.metric_time__day
+  , subq_33.listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day) AS metric_time__day
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_14.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_32.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_13.metric_time__day
+      , subq_13.listing__country_latest
+      , COALESCE(subq_13.bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_11.metric_time__day AS metric_time__day
+        , subq_10.listing__country_latest AS listing__country_latest
+        , subq_10.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_12.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_12
+      ) subq_11
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+          , SUM(subq_9.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_8.metric_time__day
+            , subq_8.listing__country_latest
+            , subq_8.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_7.metric_time__day
+              , subq_7.booking__is_instant
+              , subq_7.listing__country_latest
+              , subq_7.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_6.metric_time__day
+                , subq_6.booking__is_instant
+                , subq_6.listing__country_latest
+                , subq_6.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_2.metric_time__day AS metric_time__day
+                  , subq_2.listing AS listing
+                  , subq_2.booking__is_instant AS booking__is_instant
+                  , subq_5.country_latest AS listing__country_latest
+                  , subq_2.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_1.metric_time__day
+                    , subq_1.listing
+                    , subq_1.booking__is_instant
+                    , subq_1.bookings
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_0.ds__day
+                      , subq_0.ds__week
+                      , subq_0.ds__month
+                      , subq_0.ds__quarter
+                      , subq_0.ds__year
+                      , subq_0.ds__extract_year
+                      , subq_0.ds__extract_quarter
+                      , subq_0.ds__extract_month
+                      , subq_0.ds__extract_day
+                      , subq_0.ds__extract_dow
+                      , subq_0.ds__extract_doy
+                      , subq_0.ds_partitioned__day
+                      , subq_0.ds_partitioned__week
+                      , subq_0.ds_partitioned__month
+                      , subq_0.ds_partitioned__quarter
+                      , subq_0.ds_partitioned__year
+                      , subq_0.ds_partitioned__extract_year
+                      , subq_0.ds_partitioned__extract_quarter
+                      , subq_0.ds_partitioned__extract_month
+                      , subq_0.ds_partitioned__extract_day
+                      , subq_0.ds_partitioned__extract_dow
+                      , subq_0.ds_partitioned__extract_doy
+                      , subq_0.paid_at__day
+                      , subq_0.paid_at__week
+                      , subq_0.paid_at__month
+                      , subq_0.paid_at__quarter
+                      , subq_0.paid_at__year
+                      , subq_0.paid_at__extract_year
+                      , subq_0.paid_at__extract_quarter
+                      , subq_0.paid_at__extract_month
+                      , subq_0.paid_at__extract_day
+                      , subq_0.paid_at__extract_dow
+                      , subq_0.paid_at__extract_doy
+                      , subq_0.booking__ds__day
+                      , subq_0.booking__ds__week
+                      , subq_0.booking__ds__month
+                      , subq_0.booking__ds__quarter
+                      , subq_0.booking__ds__year
+                      , subq_0.booking__ds__extract_year
+                      , subq_0.booking__ds__extract_quarter
+                      , subq_0.booking__ds__extract_month
+                      , subq_0.booking__ds__extract_day
+                      , subq_0.booking__ds__extract_dow
+                      , subq_0.booking__ds__extract_doy
+                      , subq_0.booking__ds_partitioned__day
+                      , subq_0.booking__ds_partitioned__week
+                      , subq_0.booking__ds_partitioned__month
+                      , subq_0.booking__ds_partitioned__quarter
+                      , subq_0.booking__ds_partitioned__year
+                      , subq_0.booking__ds_partitioned__extract_year
+                      , subq_0.booking__ds_partitioned__extract_quarter
+                      , subq_0.booking__ds_partitioned__extract_month
+                      , subq_0.booking__ds_partitioned__extract_day
+                      , subq_0.booking__ds_partitioned__extract_dow
+                      , subq_0.booking__ds_partitioned__extract_doy
+                      , subq_0.booking__paid_at__day
+                      , subq_0.booking__paid_at__week
+                      , subq_0.booking__paid_at__month
+                      , subq_0.booking__paid_at__quarter
+                      , subq_0.booking__paid_at__year
+                      , subq_0.booking__paid_at__extract_year
+                      , subq_0.booking__paid_at__extract_quarter
+                      , subq_0.booking__paid_at__extract_month
+                      , subq_0.booking__paid_at__extract_day
+                      , subq_0.booking__paid_at__extract_dow
+                      , subq_0.booking__paid_at__extract_doy
+                      , subq_0.ds__day AS metric_time__day
+                      , subq_0.ds__week AS metric_time__week
+                      , subq_0.ds__month AS metric_time__month
+                      , subq_0.ds__quarter AS metric_time__quarter
+                      , subq_0.ds__year AS metric_time__year
+                      , subq_0.ds__extract_year AS metric_time__extract_year
+                      , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_0.ds__extract_month AS metric_time__extract_month
+                      , subq_0.ds__extract_day AS metric_time__extract_day
+                      , subq_0.ds__extract_dow AS metric_time__extract_dow
+                      , subq_0.ds__extract_doy AS metric_time__extract_doy
+                      , subq_0.listing
+                      , subq_0.guest
+                      , subq_0.host
+                      , subq_0.booking__listing
+                      , subq_0.booking__guest
+                      , subq_0.booking__host
+                      , subq_0.is_instant
+                      , subq_0.booking__is_instant
+                      , subq_0.bookings
+                      , subq_0.instant_bookings
+                      , subq_0.booking_value
+                      , subq_0.max_booking_value
+                      , subq_0.min_booking_value
+                      , subq_0.bookers
+                      , subq_0.average_booking_value
+                      , subq_0.referred_bookings
+                      , subq_0.median_booking_value
+                      , subq_0.booking_value_p99
+                      , subq_0.discrete_booking_value_p99
+                      , subq_0.approximate_continuous_booking_value_p99
+                      , subq_0.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_0
+                  ) subq_1
+                ) subq_2
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_4.listing
+                    , subq_4.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_3.ds__day
+                      , subq_3.ds__week
+                      , subq_3.ds__month
+                      , subq_3.ds__quarter
+                      , subq_3.ds__year
+                      , subq_3.ds__extract_year
+                      , subq_3.ds__extract_quarter
+                      , subq_3.ds__extract_month
+                      , subq_3.ds__extract_day
+                      , subq_3.ds__extract_dow
+                      , subq_3.ds__extract_doy
+                      , subq_3.created_at__day
+                      , subq_3.created_at__week
+                      , subq_3.created_at__month
+                      , subq_3.created_at__quarter
+                      , subq_3.created_at__year
+                      , subq_3.created_at__extract_year
+                      , subq_3.created_at__extract_quarter
+                      , subq_3.created_at__extract_month
+                      , subq_3.created_at__extract_day
+                      , subq_3.created_at__extract_dow
+                      , subq_3.created_at__extract_doy
+                      , subq_3.listing__ds__day
+                      , subq_3.listing__ds__week
+                      , subq_3.listing__ds__month
+                      , subq_3.listing__ds__quarter
+                      , subq_3.listing__ds__year
+                      , subq_3.listing__ds__extract_year
+                      , subq_3.listing__ds__extract_quarter
+                      , subq_3.listing__ds__extract_month
+                      , subq_3.listing__ds__extract_day
+                      , subq_3.listing__ds__extract_dow
+                      , subq_3.listing__ds__extract_doy
+                      , subq_3.listing__created_at__day
+                      , subq_3.listing__created_at__week
+                      , subq_3.listing__created_at__month
+                      , subq_3.listing__created_at__quarter
+                      , subq_3.listing__created_at__year
+                      , subq_3.listing__created_at__extract_year
+                      , subq_3.listing__created_at__extract_quarter
+                      , subq_3.listing__created_at__extract_month
+                      , subq_3.listing__created_at__extract_day
+                      , subq_3.listing__created_at__extract_dow
+                      , subq_3.listing__created_at__extract_doy
+                      , subq_3.ds__day AS metric_time__day
+                      , subq_3.ds__week AS metric_time__week
+                      , subq_3.ds__month AS metric_time__month
+                      , subq_3.ds__quarter AS metric_time__quarter
+                      , subq_3.ds__year AS metric_time__year
+                      , subq_3.ds__extract_year AS metric_time__extract_year
+                      , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_3.ds__extract_month AS metric_time__extract_month
+                      , subq_3.ds__extract_day AS metric_time__extract_day
+                      , subq_3.ds__extract_dow AS metric_time__extract_dow
+                      , subq_3.ds__extract_doy AS metric_time__extract_doy
+                      , subq_3.listing
+                      , subq_3.user
+                      , subq_3.listing__user
+                      , subq_3.country_latest
+                      , subq_3.is_lux_latest
+                      , subq_3.capacity_latest
+                      , subq_3.listing__country_latest
+                      , subq_3.listing__is_lux_latest
+                      , subq_3.listing__capacity_latest
+                      , subq_3.listings
+                      , subq_3.largest_listing
+                      , subq_3.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_3
+                  ) subq_4
+                ) subq_5
+                ON
+                  subq_2.listing = subq_5.listing
+              ) subq_6
+            ) subq_7
+            WHERE booking__is_instant
+          ) subq_8
+        ) subq_9
+        GROUP BY
+          subq_9.metric_time__day
+          , subq_9.listing__country_latest
+      ) subq_10
+      ON
+        subq_11.metric_time__day = subq_10.metric_time__day
+    ) subq_13
+  ) subq_14
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day
+      , subq_31.listing__country_latest
+      , COALESCE(subq_31.bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_29.metric_time__day AS metric_time__day
+        , subq_28.listing__country_latest AS listing__country_latest
+        , subq_28.bookings AS bookings
+      FROM (
+        -- Time Spine
+        SELECT
+          subq_30.ds AS metric_time__day
+        FROM ***************************.mf_time_spine subq_30
+      ) subq_29
+      LEFT OUTER JOIN (
+        -- Aggregate Measures
+        SELECT
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+          , SUM(subq_27.bookings) AS bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+          SELECT
+            subq_26.metric_time__day
+            , subq_26.listing__country_latest
+            , subq_26.bookings
+          FROM (
+            -- Constrain Output with WHERE
+            SELECT
+              subq_25.metric_time__day
+              , subq_25.booking__is_instant
+              , subq_25.listing__country_latest
+              , subq_25.bookings
+            FROM (
+              -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+              SELECT
+                subq_24.metric_time__day
+                , subq_24.booking__is_instant
+                , subq_24.listing__country_latest
+                , subq_24.bookings
+              FROM (
+                -- Join Standard Outputs
+                SELECT
+                  subq_20.metric_time__day AS metric_time__day
+                  , subq_20.listing AS listing
+                  , subq_20.booking__is_instant AS booking__is_instant
+                  , subq_23.country_latest AS listing__country_latest
+                  , subq_20.bookings AS bookings
+                FROM (
+                  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                  SELECT
+                    subq_19.metric_time__day
+                    , subq_19.listing
+                    , subq_19.booking__is_instant
+                    , subq_19.bookings
+                  FROM (
+                    -- Join to Time Spine Dataset
+                    SELECT
+                      subq_17.metric_time__day AS metric_time__day
+                      , DATE_TRUNC('week', subq_17.metric_time__day) AS metric_time__week
+                      , DATE_TRUNC('month', subq_17.metric_time__day) AS metric_time__month
+                      , DATE_TRUNC('quarter', subq_17.metric_time__day) AS metric_time__quarter
+                      , DATE_TRUNC('year', subq_17.metric_time__day) AS metric_time__year
+                      , EXTRACT(year FROM subq_17.metric_time__day) AS metric_time__extract_year
+                      , EXTRACT(quarter FROM subq_17.metric_time__day) AS metric_time__extract_quarter
+                      , EXTRACT(month FROM subq_17.metric_time__day) AS metric_time__extract_month
+                      , EXTRACT(day FROM subq_17.metric_time__day) AS metric_time__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM subq_17.metric_time__day) AS metric_time__extract_dow
+                      , EXTRACT(doy FROM subq_17.metric_time__day) AS metric_time__extract_doy
+                      , subq_16.ds__day AS ds__day
+                      , subq_16.ds__week AS ds__week
+                      , subq_16.ds__month AS ds__month
+                      , subq_16.ds__quarter AS ds__quarter
+                      , subq_16.ds__year AS ds__year
+                      , subq_16.ds__extract_year AS ds__extract_year
+                      , subq_16.ds__extract_quarter AS ds__extract_quarter
+                      , subq_16.ds__extract_month AS ds__extract_month
+                      , subq_16.ds__extract_day AS ds__extract_day
+                      , subq_16.ds__extract_dow AS ds__extract_dow
+                      , subq_16.ds__extract_doy AS ds__extract_doy
+                      , subq_16.ds_partitioned__day AS ds_partitioned__day
+                      , subq_16.ds_partitioned__week AS ds_partitioned__week
+                      , subq_16.ds_partitioned__month AS ds_partitioned__month
+                      , subq_16.ds_partitioned__quarter AS ds_partitioned__quarter
+                      , subq_16.ds_partitioned__year AS ds_partitioned__year
+                      , subq_16.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                      , subq_16.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                      , subq_16.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                      , subq_16.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                      , subq_16.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                      , subq_16.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                      , subq_16.paid_at__day AS paid_at__day
+                      , subq_16.paid_at__week AS paid_at__week
+                      , subq_16.paid_at__month AS paid_at__month
+                      , subq_16.paid_at__quarter AS paid_at__quarter
+                      , subq_16.paid_at__year AS paid_at__year
+                      , subq_16.paid_at__extract_year AS paid_at__extract_year
+                      , subq_16.paid_at__extract_quarter AS paid_at__extract_quarter
+                      , subq_16.paid_at__extract_month AS paid_at__extract_month
+                      , subq_16.paid_at__extract_day AS paid_at__extract_day
+                      , subq_16.paid_at__extract_dow AS paid_at__extract_dow
+                      , subq_16.paid_at__extract_doy AS paid_at__extract_doy
+                      , subq_16.booking__ds__day AS booking__ds__day
+                      , subq_16.booking__ds__week AS booking__ds__week
+                      , subq_16.booking__ds__month AS booking__ds__month
+                      , subq_16.booking__ds__quarter AS booking__ds__quarter
+                      , subq_16.booking__ds__year AS booking__ds__year
+                      , subq_16.booking__ds__extract_year AS booking__ds__extract_year
+                      , subq_16.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                      , subq_16.booking__ds__extract_month AS booking__ds__extract_month
+                      , subq_16.booking__ds__extract_day AS booking__ds__extract_day
+                      , subq_16.booking__ds__extract_dow AS booking__ds__extract_dow
+                      , subq_16.booking__ds__extract_doy AS booking__ds__extract_doy
+                      , subq_16.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                      , subq_16.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                      , subq_16.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                      , subq_16.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                      , subq_16.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                      , subq_16.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                      , subq_16.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                      , subq_16.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                      , subq_16.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                      , subq_16.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                      , subq_16.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                      , subq_16.booking__paid_at__day AS booking__paid_at__day
+                      , subq_16.booking__paid_at__week AS booking__paid_at__week
+                      , subq_16.booking__paid_at__month AS booking__paid_at__month
+                      , subq_16.booking__paid_at__quarter AS booking__paid_at__quarter
+                      , subq_16.booking__paid_at__year AS booking__paid_at__year
+                      , subq_16.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                      , subq_16.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                      , subq_16.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                      , subq_16.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                      , subq_16.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                      , subq_16.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                      , subq_16.listing AS listing
+                      , subq_16.guest AS guest
+                      , subq_16.host AS host
+                      , subq_16.booking__listing AS booking__listing
+                      , subq_16.booking__guest AS booking__guest
+                      , subq_16.booking__host AS booking__host
+                      , subq_16.is_instant AS is_instant
+                      , subq_16.booking__is_instant AS booking__is_instant
+                      , subq_16.bookings AS bookings
+                      , subq_16.instant_bookings AS instant_bookings
+                      , subq_16.booking_value AS booking_value
+                      , subq_16.max_booking_value AS max_booking_value
+                      , subq_16.min_booking_value AS min_booking_value
+                      , subq_16.bookers AS bookers
+                      , subq_16.average_booking_value AS average_booking_value
+                      , subq_16.referred_bookings AS referred_bookings
+                      , subq_16.median_booking_value AS median_booking_value
+                      , subq_16.booking_value_p99 AS booking_value_p99
+                      , subq_16.discrete_booking_value_p99 AS discrete_booking_value_p99
+                      , subq_16.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                      , subq_16.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Time Spine
+                      SELECT
+                        subq_18.ds AS metric_time__day
+                      FROM ***************************.mf_time_spine subq_18
+                    ) subq_17
+                    INNER JOIN (
+                      -- Metric Time Dimension 'ds'
+                      SELECT
+                        subq_15.ds__day
+                        , subq_15.ds__week
+                        , subq_15.ds__month
+                        , subq_15.ds__quarter
+                        , subq_15.ds__year
+                        , subq_15.ds__extract_year
+                        , subq_15.ds__extract_quarter
+                        , subq_15.ds__extract_month
+                        , subq_15.ds__extract_day
+                        , subq_15.ds__extract_dow
+                        , subq_15.ds__extract_doy
+                        , subq_15.ds_partitioned__day
+                        , subq_15.ds_partitioned__week
+                        , subq_15.ds_partitioned__month
+                        , subq_15.ds_partitioned__quarter
+                        , subq_15.ds_partitioned__year
+                        , subq_15.ds_partitioned__extract_year
+                        , subq_15.ds_partitioned__extract_quarter
+                        , subq_15.ds_partitioned__extract_month
+                        , subq_15.ds_partitioned__extract_day
+                        , subq_15.ds_partitioned__extract_dow
+                        , subq_15.ds_partitioned__extract_doy
+                        , subq_15.paid_at__day
+                        , subq_15.paid_at__week
+                        , subq_15.paid_at__month
+                        , subq_15.paid_at__quarter
+                        , subq_15.paid_at__year
+                        , subq_15.paid_at__extract_year
+                        , subq_15.paid_at__extract_quarter
+                        , subq_15.paid_at__extract_month
+                        , subq_15.paid_at__extract_day
+                        , subq_15.paid_at__extract_dow
+                        , subq_15.paid_at__extract_doy
+                        , subq_15.booking__ds__day
+                        , subq_15.booking__ds__week
+                        , subq_15.booking__ds__month
+                        , subq_15.booking__ds__quarter
+                        , subq_15.booking__ds__year
+                        , subq_15.booking__ds__extract_year
+                        , subq_15.booking__ds__extract_quarter
+                        , subq_15.booking__ds__extract_month
+                        , subq_15.booking__ds__extract_day
+                        , subq_15.booking__ds__extract_dow
+                        , subq_15.booking__ds__extract_doy
+                        , subq_15.booking__ds_partitioned__day
+                        , subq_15.booking__ds_partitioned__week
+                        , subq_15.booking__ds_partitioned__month
+                        , subq_15.booking__ds_partitioned__quarter
+                        , subq_15.booking__ds_partitioned__year
+                        , subq_15.booking__ds_partitioned__extract_year
+                        , subq_15.booking__ds_partitioned__extract_quarter
+                        , subq_15.booking__ds_partitioned__extract_month
+                        , subq_15.booking__ds_partitioned__extract_day
+                        , subq_15.booking__ds_partitioned__extract_dow
+                        , subq_15.booking__ds_partitioned__extract_doy
+                        , subq_15.booking__paid_at__day
+                        , subq_15.booking__paid_at__week
+                        , subq_15.booking__paid_at__month
+                        , subq_15.booking__paid_at__quarter
+                        , subq_15.booking__paid_at__year
+                        , subq_15.booking__paid_at__extract_year
+                        , subq_15.booking__paid_at__extract_quarter
+                        , subq_15.booking__paid_at__extract_month
+                        , subq_15.booking__paid_at__extract_day
+                        , subq_15.booking__paid_at__extract_dow
+                        , subq_15.booking__paid_at__extract_doy
+                        , subq_15.ds__day AS metric_time__day
+                        , subq_15.ds__week AS metric_time__week
+                        , subq_15.ds__month AS metric_time__month
+                        , subq_15.ds__quarter AS metric_time__quarter
+                        , subq_15.ds__year AS metric_time__year
+                        , subq_15.ds__extract_year AS metric_time__extract_year
+                        , subq_15.ds__extract_quarter AS metric_time__extract_quarter
+                        , subq_15.ds__extract_month AS metric_time__extract_month
+                        , subq_15.ds__extract_day AS metric_time__extract_day
+                        , subq_15.ds__extract_dow AS metric_time__extract_dow
+                        , subq_15.ds__extract_doy AS metric_time__extract_doy
+                        , subq_15.listing
+                        , subq_15.guest
+                        , subq_15.host
+                        , subq_15.booking__listing
+                        , subq_15.booking__guest
+                        , subq_15.booking__host
+                        , subq_15.is_instant
+                        , subq_15.booking__is_instant
+                        , subq_15.bookings
+                        , subq_15.instant_bookings
+                        , subq_15.booking_value
+                        , subq_15.max_booking_value
+                        , subq_15.min_booking_value
+                        , subq_15.bookers
+                        , subq_15.average_booking_value
+                        , subq_15.referred_bookings
+                        , subq_15.median_booking_value
+                        , subq_15.booking_value_p99
+                        , subq_15.discrete_booking_value_p99
+                        , subq_15.approximate_continuous_booking_value_p99
+                        , subq_15.approximate_discrete_booking_value_p99
+                      FROM (
+                        -- Read Elements From Semantic Model 'bookings_source'
+                        SELECT
+                          1 AS bookings
+                          , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                          , bookings_source_src_28000.booking_value
+                          , bookings_source_src_28000.booking_value AS max_booking_value
+                          , bookings_source_src_28000.booking_value AS min_booking_value
+                          , bookings_source_src_28000.guest_id AS bookers
+                          , bookings_source_src_28000.booking_value AS average_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_payments
+                          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                          , bookings_source_src_28000.booking_value AS median_booking_value
+                          , bookings_source_src_28000.booking_value AS booking_value_p99
+                          , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                          , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                          , bookings_source_src_28000.is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                          , bookings_source_src_28000.is_instant AS booking__is_instant
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                          , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                          , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                          , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                          , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                          , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                          , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                          , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                          , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                          , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                          , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                          , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                          , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                          , bookings_source_src_28000.listing_id AS listing
+                          , bookings_source_src_28000.guest_id AS guest
+                          , bookings_source_src_28000.host_id AS host
+                          , bookings_source_src_28000.listing_id AS booking__listing
+                          , bookings_source_src_28000.guest_id AS booking__guest
+                          , bookings_source_src_28000.host_id AS booking__host
+                        FROM ***************************.fct_bookings bookings_source_src_28000
+                      ) subq_15
+                    ) subq_16
+                    ON
+                      DATE_ADD('day', -14, subq_17.metric_time__day) = subq_16.metric_time__day
+                  ) subq_19
+                ) subq_20
+                LEFT OUTER JOIN (
+                  -- Pass Only Elements: ['country_latest', 'listing']
+                  SELECT
+                    subq_22.listing
+                    , subq_22.country_latest
+                  FROM (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_21.ds__day
+                      , subq_21.ds__week
+                      , subq_21.ds__month
+                      , subq_21.ds__quarter
+                      , subq_21.ds__year
+                      , subq_21.ds__extract_year
+                      , subq_21.ds__extract_quarter
+                      , subq_21.ds__extract_month
+                      , subq_21.ds__extract_day
+                      , subq_21.ds__extract_dow
+                      , subq_21.ds__extract_doy
+                      , subq_21.created_at__day
+                      , subq_21.created_at__week
+                      , subq_21.created_at__month
+                      , subq_21.created_at__quarter
+                      , subq_21.created_at__year
+                      , subq_21.created_at__extract_year
+                      , subq_21.created_at__extract_quarter
+                      , subq_21.created_at__extract_month
+                      , subq_21.created_at__extract_day
+                      , subq_21.created_at__extract_dow
+                      , subq_21.created_at__extract_doy
+                      , subq_21.listing__ds__day
+                      , subq_21.listing__ds__week
+                      , subq_21.listing__ds__month
+                      , subq_21.listing__ds__quarter
+                      , subq_21.listing__ds__year
+                      , subq_21.listing__ds__extract_year
+                      , subq_21.listing__ds__extract_quarter
+                      , subq_21.listing__ds__extract_month
+                      , subq_21.listing__ds__extract_day
+                      , subq_21.listing__ds__extract_dow
+                      , subq_21.listing__ds__extract_doy
+                      , subq_21.listing__created_at__day
+                      , subq_21.listing__created_at__week
+                      , subq_21.listing__created_at__month
+                      , subq_21.listing__created_at__quarter
+                      , subq_21.listing__created_at__year
+                      , subq_21.listing__created_at__extract_year
+                      , subq_21.listing__created_at__extract_quarter
+                      , subq_21.listing__created_at__extract_month
+                      , subq_21.listing__created_at__extract_day
+                      , subq_21.listing__created_at__extract_dow
+                      , subq_21.listing__created_at__extract_doy
+                      , subq_21.ds__day AS metric_time__day
+                      , subq_21.ds__week AS metric_time__week
+                      , subq_21.ds__month AS metric_time__month
+                      , subq_21.ds__quarter AS metric_time__quarter
+                      , subq_21.ds__year AS metric_time__year
+                      , subq_21.ds__extract_year AS metric_time__extract_year
+                      , subq_21.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_21.ds__extract_month AS metric_time__extract_month
+                      , subq_21.ds__extract_day AS metric_time__extract_day
+                      , subq_21.ds__extract_dow AS metric_time__extract_dow
+                      , subq_21.ds__extract_doy AS metric_time__extract_doy
+                      , subq_21.listing
+                      , subq_21.user
+                      , subq_21.listing__user
+                      , subq_21.country_latest
+                      , subq_21.is_lux_latest
+                      , subq_21.capacity_latest
+                      , subq_21.listing__country_latest
+                      , subq_21.listing__is_lux_latest
+                      , subq_21.listing__capacity_latest
+                      , subq_21.listings
+                      , subq_21.largest_listing
+                      , subq_21.smallest_listing
+                    FROM (
+                      -- Read Elements From Semantic Model 'listings_latest'
+                      SELECT
+                        1 AS listings
+                        , listings_latest_src_28000.capacity AS largest_listing
+                        , listings_latest_src_28000.capacity AS smallest_listing
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                        , listings_latest_src_28000.country AS country_latest
+                        , listings_latest_src_28000.is_lux AS is_lux_latest
+                        , listings_latest_src_28000.capacity AS capacity_latest
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                        , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                        , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                        , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                        , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                        , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                        , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                        , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                        , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                        , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                        , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                        , listings_latest_src_28000.country AS listing__country_latest
+                        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                        , listings_latest_src_28000.capacity AS listing__capacity_latest
+                        , listings_latest_src_28000.listing_id AS listing
+                        , listings_latest_src_28000.user_id AS user
+                        , listings_latest_src_28000.user_id AS listing__user
+                      FROM ***************************.dim_listings_latest listings_latest_src_28000
+                    ) subq_21
+                  ) subq_22
+                ) subq_23
+                ON
+                  subq_20.listing = subq_23.listing
+              ) subq_24
+            ) subq_25
+            WHERE booking__is_instant
+          ) subq_26
+        ) subq_27
+        GROUP BY
+          subq_27.metric_time__day
+          , subq_27.listing__country_latest
+      ) subq_28
+      ON
+        subq_29.metric_time__day = subq_28.metric_time__day
+    ) subq_31
+  ) subq_32
+  ON
+    (
+      subq_14.listing__country_latest = subq_32.listing__country_latest
+    ) AND (
+      subq_14.metric_time__day = subq_32.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_14.metric_time__day, subq_32.metric_time__day)
+    , COALESCE(subq_14.listing__country_latest, subq_32.listing__country_latest)
+) subq_33

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -1,0 +1,140 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings_fill_nulls_with_0 - bookings_2_weeks_ago AS bookings_growth_2_weeks_fill_nulls_with_0
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day) AS metric_time__day
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest) AS listing__country_latest
+    , COALESCE(MAX(subq_48.bookings_fill_nulls_with_0), 0) AS bookings_fill_nulls_with_0
+    , COALESCE(MAX(subq_66.bookings_2_weeks_ago), 0) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_fill_nulls_with_0
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_46.ds AS metric_time__day
+        , subq_44.listing__country_latest AS listing__country_latest
+        , subq_44.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_46
+      LEFT OUTER JOIN (
+        -- Join Standard Outputs
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          subq_37.metric_time__day AS metric_time__day
+          , listings_latest_src_28000.country AS listing__country_latest
+          , SUM(subq_37.bookings) AS bookings
+        FROM (
+          -- Constrain Output with WHERE
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          SELECT
+            metric_time__day
+            , listing
+            , bookings
+          FROM (
+            -- Read Elements From Semantic Model 'bookings_source'
+            -- Metric Time Dimension 'ds'
+            SELECT
+              DATE_TRUNC('day', ds) AS metric_time__day
+              , listing_id AS listing
+              , is_instant AS booking__is_instant
+              , 1 AS bookings
+            FROM ***************************.fct_bookings bookings_source_src_28000
+          ) subq_35
+          WHERE booking__is_instant
+        ) subq_37
+        LEFT OUTER JOIN
+          ***************************.dim_listings_latest listings_latest_src_28000
+        ON
+          subq_37.listing = listings_latest_src_28000.listing_id
+        GROUP BY
+          subq_37.metric_time__day
+          , listings_latest_src_28000.country
+      ) subq_44
+      ON
+        subq_46.ds = subq_44.metric_time__day
+    ) subq_47
+  ) subq_48
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , COALESCE(bookings, 0) AS bookings_2_weeks_ago
+    FROM (
+      -- Join to Time Spine Dataset
+      SELECT
+        subq_64.ds AS metric_time__day
+        , subq_62.listing__country_latest AS listing__country_latest
+        , subq_62.bookings AS bookings
+      FROM ***************************.mf_time_spine subq_64
+      LEFT OUTER JOIN (
+        -- Constrain Output with WHERE
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        -- Aggregate Measures
+        SELECT
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
+        FROM (
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_54.metric_time__day AS metric_time__day
+            , subq_54.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_54.bookings AS bookings
+          FROM (
+            -- Join to Time Spine Dataset
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+            SELECT
+              subq_52.ds AS metric_time__day
+              , subq_50.listing AS listing
+              , subq_50.booking__is_instant AS booking__is_instant
+              , subq_50.bookings AS bookings
+            FROM ***************************.mf_time_spine subq_52
+            INNER JOIN (
+              -- Read Elements From Semantic Model 'bookings_source'
+              -- Metric Time Dimension 'ds'
+              SELECT
+                DATE_TRUNC('day', ds) AS metric_time__day
+                , listing_id AS listing
+                , is_instant AS booking__is_instant
+                , 1 AS bookings
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_50
+            ON
+              DATE_ADD('day', -14, subq_52.ds) = subq_50.metric_time__day
+          ) subq_54
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_54.listing = listings_latest_src_28000.listing_id
+        ) subq_59
+        WHERE booking__is_instant
+        GROUP BY
+          metric_time__day
+          , listing__country_latest
+      ) subq_62
+      ON
+        subq_64.ds = subq_62.metric_time__day
+    ) subq_65
+  ) subq_66
+  ON
+    (
+      subq_48.listing__country_latest = subq_66.listing__country_latest
+    ) AND (
+      subq_48.metric_time__day = subq_66.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_48.metric_time__day, subq_66.metric_time__day)
+    , COALESCE(subq_48.listing__country_latest, subq_66.listing__country_latest)
+) subq_67

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
@@ -1,0 +1,383 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_10.listing__country_latest
+  , subq_10.bookings
+FROM (
+  -- Aggregate Measures
+  SELECT
+    subq_9.listing__country_latest
+    , SUM(subq_9.bookings) AS bookings
+  FROM (
+    -- Pass Only Elements: ['bookings', 'listing__country_latest']
+    SELECT
+      subq_8.listing__country_latest
+      , subq_8.bookings
+    FROM (
+      -- Constrain Output with WHERE
+      SELECT
+        subq_7.metric_time__day
+        , subq_7.listing__country_latest
+        , subq_7.bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_6.metric_time__day
+          , subq_6.listing__country_latest
+          , subq_6.bookings
+        FROM (
+          -- Join Standard Outputs
+          SELECT
+            subq_2.metric_time__day AS metric_time__day
+            , subq_2.listing AS listing
+            , subq_5.country_latest AS listing__country_latest
+            , subq_2.bookings AS bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+            SELECT
+              subq_1.metric_time__day
+              , subq_1.listing
+              , subq_1.bookings
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_0.ds__day
+                , subq_0.ds__week
+                , subq_0.ds__month
+                , subq_0.ds__quarter
+                , subq_0.ds__year
+                , subq_0.ds__extract_year
+                , subq_0.ds__extract_quarter
+                , subq_0.ds__extract_month
+                , subq_0.ds__extract_day
+                , subq_0.ds__extract_dow
+                , subq_0.ds__extract_doy
+                , subq_0.ds_partitioned__day
+                , subq_0.ds_partitioned__week
+                , subq_0.ds_partitioned__month
+                , subq_0.ds_partitioned__quarter
+                , subq_0.ds_partitioned__year
+                , subq_0.ds_partitioned__extract_year
+                , subq_0.ds_partitioned__extract_quarter
+                , subq_0.ds_partitioned__extract_month
+                , subq_0.ds_partitioned__extract_day
+                , subq_0.ds_partitioned__extract_dow
+                , subq_0.ds_partitioned__extract_doy
+                , subq_0.paid_at__day
+                , subq_0.paid_at__week
+                , subq_0.paid_at__month
+                , subq_0.paid_at__quarter
+                , subq_0.paid_at__year
+                , subq_0.paid_at__extract_year
+                , subq_0.paid_at__extract_quarter
+                , subq_0.paid_at__extract_month
+                , subq_0.paid_at__extract_day
+                , subq_0.paid_at__extract_dow
+                , subq_0.paid_at__extract_doy
+                , subq_0.booking__ds__day
+                , subq_0.booking__ds__week
+                , subq_0.booking__ds__month
+                , subq_0.booking__ds__quarter
+                , subq_0.booking__ds__year
+                , subq_0.booking__ds__extract_year
+                , subq_0.booking__ds__extract_quarter
+                , subq_0.booking__ds__extract_month
+                , subq_0.booking__ds__extract_day
+                , subq_0.booking__ds__extract_dow
+                , subq_0.booking__ds__extract_doy
+                , subq_0.booking__ds_partitioned__day
+                , subq_0.booking__ds_partitioned__week
+                , subq_0.booking__ds_partitioned__month
+                , subq_0.booking__ds_partitioned__quarter
+                , subq_0.booking__ds_partitioned__year
+                , subq_0.booking__ds_partitioned__extract_year
+                , subq_0.booking__ds_partitioned__extract_quarter
+                , subq_0.booking__ds_partitioned__extract_month
+                , subq_0.booking__ds_partitioned__extract_day
+                , subq_0.booking__ds_partitioned__extract_dow
+                , subq_0.booking__ds_partitioned__extract_doy
+                , subq_0.booking__paid_at__day
+                , subq_0.booking__paid_at__week
+                , subq_0.booking__paid_at__month
+                , subq_0.booking__paid_at__quarter
+                , subq_0.booking__paid_at__year
+                , subq_0.booking__paid_at__extract_year
+                , subq_0.booking__paid_at__extract_quarter
+                , subq_0.booking__paid_at__extract_month
+                , subq_0.booking__paid_at__extract_day
+                , subq_0.booking__paid_at__extract_dow
+                , subq_0.booking__paid_at__extract_doy
+                , subq_0.ds__day AS metric_time__day
+                , subq_0.ds__week AS metric_time__week
+                , subq_0.ds__month AS metric_time__month
+                , subq_0.ds__quarter AS metric_time__quarter
+                , subq_0.ds__year AS metric_time__year
+                , subq_0.ds__extract_year AS metric_time__extract_year
+                , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_0.ds__extract_month AS metric_time__extract_month
+                , subq_0.ds__extract_day AS metric_time__extract_day
+                , subq_0.ds__extract_dow AS metric_time__extract_dow
+                , subq_0.ds__extract_doy AS metric_time__extract_doy
+                , subq_0.listing
+                , subq_0.guest
+                , subq_0.host
+                , subq_0.booking__listing
+                , subq_0.booking__guest
+                , subq_0.booking__host
+                , subq_0.is_instant
+                , subq_0.booking__is_instant
+                , subq_0.bookings
+                , subq_0.instant_bookings
+                , subq_0.booking_value
+                , subq_0.max_booking_value
+                , subq_0.min_booking_value
+                , subq_0.bookers
+                , subq_0.average_booking_value
+                , subq_0.referred_bookings
+                , subq_0.median_booking_value
+                , subq_0.booking_value_p99
+                , subq_0.discrete_booking_value_p99
+                , subq_0.approximate_continuous_booking_value_p99
+                , subq_0.approximate_discrete_booking_value_p99
+              FROM (
+                -- Read Elements From Semantic Model 'bookings_source'
+                SELECT
+                  1 AS bookings
+                  , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                  , bookings_source_src_28000.booking_value
+                  , bookings_source_src_28000.booking_value AS max_booking_value
+                  , bookings_source_src_28000.booking_value AS min_booking_value
+                  , bookings_source_src_28000.guest_id AS bookers
+                  , bookings_source_src_28000.booking_value AS average_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_payments
+                  , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                  , bookings_source_src_28000.booking_value AS median_booking_value
+                  , bookings_source_src_28000.booking_value AS booking_value_p99
+                  , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                  , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                  , bookings_source_src_28000.is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                  , bookings_source_src_28000.is_instant AS booking__is_instant
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                  , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                  , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                  , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                  , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                  , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                  , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                  , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                  , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                  , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                  , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                  , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                  , bookings_source_src_28000.listing_id AS listing
+                  , bookings_source_src_28000.guest_id AS guest
+                  , bookings_source_src_28000.host_id AS host
+                  , bookings_source_src_28000.listing_id AS booking__listing
+                  , bookings_source_src_28000.guest_id AS booking__guest
+                  , bookings_source_src_28000.host_id AS booking__host
+                FROM ***************************.fct_bookings bookings_source_src_28000
+              ) subq_0
+            ) subq_1
+          ) subq_2
+          LEFT OUTER JOIN (
+            -- Pass Only Elements: ['country_latest', 'listing']
+            SELECT
+              subq_4.listing
+              , subq_4.country_latest
+            FROM (
+              -- Metric Time Dimension 'ds'
+              SELECT
+                subq_3.ds__day
+                , subq_3.ds__week
+                , subq_3.ds__month
+                , subq_3.ds__quarter
+                , subq_3.ds__year
+                , subq_3.ds__extract_year
+                , subq_3.ds__extract_quarter
+                , subq_3.ds__extract_month
+                , subq_3.ds__extract_day
+                , subq_3.ds__extract_dow
+                , subq_3.ds__extract_doy
+                , subq_3.created_at__day
+                , subq_3.created_at__week
+                , subq_3.created_at__month
+                , subq_3.created_at__quarter
+                , subq_3.created_at__year
+                , subq_3.created_at__extract_year
+                , subq_3.created_at__extract_quarter
+                , subq_3.created_at__extract_month
+                , subq_3.created_at__extract_day
+                , subq_3.created_at__extract_dow
+                , subq_3.created_at__extract_doy
+                , subq_3.listing__ds__day
+                , subq_3.listing__ds__week
+                , subq_3.listing__ds__month
+                , subq_3.listing__ds__quarter
+                , subq_3.listing__ds__year
+                , subq_3.listing__ds__extract_year
+                , subq_3.listing__ds__extract_quarter
+                , subq_3.listing__ds__extract_month
+                , subq_3.listing__ds__extract_day
+                , subq_3.listing__ds__extract_dow
+                , subq_3.listing__ds__extract_doy
+                , subq_3.listing__created_at__day
+                , subq_3.listing__created_at__week
+                , subq_3.listing__created_at__month
+                , subq_3.listing__created_at__quarter
+                , subq_3.listing__created_at__year
+                , subq_3.listing__created_at__extract_year
+                , subq_3.listing__created_at__extract_quarter
+                , subq_3.listing__created_at__extract_month
+                , subq_3.listing__created_at__extract_day
+                , subq_3.listing__created_at__extract_dow
+                , subq_3.listing__created_at__extract_doy
+                , subq_3.ds__day AS metric_time__day
+                , subq_3.ds__week AS metric_time__week
+                , subq_3.ds__month AS metric_time__month
+                , subq_3.ds__quarter AS metric_time__quarter
+                , subq_3.ds__year AS metric_time__year
+                , subq_3.ds__extract_year AS metric_time__extract_year
+                , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                , subq_3.ds__extract_month AS metric_time__extract_month
+                , subq_3.ds__extract_day AS metric_time__extract_day
+                , subq_3.ds__extract_dow AS metric_time__extract_dow
+                , subq_3.ds__extract_doy AS metric_time__extract_doy
+                , subq_3.listing
+                , subq_3.user
+                , subq_3.listing__user
+                , subq_3.country_latest
+                , subq_3.is_lux_latest
+                , subq_3.capacity_latest
+                , subq_3.listing__country_latest
+                , subq_3.listing__is_lux_latest
+                , subq_3.listing__capacity_latest
+                , subq_3.listings
+                , subq_3.largest_listing
+                , subq_3.smallest_listing
+              FROM (
+                -- Read Elements From Semantic Model 'listings_latest'
+                SELECT
+                  1 AS listings
+                  , listings_latest_src_28000.capacity AS largest_listing
+                  , listings_latest_src_28000.capacity AS smallest_listing
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                  , listings_latest_src_28000.country AS country_latest
+                  , listings_latest_src_28000.is_lux AS is_lux_latest
+                  , listings_latest_src_28000.capacity AS capacity_latest
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                  , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                  , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                  , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                  , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                  , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                  , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                  , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                  , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                  , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                  , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                  , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                  , listings_latest_src_28000.country AS listing__country_latest
+                  , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                  , listings_latest_src_28000.capacity AS listing__capacity_latest
+                  , listings_latest_src_28000.listing_id AS listing
+                  , listings_latest_src_28000.user_id AS user
+                  , listings_latest_src_28000.user_id AS listing__user
+                FROM ***************************.dim_listings_latest listings_latest_src_28000
+              ) subq_3
+            ) subq_4
+          ) subq_5
+          ON
+            subq_2.listing = subq_5.listing
+        ) subq_6
+      ) subq_7
+      WHERE metric_time__day = '2024-01-01'
+    ) subq_8
+  ) subq_9
+  GROUP BY
+    subq_9.listing__country_latest
+) subq_10

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0_optimized.sql
@@ -1,0 +1,32 @@
+-- Constrain Output with WHERE
+-- Pass Only Elements: ['bookings', 'listing__country_latest']
+-- Aggregate Measures
+-- Compute Metrics via Expressions
+SELECT
+  listing__country_latest
+  , SUM(bookings) AS bookings
+FROM (
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+  SELECT
+    subq_13.metric_time__day AS metric_time__day
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
+  FROM (
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
+    SELECT
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , listing_id AS listing
+      , 1 AS bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE metric_time__day = '2024-01-01'
+GROUP BY
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -1,0 +1,918 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_27.metric_time__day
+  , subq_27.listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day) AS metric_time__day
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest) AS listing__country_latest
+    , MAX(subq_11.bookings) AS bookings
+    , MAX(subq_26.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_10.metric_time__day
+      , subq_10.listing__country_latest
+      , subq_10.bookings
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+        , SUM(subq_9.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_8.metric_time__day
+          , subq_8.listing__country_latest
+          , subq_8.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_7.metric_time__day
+            , subq_7.booking__is_instant
+            , subq_7.listing__country_latest
+            , subq_7.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_6.metric_time__day
+              , subq_6.booking__is_instant
+              , subq_6.listing__country_latest
+              , subq_6.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_2.metric_time__day AS metric_time__day
+                , subq_2.listing AS listing
+                , subq_2.booking__is_instant AS booking__is_instant
+                , subq_5.country_latest AS listing__country_latest
+                , subq_2.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_1.metric_time__day
+                  , subq_1.listing
+                  , subq_1.booking__is_instant
+                  , subq_1.bookings
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_0.ds__day
+                    , subq_0.ds__week
+                    , subq_0.ds__month
+                    , subq_0.ds__quarter
+                    , subq_0.ds__year
+                    , subq_0.ds__extract_year
+                    , subq_0.ds__extract_quarter
+                    , subq_0.ds__extract_month
+                    , subq_0.ds__extract_day
+                    , subq_0.ds__extract_dow
+                    , subq_0.ds__extract_doy
+                    , subq_0.ds_partitioned__day
+                    , subq_0.ds_partitioned__week
+                    , subq_0.ds_partitioned__month
+                    , subq_0.ds_partitioned__quarter
+                    , subq_0.ds_partitioned__year
+                    , subq_0.ds_partitioned__extract_year
+                    , subq_0.ds_partitioned__extract_quarter
+                    , subq_0.ds_partitioned__extract_month
+                    , subq_0.ds_partitioned__extract_day
+                    , subq_0.ds_partitioned__extract_dow
+                    , subq_0.ds_partitioned__extract_doy
+                    , subq_0.paid_at__day
+                    , subq_0.paid_at__week
+                    , subq_0.paid_at__month
+                    , subq_0.paid_at__quarter
+                    , subq_0.paid_at__year
+                    , subq_0.paid_at__extract_year
+                    , subq_0.paid_at__extract_quarter
+                    , subq_0.paid_at__extract_month
+                    , subq_0.paid_at__extract_day
+                    , subq_0.paid_at__extract_dow
+                    , subq_0.paid_at__extract_doy
+                    , subq_0.booking__ds__day
+                    , subq_0.booking__ds__week
+                    , subq_0.booking__ds__month
+                    , subq_0.booking__ds__quarter
+                    , subq_0.booking__ds__year
+                    , subq_0.booking__ds__extract_year
+                    , subq_0.booking__ds__extract_quarter
+                    , subq_0.booking__ds__extract_month
+                    , subq_0.booking__ds__extract_day
+                    , subq_0.booking__ds__extract_dow
+                    , subq_0.booking__ds__extract_doy
+                    , subq_0.booking__ds_partitioned__day
+                    , subq_0.booking__ds_partitioned__week
+                    , subq_0.booking__ds_partitioned__month
+                    , subq_0.booking__ds_partitioned__quarter
+                    , subq_0.booking__ds_partitioned__year
+                    , subq_0.booking__ds_partitioned__extract_year
+                    , subq_0.booking__ds_partitioned__extract_quarter
+                    , subq_0.booking__ds_partitioned__extract_month
+                    , subq_0.booking__ds_partitioned__extract_day
+                    , subq_0.booking__ds_partitioned__extract_dow
+                    , subq_0.booking__ds_partitioned__extract_doy
+                    , subq_0.booking__paid_at__day
+                    , subq_0.booking__paid_at__week
+                    , subq_0.booking__paid_at__month
+                    , subq_0.booking__paid_at__quarter
+                    , subq_0.booking__paid_at__year
+                    , subq_0.booking__paid_at__extract_year
+                    , subq_0.booking__paid_at__extract_quarter
+                    , subq_0.booking__paid_at__extract_month
+                    , subq_0.booking__paid_at__extract_day
+                    , subq_0.booking__paid_at__extract_dow
+                    , subq_0.booking__paid_at__extract_doy
+                    , subq_0.ds__day AS metric_time__day
+                    , subq_0.ds__week AS metric_time__week
+                    , subq_0.ds__month AS metric_time__month
+                    , subq_0.ds__quarter AS metric_time__quarter
+                    , subq_0.ds__year AS metric_time__year
+                    , subq_0.ds__extract_year AS metric_time__extract_year
+                    , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_0.ds__extract_month AS metric_time__extract_month
+                    , subq_0.ds__extract_day AS metric_time__extract_day
+                    , subq_0.ds__extract_dow AS metric_time__extract_dow
+                    , subq_0.ds__extract_doy AS metric_time__extract_doy
+                    , subq_0.listing
+                    , subq_0.guest
+                    , subq_0.host
+                    , subq_0.booking__listing
+                    , subq_0.booking__guest
+                    , subq_0.booking__host
+                    , subq_0.is_instant
+                    , subq_0.booking__is_instant
+                    , subq_0.bookings
+                    , subq_0.instant_bookings
+                    , subq_0.booking_value
+                    , subq_0.max_booking_value
+                    , subq_0.min_booking_value
+                    , subq_0.bookers
+                    , subq_0.average_booking_value
+                    , subq_0.referred_bookings
+                    , subq_0.median_booking_value
+                    , subq_0.booking_value_p99
+                    , subq_0.discrete_booking_value_p99
+                    , subq_0.approximate_continuous_booking_value_p99
+                    , subq_0.approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Read Elements From Semantic Model 'bookings_source'
+                    SELECT
+                      1 AS bookings
+                      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                      , bookings_source_src_28000.booking_value
+                      , bookings_source_src_28000.booking_value AS max_booking_value
+                      , bookings_source_src_28000.booking_value AS min_booking_value
+                      , bookings_source_src_28000.guest_id AS bookers
+                      , bookings_source_src_28000.booking_value AS average_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_payments
+                      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                      , bookings_source_src_28000.booking_value AS median_booking_value
+                      , bookings_source_src_28000.booking_value AS booking_value_p99
+                      , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                      , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                      , bookings_source_src_28000.is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                      , bookings_source_src_28000.is_instant AS booking__is_instant
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                      , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                      , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                      , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                      , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                      , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                      , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                      , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                      , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                      , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                      , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                      , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                      , bookings_source_src_28000.listing_id AS listing
+                      , bookings_source_src_28000.guest_id AS guest
+                      , bookings_source_src_28000.host_id AS host
+                      , bookings_source_src_28000.listing_id AS booking__listing
+                      , bookings_source_src_28000.guest_id AS booking__guest
+                      , bookings_source_src_28000.host_id AS booking__host
+                    FROM ***************************.fct_bookings bookings_source_src_28000
+                  ) subq_0
+                ) subq_1
+              ) subq_2
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_4.listing
+                  , subq_4.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_3.ds__day
+                    , subq_3.ds__week
+                    , subq_3.ds__month
+                    , subq_3.ds__quarter
+                    , subq_3.ds__year
+                    , subq_3.ds__extract_year
+                    , subq_3.ds__extract_quarter
+                    , subq_3.ds__extract_month
+                    , subq_3.ds__extract_day
+                    , subq_3.ds__extract_dow
+                    , subq_3.ds__extract_doy
+                    , subq_3.created_at__day
+                    , subq_3.created_at__week
+                    , subq_3.created_at__month
+                    , subq_3.created_at__quarter
+                    , subq_3.created_at__year
+                    , subq_3.created_at__extract_year
+                    , subq_3.created_at__extract_quarter
+                    , subq_3.created_at__extract_month
+                    , subq_3.created_at__extract_day
+                    , subq_3.created_at__extract_dow
+                    , subq_3.created_at__extract_doy
+                    , subq_3.listing__ds__day
+                    , subq_3.listing__ds__week
+                    , subq_3.listing__ds__month
+                    , subq_3.listing__ds__quarter
+                    , subq_3.listing__ds__year
+                    , subq_3.listing__ds__extract_year
+                    , subq_3.listing__ds__extract_quarter
+                    , subq_3.listing__ds__extract_month
+                    , subq_3.listing__ds__extract_day
+                    , subq_3.listing__ds__extract_dow
+                    , subq_3.listing__ds__extract_doy
+                    , subq_3.listing__created_at__day
+                    , subq_3.listing__created_at__week
+                    , subq_3.listing__created_at__month
+                    , subq_3.listing__created_at__quarter
+                    , subq_3.listing__created_at__year
+                    , subq_3.listing__created_at__extract_year
+                    , subq_3.listing__created_at__extract_quarter
+                    , subq_3.listing__created_at__extract_month
+                    , subq_3.listing__created_at__extract_day
+                    , subq_3.listing__created_at__extract_dow
+                    , subq_3.listing__created_at__extract_doy
+                    , subq_3.ds__day AS metric_time__day
+                    , subq_3.ds__week AS metric_time__week
+                    , subq_3.ds__month AS metric_time__month
+                    , subq_3.ds__quarter AS metric_time__quarter
+                    , subq_3.ds__year AS metric_time__year
+                    , subq_3.ds__extract_year AS metric_time__extract_year
+                    , subq_3.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_3.ds__extract_month AS metric_time__extract_month
+                    , subq_3.ds__extract_day AS metric_time__extract_day
+                    , subq_3.ds__extract_dow AS metric_time__extract_dow
+                    , subq_3.ds__extract_doy AS metric_time__extract_doy
+                    , subq_3.listing
+                    , subq_3.user
+                    , subq_3.listing__user
+                    , subq_3.country_latest
+                    , subq_3.is_lux_latest
+                    , subq_3.capacity_latest
+                    , subq_3.listing__country_latest
+                    , subq_3.listing__is_lux_latest
+                    , subq_3.listing__capacity_latest
+                    , subq_3.listings
+                    , subq_3.largest_listing
+                    , subq_3.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_3
+                ) subq_4
+              ) subq_5
+              ON
+                subq_2.listing = subq_5.listing
+            ) subq_6
+          ) subq_7
+          WHERE booking__is_instant
+        ) subq_8
+      ) subq_9
+      GROUP BY
+        subq_9.metric_time__day
+        , subq_9.listing__country_latest
+    ) subq_10
+  ) subq_11
+  FULL OUTER JOIN (
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_25.metric_time__day
+      , subq_25.listing__country_latest
+      , subq_25.bookings AS bookings_2_weeks_ago
+    FROM (
+      -- Aggregate Measures
+      SELECT
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+        , SUM(subq_24.bookings) AS bookings
+      FROM (
+        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+        SELECT
+          subq_23.metric_time__day
+          , subq_23.listing__country_latest
+          , subq_23.bookings
+        FROM (
+          -- Constrain Output with WHERE
+          SELECT
+            subq_22.metric_time__day
+            , subq_22.booking__is_instant
+            , subq_22.listing__country_latest
+            , subq_22.bookings
+          FROM (
+            -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+            SELECT
+              subq_21.metric_time__day
+              , subq_21.booking__is_instant
+              , subq_21.listing__country_latest
+              , subq_21.bookings
+            FROM (
+              -- Join Standard Outputs
+              SELECT
+                subq_17.metric_time__day AS metric_time__day
+                , subq_17.listing AS listing
+                , subq_17.booking__is_instant AS booking__is_instant
+                , subq_20.country_latest AS listing__country_latest
+                , subq_17.bookings AS bookings
+              FROM (
+                -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+                SELECT
+                  subq_16.metric_time__day
+                  , subq_16.listing
+                  , subq_16.booking__is_instant
+                  , subq_16.bookings
+                FROM (
+                  -- Join to Time Spine Dataset
+                  SELECT
+                    subq_14.metric_time__day AS metric_time__day
+                    , DATE_TRUNC('week', subq_14.metric_time__day) AS metric_time__week
+                    , DATE_TRUNC('month', subq_14.metric_time__day) AS metric_time__month
+                    , DATE_TRUNC('quarter', subq_14.metric_time__day) AS metric_time__quarter
+                    , DATE_TRUNC('year', subq_14.metric_time__day) AS metric_time__year
+                    , EXTRACT(year FROM subq_14.metric_time__day) AS metric_time__extract_year
+                    , EXTRACT(quarter FROM subq_14.metric_time__day) AS metric_time__extract_quarter
+                    , EXTRACT(month FROM subq_14.metric_time__day) AS metric_time__extract_month
+                    , EXTRACT(day FROM subq_14.metric_time__day) AS metric_time__extract_day
+                    , EXTRACT(DAY_OF_WEEK FROM subq_14.metric_time__day) AS metric_time__extract_dow
+                    , EXTRACT(doy FROM subq_14.metric_time__day) AS metric_time__extract_doy
+                    , subq_13.ds__day AS ds__day
+                    , subq_13.ds__week AS ds__week
+                    , subq_13.ds__month AS ds__month
+                    , subq_13.ds__quarter AS ds__quarter
+                    , subq_13.ds__year AS ds__year
+                    , subq_13.ds__extract_year AS ds__extract_year
+                    , subq_13.ds__extract_quarter AS ds__extract_quarter
+                    , subq_13.ds__extract_month AS ds__extract_month
+                    , subq_13.ds__extract_day AS ds__extract_day
+                    , subq_13.ds__extract_dow AS ds__extract_dow
+                    , subq_13.ds__extract_doy AS ds__extract_doy
+                    , subq_13.ds_partitioned__day AS ds_partitioned__day
+                    , subq_13.ds_partitioned__week AS ds_partitioned__week
+                    , subq_13.ds_partitioned__month AS ds_partitioned__month
+                    , subq_13.ds_partitioned__quarter AS ds_partitioned__quarter
+                    , subq_13.ds_partitioned__year AS ds_partitioned__year
+                    , subq_13.ds_partitioned__extract_year AS ds_partitioned__extract_year
+                    , subq_13.ds_partitioned__extract_quarter AS ds_partitioned__extract_quarter
+                    , subq_13.ds_partitioned__extract_month AS ds_partitioned__extract_month
+                    , subq_13.ds_partitioned__extract_day AS ds_partitioned__extract_day
+                    , subq_13.ds_partitioned__extract_dow AS ds_partitioned__extract_dow
+                    , subq_13.ds_partitioned__extract_doy AS ds_partitioned__extract_doy
+                    , subq_13.paid_at__day AS paid_at__day
+                    , subq_13.paid_at__week AS paid_at__week
+                    , subq_13.paid_at__month AS paid_at__month
+                    , subq_13.paid_at__quarter AS paid_at__quarter
+                    , subq_13.paid_at__year AS paid_at__year
+                    , subq_13.paid_at__extract_year AS paid_at__extract_year
+                    , subq_13.paid_at__extract_quarter AS paid_at__extract_quarter
+                    , subq_13.paid_at__extract_month AS paid_at__extract_month
+                    , subq_13.paid_at__extract_day AS paid_at__extract_day
+                    , subq_13.paid_at__extract_dow AS paid_at__extract_dow
+                    , subq_13.paid_at__extract_doy AS paid_at__extract_doy
+                    , subq_13.booking__ds__day AS booking__ds__day
+                    , subq_13.booking__ds__week AS booking__ds__week
+                    , subq_13.booking__ds__month AS booking__ds__month
+                    , subq_13.booking__ds__quarter AS booking__ds__quarter
+                    , subq_13.booking__ds__year AS booking__ds__year
+                    , subq_13.booking__ds__extract_year AS booking__ds__extract_year
+                    , subq_13.booking__ds__extract_quarter AS booking__ds__extract_quarter
+                    , subq_13.booking__ds__extract_month AS booking__ds__extract_month
+                    , subq_13.booking__ds__extract_day AS booking__ds__extract_day
+                    , subq_13.booking__ds__extract_dow AS booking__ds__extract_dow
+                    , subq_13.booking__ds__extract_doy AS booking__ds__extract_doy
+                    , subq_13.booking__ds_partitioned__day AS booking__ds_partitioned__day
+                    , subq_13.booking__ds_partitioned__week AS booking__ds_partitioned__week
+                    , subq_13.booking__ds_partitioned__month AS booking__ds_partitioned__month
+                    , subq_13.booking__ds_partitioned__quarter AS booking__ds_partitioned__quarter
+                    , subq_13.booking__ds_partitioned__year AS booking__ds_partitioned__year
+                    , subq_13.booking__ds_partitioned__extract_year AS booking__ds_partitioned__extract_year
+                    , subq_13.booking__ds_partitioned__extract_quarter AS booking__ds_partitioned__extract_quarter
+                    , subq_13.booking__ds_partitioned__extract_month AS booking__ds_partitioned__extract_month
+                    , subq_13.booking__ds_partitioned__extract_day AS booking__ds_partitioned__extract_day
+                    , subq_13.booking__ds_partitioned__extract_dow AS booking__ds_partitioned__extract_dow
+                    , subq_13.booking__ds_partitioned__extract_doy AS booking__ds_partitioned__extract_doy
+                    , subq_13.booking__paid_at__day AS booking__paid_at__day
+                    , subq_13.booking__paid_at__week AS booking__paid_at__week
+                    , subq_13.booking__paid_at__month AS booking__paid_at__month
+                    , subq_13.booking__paid_at__quarter AS booking__paid_at__quarter
+                    , subq_13.booking__paid_at__year AS booking__paid_at__year
+                    , subq_13.booking__paid_at__extract_year AS booking__paid_at__extract_year
+                    , subq_13.booking__paid_at__extract_quarter AS booking__paid_at__extract_quarter
+                    , subq_13.booking__paid_at__extract_month AS booking__paid_at__extract_month
+                    , subq_13.booking__paid_at__extract_day AS booking__paid_at__extract_day
+                    , subq_13.booking__paid_at__extract_dow AS booking__paid_at__extract_dow
+                    , subq_13.booking__paid_at__extract_doy AS booking__paid_at__extract_doy
+                    , subq_13.listing AS listing
+                    , subq_13.guest AS guest
+                    , subq_13.host AS host
+                    , subq_13.booking__listing AS booking__listing
+                    , subq_13.booking__guest AS booking__guest
+                    , subq_13.booking__host AS booking__host
+                    , subq_13.is_instant AS is_instant
+                    , subq_13.booking__is_instant AS booking__is_instant
+                    , subq_13.bookings AS bookings
+                    , subq_13.instant_bookings AS instant_bookings
+                    , subq_13.booking_value AS booking_value
+                    , subq_13.max_booking_value AS max_booking_value
+                    , subq_13.min_booking_value AS min_booking_value
+                    , subq_13.bookers AS bookers
+                    , subq_13.average_booking_value AS average_booking_value
+                    , subq_13.referred_bookings AS referred_bookings
+                    , subq_13.median_booking_value AS median_booking_value
+                    , subq_13.booking_value_p99 AS booking_value_p99
+                    , subq_13.discrete_booking_value_p99 AS discrete_booking_value_p99
+                    , subq_13.approximate_continuous_booking_value_p99 AS approximate_continuous_booking_value_p99
+                    , subq_13.approximate_discrete_booking_value_p99 AS approximate_discrete_booking_value_p99
+                  FROM (
+                    -- Time Spine
+                    SELECT
+                      subq_15.ds AS metric_time__day
+                    FROM ***************************.mf_time_spine subq_15
+                  ) subq_14
+                  INNER JOIN (
+                    -- Metric Time Dimension 'ds'
+                    SELECT
+                      subq_12.ds__day
+                      , subq_12.ds__week
+                      , subq_12.ds__month
+                      , subq_12.ds__quarter
+                      , subq_12.ds__year
+                      , subq_12.ds__extract_year
+                      , subq_12.ds__extract_quarter
+                      , subq_12.ds__extract_month
+                      , subq_12.ds__extract_day
+                      , subq_12.ds__extract_dow
+                      , subq_12.ds__extract_doy
+                      , subq_12.ds_partitioned__day
+                      , subq_12.ds_partitioned__week
+                      , subq_12.ds_partitioned__month
+                      , subq_12.ds_partitioned__quarter
+                      , subq_12.ds_partitioned__year
+                      , subq_12.ds_partitioned__extract_year
+                      , subq_12.ds_partitioned__extract_quarter
+                      , subq_12.ds_partitioned__extract_month
+                      , subq_12.ds_partitioned__extract_day
+                      , subq_12.ds_partitioned__extract_dow
+                      , subq_12.ds_partitioned__extract_doy
+                      , subq_12.paid_at__day
+                      , subq_12.paid_at__week
+                      , subq_12.paid_at__month
+                      , subq_12.paid_at__quarter
+                      , subq_12.paid_at__year
+                      , subq_12.paid_at__extract_year
+                      , subq_12.paid_at__extract_quarter
+                      , subq_12.paid_at__extract_month
+                      , subq_12.paid_at__extract_day
+                      , subq_12.paid_at__extract_dow
+                      , subq_12.paid_at__extract_doy
+                      , subq_12.booking__ds__day
+                      , subq_12.booking__ds__week
+                      , subq_12.booking__ds__month
+                      , subq_12.booking__ds__quarter
+                      , subq_12.booking__ds__year
+                      , subq_12.booking__ds__extract_year
+                      , subq_12.booking__ds__extract_quarter
+                      , subq_12.booking__ds__extract_month
+                      , subq_12.booking__ds__extract_day
+                      , subq_12.booking__ds__extract_dow
+                      , subq_12.booking__ds__extract_doy
+                      , subq_12.booking__ds_partitioned__day
+                      , subq_12.booking__ds_partitioned__week
+                      , subq_12.booking__ds_partitioned__month
+                      , subq_12.booking__ds_partitioned__quarter
+                      , subq_12.booking__ds_partitioned__year
+                      , subq_12.booking__ds_partitioned__extract_year
+                      , subq_12.booking__ds_partitioned__extract_quarter
+                      , subq_12.booking__ds_partitioned__extract_month
+                      , subq_12.booking__ds_partitioned__extract_day
+                      , subq_12.booking__ds_partitioned__extract_dow
+                      , subq_12.booking__ds_partitioned__extract_doy
+                      , subq_12.booking__paid_at__day
+                      , subq_12.booking__paid_at__week
+                      , subq_12.booking__paid_at__month
+                      , subq_12.booking__paid_at__quarter
+                      , subq_12.booking__paid_at__year
+                      , subq_12.booking__paid_at__extract_year
+                      , subq_12.booking__paid_at__extract_quarter
+                      , subq_12.booking__paid_at__extract_month
+                      , subq_12.booking__paid_at__extract_day
+                      , subq_12.booking__paid_at__extract_dow
+                      , subq_12.booking__paid_at__extract_doy
+                      , subq_12.ds__day AS metric_time__day
+                      , subq_12.ds__week AS metric_time__week
+                      , subq_12.ds__month AS metric_time__month
+                      , subq_12.ds__quarter AS metric_time__quarter
+                      , subq_12.ds__year AS metric_time__year
+                      , subq_12.ds__extract_year AS metric_time__extract_year
+                      , subq_12.ds__extract_quarter AS metric_time__extract_quarter
+                      , subq_12.ds__extract_month AS metric_time__extract_month
+                      , subq_12.ds__extract_day AS metric_time__extract_day
+                      , subq_12.ds__extract_dow AS metric_time__extract_dow
+                      , subq_12.ds__extract_doy AS metric_time__extract_doy
+                      , subq_12.listing
+                      , subq_12.guest
+                      , subq_12.host
+                      , subq_12.booking__listing
+                      , subq_12.booking__guest
+                      , subq_12.booking__host
+                      , subq_12.is_instant
+                      , subq_12.booking__is_instant
+                      , subq_12.bookings
+                      , subq_12.instant_bookings
+                      , subq_12.booking_value
+                      , subq_12.max_booking_value
+                      , subq_12.min_booking_value
+                      , subq_12.bookers
+                      , subq_12.average_booking_value
+                      , subq_12.referred_bookings
+                      , subq_12.median_booking_value
+                      , subq_12.booking_value_p99
+                      , subq_12.discrete_booking_value_p99
+                      , subq_12.approximate_continuous_booking_value_p99
+                      , subq_12.approximate_discrete_booking_value_p99
+                    FROM (
+                      -- Read Elements From Semantic Model 'bookings_source'
+                      SELECT
+                        1 AS bookings
+                        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                        , bookings_source_src_28000.booking_value
+                        , bookings_source_src_28000.booking_value AS max_booking_value
+                        , bookings_source_src_28000.booking_value AS min_booking_value
+                        , bookings_source_src_28000.guest_id AS bookers
+                        , bookings_source_src_28000.booking_value AS average_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_payments
+                        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                        , bookings_source_src_28000.booking_value AS median_booking_value
+                        , bookings_source_src_28000.booking_value AS booking_value_p99
+                        , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                        , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                        , bookings_source_src_28000.is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                        , bookings_source_src_28000.is_instant AS booking__is_instant
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                        , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                        , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                        , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                        , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                        , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                        , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                        , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                        , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                        , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                        , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                        , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                        , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                        , bookings_source_src_28000.listing_id AS listing
+                        , bookings_source_src_28000.guest_id AS guest
+                        , bookings_source_src_28000.host_id AS host
+                        , bookings_source_src_28000.listing_id AS booking__listing
+                        , bookings_source_src_28000.guest_id AS booking__guest
+                        , bookings_source_src_28000.host_id AS booking__host
+                      FROM ***************************.fct_bookings bookings_source_src_28000
+                    ) subq_12
+                  ) subq_13
+                  ON
+                    DATE_ADD('day', -14, subq_14.metric_time__day) = subq_13.metric_time__day
+                ) subq_16
+              ) subq_17
+              LEFT OUTER JOIN (
+                -- Pass Only Elements: ['country_latest', 'listing']
+                SELECT
+                  subq_19.listing
+                  , subq_19.country_latest
+                FROM (
+                  -- Metric Time Dimension 'ds'
+                  SELECT
+                    subq_18.ds__day
+                    , subq_18.ds__week
+                    , subq_18.ds__month
+                    , subq_18.ds__quarter
+                    , subq_18.ds__year
+                    , subq_18.ds__extract_year
+                    , subq_18.ds__extract_quarter
+                    , subq_18.ds__extract_month
+                    , subq_18.ds__extract_day
+                    , subq_18.ds__extract_dow
+                    , subq_18.ds__extract_doy
+                    , subq_18.created_at__day
+                    , subq_18.created_at__week
+                    , subq_18.created_at__month
+                    , subq_18.created_at__quarter
+                    , subq_18.created_at__year
+                    , subq_18.created_at__extract_year
+                    , subq_18.created_at__extract_quarter
+                    , subq_18.created_at__extract_month
+                    , subq_18.created_at__extract_day
+                    , subq_18.created_at__extract_dow
+                    , subq_18.created_at__extract_doy
+                    , subq_18.listing__ds__day
+                    , subq_18.listing__ds__week
+                    , subq_18.listing__ds__month
+                    , subq_18.listing__ds__quarter
+                    , subq_18.listing__ds__year
+                    , subq_18.listing__ds__extract_year
+                    , subq_18.listing__ds__extract_quarter
+                    , subq_18.listing__ds__extract_month
+                    , subq_18.listing__ds__extract_day
+                    , subq_18.listing__ds__extract_dow
+                    , subq_18.listing__ds__extract_doy
+                    , subq_18.listing__created_at__day
+                    , subq_18.listing__created_at__week
+                    , subq_18.listing__created_at__month
+                    , subq_18.listing__created_at__quarter
+                    , subq_18.listing__created_at__year
+                    , subq_18.listing__created_at__extract_year
+                    , subq_18.listing__created_at__extract_quarter
+                    , subq_18.listing__created_at__extract_month
+                    , subq_18.listing__created_at__extract_day
+                    , subq_18.listing__created_at__extract_dow
+                    , subq_18.listing__created_at__extract_doy
+                    , subq_18.ds__day AS metric_time__day
+                    , subq_18.ds__week AS metric_time__week
+                    , subq_18.ds__month AS metric_time__month
+                    , subq_18.ds__quarter AS metric_time__quarter
+                    , subq_18.ds__year AS metric_time__year
+                    , subq_18.ds__extract_year AS metric_time__extract_year
+                    , subq_18.ds__extract_quarter AS metric_time__extract_quarter
+                    , subq_18.ds__extract_month AS metric_time__extract_month
+                    , subq_18.ds__extract_day AS metric_time__extract_day
+                    , subq_18.ds__extract_dow AS metric_time__extract_dow
+                    , subq_18.ds__extract_doy AS metric_time__extract_doy
+                    , subq_18.listing
+                    , subq_18.user
+                    , subq_18.listing__user
+                    , subq_18.country_latest
+                    , subq_18.is_lux_latest
+                    , subq_18.capacity_latest
+                    , subq_18.listing__country_latest
+                    , subq_18.listing__is_lux_latest
+                    , subq_18.listing__capacity_latest
+                    , subq_18.listings
+                    , subq_18.largest_listing
+                    , subq_18.smallest_listing
+                  FROM (
+                    -- Read Elements From Semantic Model 'listings_latest'
+                    SELECT
+                      1 AS listings
+                      , listings_latest_src_28000.capacity AS largest_listing
+                      , listings_latest_src_28000.capacity AS smallest_listing
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS created_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS created_at__extract_doy
+                      , listings_latest_src_28000.country AS country_latest
+                      , listings_latest_src_28000.is_lux AS is_lux_latest
+                      , listings_latest_src_28000.capacity AS capacity_latest
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__ds__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__ds__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__ds__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__ds__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__ds__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__ds__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__ds__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__ds__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__ds__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__ds__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__ds__extract_doy
+                      , DATE_TRUNC('day', listings_latest_src_28000.created_at) AS listing__created_at__day
+                      , DATE_TRUNC('week', listings_latest_src_28000.created_at) AS listing__created_at__week
+                      , DATE_TRUNC('month', listings_latest_src_28000.created_at) AS listing__created_at__month
+                      , DATE_TRUNC('quarter', listings_latest_src_28000.created_at) AS listing__created_at__quarter
+                      , DATE_TRUNC('year', listings_latest_src_28000.created_at) AS listing__created_at__year
+                      , EXTRACT(year FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_year
+                      , EXTRACT(quarter FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_quarter
+                      , EXTRACT(month FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_month
+                      , EXTRACT(day FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_day
+                      , EXTRACT(DAY_OF_WEEK FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_dow
+                      , EXTRACT(doy FROM listings_latest_src_28000.created_at) AS listing__created_at__extract_doy
+                      , listings_latest_src_28000.country AS listing__country_latest
+                      , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+                      , listings_latest_src_28000.capacity AS listing__capacity_latest
+                      , listings_latest_src_28000.listing_id AS listing
+                      , listings_latest_src_28000.user_id AS user
+                      , listings_latest_src_28000.user_id AS listing__user
+                    FROM ***************************.dim_listings_latest listings_latest_src_28000
+                  ) subq_18
+                ) subq_19
+              ) subq_20
+              ON
+                subq_17.listing = subq_20.listing
+            ) subq_21
+          ) subq_22
+          WHERE booking__is_instant
+        ) subq_23
+      ) subq_24
+      GROUP BY
+        subq_24.metric_time__day
+        , subq_24.listing__country_latest
+    ) subq_25
+  ) subq_26
+  ON
+    (
+      subq_11.listing__country_latest = subq_26.listing__country_latest
+    ) AND (
+      subq_11.metric_time__day = subq_26.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_11.metric_time__day, subq_26.metric_time__day)
+    , COALESCE(subq_11.listing__country_latest, subq_26.listing__country_latest)
+) subq_27

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,0 +1,108 @@
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , listing__country_latest
+  , bookings - bookings_2_weeks_ago AS bookings_growth_2_weeks
+FROM (
+  -- Combine Aggregated Outputs
+  SELECT
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day) AS metric_time__day
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest) AS listing__country_latest
+    , MAX(subq_39.bookings) AS bookings
+    , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
+  FROM (
+    -- Join Standard Outputs
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      subq_31.metric_time__day AS metric_time__day
+      , listings_latest_src_28000.country AS listing__country_latest
+      , SUM(subq_31.bookings) AS bookings
+    FROM (
+      -- Constrain Output with WHERE
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      SELECT
+        metric_time__day
+        , listing
+        , bookings
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , is_instant AS booking__is_instant
+          , 1 AS bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_29
+      WHERE booking__is_instant
+    ) subq_31
+    LEFT OUTER JOIN
+      ***************************.dim_listings_latest listings_latest_src_28000
+    ON
+      subq_31.listing = listings_latest_src_28000.listing_id
+    GROUP BY
+      subq_31.metric_time__day
+      , listings_latest_src_28000.country
+  ) subq_39
+  FULL OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
+    SELECT
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings_2_weeks_ago
+    FROM (
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+      SELECT
+        subq_45.metric_time__day AS metric_time__day
+        , subq_45.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_45.bookings AS bookings
+      FROM (
+        -- Join to Time Spine Dataset
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+        SELECT
+          subq_43.ds AS metric_time__day
+          , subq_41.listing AS listing
+          , subq_41.booking__is_instant AS booking__is_instant
+          , subq_41.bookings AS bookings
+        FROM ***************************.mf_time_spine subq_43
+        INNER JOIN (
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
+          SELECT
+            DATE_TRUNC('day', ds) AS metric_time__day
+            , listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_41
+        ON
+          DATE_ADD('day', -14, subq_43.ds) = subq_41.metric_time__day
+      ) subq_45
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_45.listing = listings_latest_src_28000.listing_id
+    ) subq_50
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , listing__country_latest
+  ) subq_54
+  ON
+    (
+      subq_39.listing__country_latest = subq_54.listing__country_latest
+    ) AND (
+      subq_39.metric_time__day = subq_54.metric_time__day
+    )
+  GROUP BY
+    COALESCE(subq_39.metric_time__day, subq_54.metric_time__day)
+    , COALESCE(subq_39.listing__country_latest, subq_54.listing__country_latest)
+) subq_55

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0.sql
@@ -1,0 +1,248 @@
+-- Compute Metrics via Expressions
+SELECT
+  subq_8.metric_time__day
+  , subq_8.booking__is_instant
+  , subq_8.bookings AS bookings_join_to_time_spine
+FROM (
+  -- Constrain Output with WHERE
+  SELECT
+    subq_7.metric_time__day
+    , subq_7.booking__is_instant
+    , subq_7.bookings
+  FROM (
+    -- Join to Time Spine Dataset
+    SELECT
+      subq_5.metric_time__day AS metric_time__day
+      , subq_4.booking__is_instant AS booking__is_instant
+      , subq_4.bookings AS bookings
+    FROM (
+      -- Time Spine
+      SELECT
+        subq_6.ds AS metric_time__day
+      FROM ***************************.mf_time_spine subq_6
+    ) subq_5
+    LEFT OUTER JOIN (
+      -- Aggregate Measures
+      SELECT
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+        , SUM(subq_3.bookings) AS bookings
+      FROM (
+        -- Constrain Output with WHERE
+        SELECT
+          subq_2.metric_time__day
+          , subq_2.booking__is_instant
+          , subq_2.bookings
+        FROM (
+          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+          SELECT
+            subq_1.metric_time__day
+            , subq_1.booking__is_instant
+            , subq_1.bookings
+          FROM (
+            -- Metric Time Dimension 'ds'
+            SELECT
+              subq_0.ds__day
+              , subq_0.ds__week
+              , subq_0.ds__month
+              , subq_0.ds__quarter
+              , subq_0.ds__year
+              , subq_0.ds__extract_year
+              , subq_0.ds__extract_quarter
+              , subq_0.ds__extract_month
+              , subq_0.ds__extract_day
+              , subq_0.ds__extract_dow
+              , subq_0.ds__extract_doy
+              , subq_0.ds_partitioned__day
+              , subq_0.ds_partitioned__week
+              , subq_0.ds_partitioned__month
+              , subq_0.ds_partitioned__quarter
+              , subq_0.ds_partitioned__year
+              , subq_0.ds_partitioned__extract_year
+              , subq_0.ds_partitioned__extract_quarter
+              , subq_0.ds_partitioned__extract_month
+              , subq_0.ds_partitioned__extract_day
+              , subq_0.ds_partitioned__extract_dow
+              , subq_0.ds_partitioned__extract_doy
+              , subq_0.paid_at__day
+              , subq_0.paid_at__week
+              , subq_0.paid_at__month
+              , subq_0.paid_at__quarter
+              , subq_0.paid_at__year
+              , subq_0.paid_at__extract_year
+              , subq_0.paid_at__extract_quarter
+              , subq_0.paid_at__extract_month
+              , subq_0.paid_at__extract_day
+              , subq_0.paid_at__extract_dow
+              , subq_0.paid_at__extract_doy
+              , subq_0.booking__ds__day
+              , subq_0.booking__ds__week
+              , subq_0.booking__ds__month
+              , subq_0.booking__ds__quarter
+              , subq_0.booking__ds__year
+              , subq_0.booking__ds__extract_year
+              , subq_0.booking__ds__extract_quarter
+              , subq_0.booking__ds__extract_month
+              , subq_0.booking__ds__extract_day
+              , subq_0.booking__ds__extract_dow
+              , subq_0.booking__ds__extract_doy
+              , subq_0.booking__ds_partitioned__day
+              , subq_0.booking__ds_partitioned__week
+              , subq_0.booking__ds_partitioned__month
+              , subq_0.booking__ds_partitioned__quarter
+              , subq_0.booking__ds_partitioned__year
+              , subq_0.booking__ds_partitioned__extract_year
+              , subq_0.booking__ds_partitioned__extract_quarter
+              , subq_0.booking__ds_partitioned__extract_month
+              , subq_0.booking__ds_partitioned__extract_day
+              , subq_0.booking__ds_partitioned__extract_dow
+              , subq_0.booking__ds_partitioned__extract_doy
+              , subq_0.booking__paid_at__day
+              , subq_0.booking__paid_at__week
+              , subq_0.booking__paid_at__month
+              , subq_0.booking__paid_at__quarter
+              , subq_0.booking__paid_at__year
+              , subq_0.booking__paid_at__extract_year
+              , subq_0.booking__paid_at__extract_quarter
+              , subq_0.booking__paid_at__extract_month
+              , subq_0.booking__paid_at__extract_day
+              , subq_0.booking__paid_at__extract_dow
+              , subq_0.booking__paid_at__extract_doy
+              , subq_0.ds__day AS metric_time__day
+              , subq_0.ds__week AS metric_time__week
+              , subq_0.ds__month AS metric_time__month
+              , subq_0.ds__quarter AS metric_time__quarter
+              , subq_0.ds__year AS metric_time__year
+              , subq_0.ds__extract_year AS metric_time__extract_year
+              , subq_0.ds__extract_quarter AS metric_time__extract_quarter
+              , subq_0.ds__extract_month AS metric_time__extract_month
+              , subq_0.ds__extract_day AS metric_time__extract_day
+              , subq_0.ds__extract_dow AS metric_time__extract_dow
+              , subq_0.ds__extract_doy AS metric_time__extract_doy
+              , subq_0.listing
+              , subq_0.guest
+              , subq_0.host
+              , subq_0.booking__listing
+              , subq_0.booking__guest
+              , subq_0.booking__host
+              , subq_0.is_instant
+              , subq_0.booking__is_instant
+              , subq_0.bookings
+              , subq_0.instant_bookings
+              , subq_0.booking_value
+              , subq_0.max_booking_value
+              , subq_0.min_booking_value
+              , subq_0.bookers
+              , subq_0.average_booking_value
+              , subq_0.referred_bookings
+              , subq_0.median_booking_value
+              , subq_0.booking_value_p99
+              , subq_0.discrete_booking_value_p99
+              , subq_0.approximate_continuous_booking_value_p99
+              , subq_0.approximate_discrete_booking_value_p99
+            FROM (
+              -- Read Elements From Semantic Model 'bookings_source'
+              SELECT
+                1 AS bookings
+                , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+                , bookings_source_src_28000.booking_value
+                , bookings_source_src_28000.booking_value AS max_booking_value
+                , bookings_source_src_28000.booking_value AS min_booking_value
+                , bookings_source_src_28000.guest_id AS bookers
+                , bookings_source_src_28000.booking_value AS average_booking_value
+                , bookings_source_src_28000.booking_value AS booking_payments
+                , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+                , bookings_source_src_28000.booking_value AS median_booking_value
+                , bookings_source_src_28000.booking_value AS booking_value_p99
+                , bookings_source_src_28000.booking_value AS discrete_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_continuous_booking_value_p99
+                , bookings_source_src_28000.booking_value AS approximate_discrete_booking_value_p99
+                , bookings_source_src_28000.is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS paid_at__extract_doy
+                , bookings_source_src_28000.is_instant AS booking__is_instant
+                , DATE_TRUNC('day', bookings_source_src_28000.ds) AS booking__ds__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds) AS booking__ds__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds) AS booking__ds__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds) AS booking__ds__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds) AS booking__ds__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds) AS booking__ds__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds) AS booking__ds__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds) AS booking__ds__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds) AS booking__ds__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds) AS booking__ds__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds) AS booking__ds__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__day
+                , DATE_TRUNC('week', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__week
+                , DATE_TRUNC('month', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__year
+                , EXTRACT(year FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.ds_partitioned) AS booking__ds_partitioned__extract_doy
+                , DATE_TRUNC('day', bookings_source_src_28000.paid_at) AS booking__paid_at__day
+                , DATE_TRUNC('week', bookings_source_src_28000.paid_at) AS booking__paid_at__week
+                , DATE_TRUNC('month', bookings_source_src_28000.paid_at) AS booking__paid_at__month
+                , DATE_TRUNC('quarter', bookings_source_src_28000.paid_at) AS booking__paid_at__quarter
+                , DATE_TRUNC('year', bookings_source_src_28000.paid_at) AS booking__paid_at__year
+                , EXTRACT(year FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_year
+                , EXTRACT(quarter FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_quarter
+                , EXTRACT(month FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_month
+                , EXTRACT(day FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_day
+                , EXTRACT(DAY_OF_WEEK FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_dow
+                , EXTRACT(doy FROM bookings_source_src_28000.paid_at) AS booking__paid_at__extract_doy
+                , bookings_source_src_28000.listing_id AS listing
+                , bookings_source_src_28000.guest_id AS guest
+                , bookings_source_src_28000.host_id AS host
+                , bookings_source_src_28000.listing_id AS booking__listing
+                , bookings_source_src_28000.guest_id AS booking__guest
+                , bookings_source_src_28000.host_id AS booking__host
+              FROM ***************************.fct_bookings bookings_source_src_28000
+            ) subq_0
+          ) subq_1
+        ) subq_2
+        WHERE booking__is_instant
+      ) subq_3
+      GROUP BY
+        subq_3.metric_time__day
+        , subq_3.booking__is_instant
+    ) subq_4
+    ON
+      subq_5.metric_time__day = subq_4.metric_time__day
+  ) subq_7
+  WHERE booking__is_instant
+) subq_8

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -1,0 +1,39 @@
+-- Constrain Output with WHERE
+-- Compute Metrics via Expressions
+SELECT
+  metric_time__day
+  , booking__is_instant
+  , bookings AS bookings_join_to_time_spine
+FROM (
+  -- Join to Time Spine Dataset
+  SELECT
+    subq_15.ds AS metric_time__day
+    , subq_13.booking__is_instant AS booking__is_instant
+    , subq_13.bookings AS bookings
+  FROM ***************************.mf_time_spine subq_15
+  LEFT OUTER JOIN (
+    -- Constrain Output with WHERE
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
+    -- Aggregate Measures
+    SELECT
+      metric_time__day
+      , booking__is_instant
+      , SUM(bookings) AS bookings
+    FROM (
+      -- Read Elements From Semantic Model 'bookings_source'
+      -- Metric Time Dimension 'ds'
+      SELECT
+        DATE_TRUNC('day', ds) AS metric_time__day
+        , is_instant AS booking__is_instant
+        , 1 AS bookings
+      FROM ***************************.fct_bookings bookings_source_src_28000
+    ) subq_10
+    WHERE booking__is_instant
+    GROUP BY
+      metric_time__day
+      , booking__is_instant
+  ) subq_13
+  ON
+    subq_15.ds = subq_13.metric_time__day
+) subq_16
+WHERE booking__is_instant


### PR DESCRIPTION
Add SQL rendering tests for pushdown edge cases

The predicate pushdown optimizer tests cover direct edge cases
for the optimizer alone, but we would like to have query rendering
variations of this so we can see how optimizers interact in their
query output.

This adds the relevant query rendering test scenarios along with
their associated snapshots.

Update SQL engine snapshots