### PR TITLE
Fix bug in line-width control in DAG pretty printer

### DIFF
--- a/metricflow-semantics/metricflow_semantics/dag/dag_to_text.py
+++ b/metricflow-semantics/metricflow_semantics/dag/dag_to_text.py
@@ -34,7 +34,7 @@ class MaxWidthTracker:
     def update_max_width_for_indented_section(self, indent_prefix: str) -> Iterator[None]:
         """Context manager used to wrap the code that prints an indented section."""
         previous_max_width = self._current_max_width
-        self._current_max_width = max(0, self._current_max_width - len(indent_prefix))
+        self._current_max_width = max(1, self._current_max_width - len(indent_prefix))
         yield None
         self._current_max_width = previous_max_width
 
@@ -101,7 +101,7 @@ class MetricFlowDagTextFormatter:
                 displayed_property.value,
                 # The string representation of displayed_property.value will be wrapped with "<!-- ", " -->" so subtract
                 # the width of those.
-                max_line_length=max_width - len("<!-- ") - len(" -->"),
+                max_line_length=max(1, max_width - len("<!-- ") - len(" -->")),
                 indent_prefix=self._value_indent_prefix,
             )
 

--- a/tests_metricflow/mf_logging/test_dag_to_text.py
+++ b/tests_metricflow/mf_logging/test_dag_to_text.py
@@ -70,11 +70,16 @@ def test_multithread_dag_to_text() -> None:
         <SqlQueryPlan>
             <SqlSelectStatementNode>
                 <!-- description =  -->
-                <!--   test -->
-                <!-- node_id =  -->
-                <!--   ss_0 -->
-                <!-- col0 =                                                                                        -->
-                <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_0 sql_expr='foo'), column_alias='bar') -->
+                <!--   'test' -->
+                <!-- node_id =          -->
+                <!--   NodeId(          -->
+                <!--     id_str='ss_0', -->
+                <!--   )                -->
+                <!-- col0 =                                                      -->
+                <!--   SqlSelectColumn(                                          -->
+                <!--     expr=SqlStringExpression(node_id=str_0 sql_expr='foo'), -->
+                <!--     column_alias='bar',                                     -->
+                <!--   )                                                         -->
                 <!-- from_source =                           -->
                 <!--   SqlTableFromClauseNode(node_id=tfc_0) -->
                 <!-- where =  -->
@@ -82,12 +87,16 @@ def test_multithread_dag_to_text() -> None:
                 <!-- distinct =  -->
                 <!--   False -->
                 <SqlTableFromClauseNode>
-                    <!-- description =            -->
-                    <!--   Read from schema.table -->
-                    <!-- node_id =  -->
-                    <!--   tfc_0 -->
-                    <!-- table_id =     -->
-                    <!--   schema.table -->
+                    <!-- description =      -->
+                    <!--   ('Read '         -->
+                    <!--    'from '         -->
+                    <!--    'schema.table') -->
+                    <!-- node_id =           -->
+                    <!--   NodeId(           -->
+                    <!--     id_str='tfc_0', -->
+                    <!--   )                 -->
+                    <!-- table_id =       -->
+                    <!--   'schema.table' -->
                 </SqlTableFromClauseNode>
             </SqlSelectStatementNode>
         </SqlQueryPlan>


### PR DESCRIPTION
This PR fixes a bug with how the maximum width for pretty printing was not correctly computed. Note that `SqlStringExpression(node_id=str_0 sql_expr='foo')` is longer than expected - this is due to a `__repr__` issue that will be addressed in a follow up.