### PR TITLE
Enable SourceScanOptimizer in query rendering tests

### DIFF
--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -52,7 +52,10 @@ def render_and_check(
     )
 
     # Run dataflow -> sql conversion with all optimizers
-    optimizations = (DataflowPlanOptimization.PREDICATE_PUSHDOWN,)
+    optimizations = (
+        DataflowPlanOptimization.SOURCE_SCAN,
+        DataflowPlanOptimization.PREDICATE_PUSHDOWN,
+    )
     if is_distinct_values_plan:
         optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec, optimizations=optimizations)
     else:

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATETIME_TRUNC(ds, day) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
     metric_time__day
-) subq_21
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
         metric_time__day
-    ) subq_33
-  ) subq_34
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
     metric_time__day
-) subq_45
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_derived_metric__plan0_optimized.sql
@@ -3,49 +3,22 @@ SELECT
   metric_time__day
   , (bookings - ref_bookings) * 1.0 / bookings AS non_referred_bookings_pct
 FROM (
-  -- Combine Aggregated Outputs
+  -- Aggregate Measures
+  -- Compute Metrics via Expressions
   SELECT
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day) AS metric_time__day
-    , MAX(subq_15.ref_bookings) AS ref_bookings
-    , MAX(subq_20.bookings) AS bookings
+    metric_time__day
+    , SUM(referred_bookings) AS ref_bookings
+    , SUM(bookings) AS bookings
   FROM (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
+    -- Read Elements From Semantic Model 'bookings_source'
+    -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
     SELECT
-      metric_time__day
-      , SUM(referred_bookings) AS ref_bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_13
-    GROUP BY
-      metric_time__day
-  ) subq_15
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , 1 AS bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_18
-    GROUP BY
-      metric_time__day
-  ) subq_20
-  ON
-    subq_15.metric_time__day = subq_20.metric_time__day
+      DATE_TRUNC('day', ds) AS metric_time__day
+      , 1 AS bookings
+      , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+    FROM ***************************.fct_bookings bookings_source_src_28000
+  ) subq_13
   GROUP BY
-    COALESCE(subq_15.metric_time__day, subq_20.metric_time__day)
-) subq_21
+    metric_time__day
+) subq_15

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_derived_metric__plan0_optimized.sql
@@ -5,103 +5,58 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day) AS metric_time__day
-    , MAX(subq_34.non_referred) AS non_referred
-    , MAX(subq_39.instant) AS instant
-    , MAX(subq_44.bookings) AS bookings
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day) AS metric_time__day
+    , MAX(subq_28.non_referred) AS non_referred
+    , MAX(subq_33.instant) AS instant
+    , MAX(subq_33.bookings) AS bookings
   FROM (
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , (bookings - ref_bookings) * 1.0 / bookings AS non_referred
     FROM (
-      -- Combine Aggregated Outputs
+      -- Aggregate Measures
+      -- Compute Metrics via Expressions
       SELECT
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day) AS metric_time__day
-        , MAX(subq_27.ref_bookings) AS ref_bookings
-        , MAX(subq_32.bookings) AS bookings
+        metric_time__day
+        , SUM(referred_bookings) AS ref_bookings
+        , SUM(bookings) AS bookings
       FROM (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['referred_bookings', 'bookings', 'metric_time__day']
         SELECT
-          metric_time__day
-          , SUM(referred_bookings) AS ref_bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['referred_bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_25
-        GROUP BY
-          metric_time__day
-      ) subq_27
-      FULL OUTER JOIN (
-        -- Aggregate Measures
-        -- Compute Metrics via Expressions
-        SELECT
-          metric_time__day
-          , SUM(bookings) AS bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['bookings', 'metric_time__day']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_30
-        GROUP BY
-          metric_time__day
-      ) subq_32
-      ON
-        subq_27.metric_time__day = subq_32.metric_time__day
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , 1 AS bookings
+          , CASE WHEN referrer_id IS NOT NULL THEN 1 ELSE 0 END AS referred_bookings
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_25
       GROUP BY
-        COALESCE(subq_27.metric_time__day, subq_32.metric_time__day)
-    ) subq_33
-  ) subq_34
+        metric_time__day
+    ) subq_27
+  ) subq_28
   FULL OUTER JOIN (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , SUM(instant_bookings) AS instant
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['instant_bookings', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_37
-    GROUP BY
-      metric_time__day
-  ) subq_39
-  ON
-    subq_34.metric_time__day = subq_39.metric_time__day
-  FULL OUTER JOIN (
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
       , SUM(bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookings', 'metric_time__day']
+      -- Pass Only Elements: ['instant_bookings', 'bookings', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , 1 AS bookings
+        , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_42
+    ) subq_31
     GROUP BY
       metric_time__day
-  ) subq_44
+  ) subq_33
   ON
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day) = subq_44.metric_time__day
+    subq_28.metric_time__day = subq_33.metric_time__day
   GROUP BY
