### PR TITLE
fix: Add Column Header to the exported CSV from query command

### DIFF
--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -340,6 +340,7 @@ def query(
         elif csv is not None:
             # csv is a LazyFile that is file-like that works in this case.
             csv_writer = csv_module.writer(csv)
+            csv_writer.writerow(df.column_names)
             for row in df.rows:
                 csv_writer.writerow(row)
             click.echo(f"🖨 Successfully written query output to {csv.name}")


### PR DESCRIPTION
# Issue
https://github.com/dbt-labs/metricflow/issues/1285

The CSV exported from the `mf query <metric> --csv <csv-file-name>` command does not contain the column header. The CSV thus does not make too much sense.

# Fix
- The code [here](https://github.com/dbt-labs/metricflow/blob/main/dbt-metricflow/dbt_metricflow/cli/main.py#L344) is writing data to the CSV file. The column names aren't getting added to the file.
- With this PR, we are adding the column names returned from `df.column_names` to the CSV to fix the issue.