### PR TITLE
Enable PredicatePushdownOptimization for all MetricFlowEngine queries

### DIFF
--- a/.changes/unreleased/Features-20240625-152952.yaml
+++ b/.changes/unreleased/Features-20240625-152952.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Enable predicate pushdown optimization by default for all callers
+time: 2024-06-25T15:29:52.514224-07:00
+custom:
+    Author: tlento
+    Issue: "1011"

--- a/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
+++ b/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
@@ -24,6 +24,11 @@ class DataflowPlanOptimization(Enum):
     SOURCE_SCAN = 0
     PREDICATE_PUSHDOWN = 1
 
+    @staticmethod
+    def all_optimizations() -> FrozenSet[DataflowPlanOptimization]:
+        """Convenience method for getting a set of all available optimizations."""
+        return frozenset((DataflowPlanOptimization.SOURCE_SCAN, DataflowPlanOptimization.PREDICATE_PUSHDOWN))
+
 
 class DataflowPlanOptimizerFactory:
     """Factory class for initializing an enumerated set of optimizers.

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -52,16 +52,14 @@ def render_and_check(
     )
 
     # Run dataflow -> sql conversion with all optimizers
-    optimizations = (
-        DataflowPlanOptimization.SOURCE_SCAN,
-        DataflowPlanOptimization.PREDICATE_PUSHDOWN,
-    )
     if is_distinct_values_plan:
         optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-            query_spec, optimizations=frozenset(optimizations)
+            query_spec, optimizations=DataflowPlanOptimization.all_optimizations()
         )
     else:
-        optimized_plan = dataflow_plan_builder.build_plan(query_spec, optimizations=frozenset(optimizations))
+        optimized_plan = dataflow_plan_builder.build_plan(
+            query_spec, optimizations=DataflowPlanOptimization.all_optimizations()
+        )
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=optimized_plan.sink_node,


### PR DESCRIPTION
This effectively releases PredicatePushdownOptimization - the moment
this change is deployed to cloud it will be enabled.

In order to allow for a rapid mitigation of any unexpected issues this
also parameterizes the query request object to allow callers to
disable optimizations as needed. This means cloud services calling
this method can override the optimizer behaviors without requiring
an update to MetricFlow.