-    COALESCE(subq_34.metric_time__day, subq_39.metric_time__day, subq_44.metric_time__day)
-) subq_45
+    COALESCE(subq_28.metric_time__day, subq_33.metric_time__day)
+) subq_34

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -9,26 +9,29 @@ FROM (
     -- Combine Aggregated Outputs
     SELECT
       MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_57.bookings) AS bookings
-      , MAX(subq_64.booking_value) AS booking_value
+      , MAX(subq_45.bookings) AS bookings
+      , MAX(subq_52.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['average_booking_value',]
+      -- Pass Only Elements: ['average_booking_value', 'bookings']
       -- Aggregate Measures
       -- Compute Metrics via Expressions
       SELECT
         AVG(average_booking_value) AS average_booking_value
+        , SUM(bookings) AS bookings
       FROM (
         -- Join Standard Outputs
-        -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'booking__is_instant']
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
           listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_36.bookings AS bookings
           , subq_36.average_booking_value AS average_booking_value
         FROM (
           -- Constrain Output with WHERE
-          -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
+          -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
             listing
+            , bookings
             , average_booking_value
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
@@ -36,6 +39,7 @@ FROM (
             SELECT
               listing_id AS listing
               , is_instant AS booking__is_instant
+              , 1 AS bookings
               , booking_value AS average_booking_value
             FROM ***************************.fct_bookings bookings_source_src_28000
           ) subq_34
@@ -48,36 +52,6 @@ FROM (
       ) subq_41
       WHERE listing__is_lux_latest
     ) subq_45
-    CROSS JOIN (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'booking__is_instant']
-      -- Pass Only Elements: ['bookings',]
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        SUM(subq_49.bookings) AS bookings
-      FROM (
-        -- Constrain Output with WHERE
-        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
-        SELECT
-          listing
-          , bookings
-        FROM (
-          -- Read Elements From Semantic Model 'bookings_source'
-          -- Metric Time Dimension 'ds'
-          SELECT
-            listing_id AS listing
-            , is_instant AS booking__is_instant
-            , 1 AS bookings
-          FROM ***************************.fct_bookings bookings_source_src_28000
-        ) subq_47
-        WHERE booking__is_instant
-      ) subq_49
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_49.listing = listings_latest_src_28000.listing_id
-    ) subq_57
     CROSS JOIN (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['booking_value', 'booking__is_instant']
@@ -93,8 +67,8 @@ FROM (
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_59
+      ) subq_47
       WHERE booking__is_instant
-    ) subq_64
-  ) subq_65
-) subq_66
+    ) subq_52
+  ) subq_53
+) subq_54

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS FLOAT64) / CAST(NULLIF(subq_34.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS FLOAT64) / CAST(NULLIF(subq_28.bookers, 0) AS FLOAT64) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
       listing
-  ) subq_34
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE PRECISION) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE PRECISION) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0_optimized.sql
@@ -8,7 +8,7 @@ FROM (
   -- Join Standard Outputs
   -- Pass Only Elements: ['listings', 'listing__bookings_per_booker']
   SELECT
-    CAST(subq_34.bookings AS DOUBLE) / CAST(NULLIF(subq_34.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
+    CAST(subq_28.bookings AS DOUBLE) / CAST(NULLIF(subq_28.bookers, 0) AS DOUBLE) AS listing__bookings_per_booker
     , subq_23.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
@@ -20,48 +20,26 @@ FROM (
     FROM ***************************.dim_listings_latest listings_latest_src_28000
   ) subq_23
   LEFT OUTER JOIN (
-    -- Combine Aggregated Outputs
+    -- Aggregate Measures
+    -- Compute Metrics via Expressions
     SELECT
-      COALESCE(subq_28.listing, subq_33.listing) AS listing
-      , MAX(subq_28.bookings) AS bookings
-      , MAX(subq_33.bookers) AS bookers
+      listing
+      , SUM(bookings) AS bookings
+      , COUNT(DISTINCT bookers) AS bookers
     FROM (
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
-      SELECT
-        listing
-        , SUM(bookings) AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'listing']
-        SELECT
-          listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_26
-      GROUP BY
-        listing
-    ) subq_28
-    FULL OUTER JOIN (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['bookers', 'listing']
-      -- Aggregate Measures
-      -- Compute Metrics via Expressions
+      -- Pass Only Elements: ['bookings', 'bookers', 'listing']
       SELECT
         listing_id AS listing
-        , COUNT(DISTINCT guest_id) AS bookers
+        , 1 AS bookings
+        , guest_id AS bookers
       FROM ***************************.fct_bookings bookings_source_src_28000
-      GROUP BY
-        listing_id
-    ) subq_33
-    ON
-      subq_28.listing = subq_33.listing
+    ) subq_26
     GROUP BY
-      COALESCE(subq_28.listing, subq_33.listing)
-  ) subq_34
+      listing
+  ) subq_28
   ON
