### PR TITLE
Remove inconsistent validation for `TimeDimensionParameter`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
+++ b/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
@@ -41,11 +41,6 @@ class TimeDimensionParameter(ProtocolHint[TimeDimensionQueryParameter]):
     grain: Optional[TimeGranularity] = None
     date_part: Optional[DatePart] = None
 
-    def __post_init__(self) -> None:  # noqa: D105
-        parsed_name = StructuredLinkableSpecName.from_name(self.name)
-        if parsed_name.time_granularity:
-            raise ValueError("Must use object syntax for `grain` parameter if `date_part` is requested.")
-
     @property
     def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
         fields_to_compare = [


### PR DESCRIPTION
Two things:
- This error wasn't do what it was supposed to do, since it never checked if `date_part` was passed. I don't think this ever got triggered because MFS was parsing the grain from the `name` param and passing it via the `grain` param instead.
- I ran into this error in the process of trying to create consistency in the behavior of our Jinja params. Since most interfaces allow passing grain via dundered syntax, this interface is inconsistent. If we eventually want to retire the dunder syntax, we should deprecate it everywhere at once to avoid creating confusion for our users in the meantime.