### PR TITLE
Allow passing granularity in where filter `TimeDimension` name

### DIFF
--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 # dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
-dbt-semantic-interfaces>=0.6.1, <2.0.0
+dbt-semantic-interfaces>=0.6.5, <2.0.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter_time_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter_time_dimension.py
@@ -91,6 +91,15 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
             )
         structured_name = DunderedNameFormatter.parse_name(time_dimension_name.lower())
 
+        grain_parsed_from_name = structured_name.time_granularity
+        grain_from_param = TimeGranularity(time_granularity_name) if time_granularity_name else None
+        if grain_parsed_from_name and grain_from_param and grain_parsed_from_name != grain_from_param:
+            raise InvalidQuerySyntax(
+                f"Received different granularities in `time_dimension_name` parameter ('{time_dimension_name}') "
+                f"and `time_granularity_name` parameter ('{time_granularity_name}')."
+            )
+
+        TimeGranularity(time_granularity_name.lower()) if time_granularity_name else None
         return WhereFilterTimeDimension(
             column_association_resolver=self._column_association_resolver,
             resolved_spec_lookup=self._resolved_spec_lookup,
@@ -99,6 +108,6 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
             element_name=structured_name.element_name,
             entity_links=tuple(EntityReference(entity_link_name.lower()) for entity_link_name in entity_path)
             + structured_name.entity_links,
-            time_grain=TimeGranularity(time_granularity_name.lower()) if time_granularity_name else None,
+            time_grain=grain_from_param or grain_parsed_from_name,
             date_part=DatePart(date_part_name.lower()) if date_part_name else None,
         )


### PR DESCRIPTION
Allow users to use dunder syntax to pass granularity in where filter `TimeDimension`. Ex:
`{{ TimeDimension('metric_time__month') }} > 2020-01-01`
This behavior is currently implemented everywhere else that similar Jinja parsing happens, making this one site inconsistent. Fix that to avoid user confusion.