-    subq_23.listing = subq_34.listing
-) subq_38
+    subq_23.listing = subq_28.listing
+) subq_32
 WHERE listing__bookings_per_booker > 1

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATETIME_TRUNC(ds, day) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    metric_time__day
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATETIME_TRUNC(bookings_source_src_28000.ds, day) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATETIME_TRUNC(ds, day) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       metric_time__day
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
     metric_time__day
-) subq_59
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_common_semantic_model__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_common_semantic_model__plan0_optimized.sql
@@ -1,40 +1,18 @@
--- Combine Aggregated Outputs
+-- Aggregate Measures
+-- Compute Metrics via Expressions
 SELECT
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
-  , MAX(subq_14.bookings) AS bookings
-  , MAX(subq_19.booking_value) AS booking_value
+  metric_time__day
+  , SUM(bookings) AS bookings
+  , SUM(booking_value) AS booking_value
 FROM (
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
-  SELECT
-    metric_time__day
-    , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  GROUP BY
-    metric_time__day
-) subq_14
-FULL OUTER JOIN (
   -- Read Elements From Semantic Model 'bookings_source'
   -- Metric Time Dimension 'ds'
-  -- Pass Only Elements: ['booking_value', 'metric_time__day']
-  -- Aggregate Measures
-  -- Compute Metrics via Expressions
+  -- Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day']
   SELECT
     DATE_TRUNC('day', ds) AS metric_time__day
-    , SUM(booking_value) AS booking_value
+    , 1 AS bookings
+    , booking_value
   FROM ***************************.fct_bookings bookings_source_src_28000
-  GROUP BY
-    DATE_TRUNC('day', ds)
-) subq_19
-ON
-  subq_14.metric_time__day = subq_19.metric_time__day
+) subq_12
 GROUP BY
-  COALESCE(subq_14.metric_time__day, subq_19.metric_time__day)
+  metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint__plan0_optimized.sql
@@ -5,71 +5,47 @@ SELECT
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day) AS metric_time__day
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day) AS metric_time__day
     , MAX(subq_41.average_booking_value) AS average_booking_value
