### PR TITLE
Upgrade DSI

### DIFF
--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.6.1
+dbt-semantic-interfaces==0.6.5
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -104,7 +104,7 @@ class SemanticModelLookup:
 
     def get_time_dimension(self, time_dimension_reference: TimeDimensionReference) -> Dimension:
         """Retrieves a full dimension object by name."""
-        return self.get_dimension(dimension_reference=time_dimension_reference.dimension_reference())
+        return self.get_dimension(dimension_reference=time_dimension_reference.dimension_reference)
 
     @property
     def measure_references(self) -> Sequence[MeasureReference]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metricflow"
-version = "0.207.0.dev1"
+version = "0.207.0.dev2"
 description = "Translates a simple metric definition into reusable SQL and executes it against the SQL engine of your choice."
 readme = "README.md"
 requires-python = ">=3.8,<3.13"


### PR DESCRIPTION
Upgrades DSI. This is needed to upgrade DSI in MFS. MFS does not depend on DSI directly, instead relying on MF to set the DSI dependency. The DSI upgrade is needed in MFS to get [this bug fix](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/309) released.
[This is the PR](https://github.com/dbt-labs/metricflow-server/pull/746) currently blocked by the upgrade.