-    , MAX(subq_53.bookings) AS bookings
-    , MAX(subq_58.booking_value) AS booking_value
+    , MAX(subq_41.bookings) AS bookings
+    , MAX(subq_46.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
+    -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
       metric_time__day
       , AVG(average_booking_value) AS average_booking_value
+      , SUM(bookings) AS bookings
     FROM (
       -- Join Standard Outputs
-      -- Pass Only Elements: ['average_booking_value', 'listing__is_lux_latest', 'metric_time__day']
+      -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'metric_time__day']
       SELECT
-        DATE_TRUNC('day', bookings_source_src_28000.ds) AS metric_time__day
+        subq_32.metric_time__day AS metric_time__day
         , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , bookings_source_src_28000.booking_value AS average_booking_value
-      FROM ***************************.fct_bookings bookings_source_src_28000
+        , subq_32.bookings AS bookings
+        , subq_32.average_booking_value AS average_booking_value
+      FROM (
+        -- Read Elements From Semantic Model 'bookings_source'
+        -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['average_booking_value', 'bookings', 'metric_time__day', 'listing']
+        SELECT
+          DATE_TRUNC('day', ds) AS metric_time__day
+          , listing_id AS listing
+          , 1 AS bookings
+          , booking_value AS average_booking_value
+        FROM ***************************.fct_bookings bookings_source_src_28000
+      ) subq_32
       LEFT OUTER JOIN
         ***************************.dim_listings_latest listings_latest_src_28000
       ON
-        bookings_source_src_28000.listing_id = listings_latest_src_28000.listing_id
+        subq_32.listing = listings_latest_src_28000.listing_id
     ) subq_37
     WHERE listing__is_lux_latest
     GROUP BY
       metric_time__day
   ) subq_41
-  FULL OUTER JOIN (
-    -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    -- Aggregate Measures
-    -- Compute Metrics via Expressions
-    SELECT
-      metric_time__day
-      , SUM(bookings) AS bookings
-    FROM (
-      -- Join Standard Outputs
-      -- Pass Only Elements: ['bookings', 'listing__is_lux_latest', 'metric_time__day']
-      SELECT
-        subq_44.metric_time__day AS metric_time__day
-        , listings_latest_src_28000.is_lux AS listing__is_lux_latest
-        , subq_44.bookings AS bookings
-      FROM (
-        -- Read Elements From Semantic Model 'bookings_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , listing_id AS listing
-          , 1 AS bookings
-        FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_44
-      LEFT OUTER JOIN
-        ***************************.dim_listings_latest listings_latest_src_28000
-      ON
-        subq_44.listing = listings_latest_src_28000.listing_id
-    ) subq_49
-    WHERE listing__is_lux_latest
-    GROUP BY
-      metric_time__day
-  ) subq_53
-  ON
-    subq_41.metric_time__day = subq_53.metric_time__day
   FULL OUTER JOIN (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
@@ -82,9 +58,9 @@ FROM (
     FROM ***************************.fct_bookings bookings_source_src_28000
     GROUP BY
       DATE_TRUNC('day', ds)
-  ) subq_58
+  ) subq_46
   ON
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day) = subq_58.metric_time__day
+    subq_41.metric_time__day = subq_46.metric_time__day
   GROUP BY
-    COALESCE(subq_41.metric_time__day, subq_53.metric_time__day, subq_58.metric_time__day)
-) subq_59
+    COALESCE(subq_41.metric_time__day, subq_46.metric_time__day)
+) subq_47


### PR DESCRIPTION
Enable SourceScanOptimizer in query rendering tests

The query rendering test suite recently added support for
DataflowPlanOptimizer usage, but that only included the
PredicatePushdownOptimizer to support development.

Now that we are getting ready to release we need to see how the
queries come out with all optimizers in place, so we add the
missing SourceScanOptimizer to the set.

Update SQL engine snapshots