### PR TITLE
Convert DAG node classes to dataclasses

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/dag_builder.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/dag_builder.py
@@ -56,19 +56,19 @@ class GroupByItemResolutionDagBuilder:
                 )
 
             source_candidates_for_measure_nodes = tuple(
-                MeasureGroupByItemSourceNode(
+                MeasureGroupByItemSourceNode.create(
                     measure_reference=measure_reference,
                     child_metric_reference=metric_reference,
                 )
                 for measure_reference in measure_references_for_metric
             )
-            return MetricGroupByItemResolutionNode(
+            return MetricGroupByItemResolutionNode.create(
                 metric_reference=metric_reference,
                 metric_input_location=metric_input_location,
                 parent_nodes=source_candidates_for_measure_nodes,
             )
         # For a derived metric, the parents are other metrics.
-        return MetricGroupByItemResolutionNode(
+        return MetricGroupByItemResolutionNode.create(
             metric_reference=metric_reference,
             metric_input_location=metric_input_location,
             parent_nodes=tuple(
@@ -88,12 +88,12 @@ class GroupByItemResolutionDagBuilder:
     ) -> QueryGroupByItemResolutionNode:
         """Builds a DAG component that represents the resolution flow for a query."""
         if len(metric_references) == 0:
-            return QueryGroupByItemResolutionNode(
-                parent_nodes=(NoMetricsGroupByItemSourceNode(),),
+            return QueryGroupByItemResolutionNode.create(
+                parent_nodes=(NoMetricsGroupByItemSourceNode.create(),),
                 metrics_in_query=metric_references,
                 where_filter_intersection=where_filter_intersection,
             )
-        return QueryGroupByItemResolutionNode(
+        return QueryGroupByItemResolutionNode.create(
             parent_nodes=tuple(
                 self._build_dag_component_for_metric(
                     metric_reference=metric_reference,

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/base_node.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/base_node.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import itertools
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Sequence, Tuple
+from typing import TYPE_CHECKING, Generic, Tuple
 
 from typing_extensions import override
 
 from metricflow_semantics.collection_helpers.merger import Mergeable
-from metricflow_semantics.dag.mf_dag import DagNode, NodeId
+from metricflow_semantics.dag.mf_dag import DagNode
 from metricflow_semantics.visitor import Visitable, VisitorOutputT
 
 if TYPE_CHECKING:
@@ -26,14 +26,14 @@ if TYPE_CHECKING:
     )
 
 
-class GroupByItemResolutionNode(DagNode, Visitable, ABC):
+@dataclass(frozen=True)
+class GroupByItemResolutionNode(DagNode["GroupByItemResolutionNode"], Visitable, ABC):
     """Base node type for nodes in a GroupByItemResolutionDag.
 
     See GroupByItemResolutionDag for more details.
     """
 
-    def __init__(self) -> None:  # noqa: D107
-        super().__init__(node_id=NodeId.create_unique(self.__class__.id_prefix()))
+    parent_nodes: Tuple[GroupByItemResolutionNode, ...]
 
     @abstractmethod
     def accept(self, visitor: GroupByItemResolutionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
@@ -44,11 +44,6 @@ class GroupByItemResolutionNode(DagNode, Visitable, ABC):
     @abstractmethod
     def ui_description(self) -> str:
         """A string that can be used to describe this node as a path element in the UI."""
-        raise NotImplementedError
-
-    @property
-    @abstractmethod
-    def parent_nodes(self) -> Sequence[GroupByItemResolutionNode]:  # noqa: D102
         raise NotImplementedError
 
     @abstractmethod

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/metric_resolution_node.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence, Union
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple, Union
 
 from dbt_semantic_interfaces.references import MetricReference
-from typing_extensions import Self, override
+from typing_extensions import override
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DisplayedProperty
@@ -19,27 +20,31 @@ from metricflow_semantics.query.group_by_item.resolution_dag.resolution_nodes.me
 from metricflow_semantics.visitor import VisitorOutputT
 
 
+@dataclass(frozen=True)
 class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
-    """Outputs group-by-items relevant to a metric based on the input group-by-items."""
+    """Outputs group-by-items relevant to a metric based on the input group-by-items.
 
-    def __init__(
-        self,
+    Attributes:
+        metric_reference: The metric that this represents.
+        metric_input_location: If this is an input metric for a derived metric, the location within the derived metric definition.
+        parent_nodes: The parent nodes of this metric.
+    """
+
+    metric_reference: MetricReference
+    metric_input_location: Optional[InputMetricDefinitionLocation]
+    parent_nodes: Tuple[Union[MeasureGroupByItemSourceNode, MetricGroupByItemResolutionNode], ...]
+
+    @staticmethod
+    def create(  # noqa: D102
         metric_reference: MetricReference,
         metric_input_location: Optional[InputMetricDefinitionLocation],
-        parent_nodes: Sequence[Union[MeasureGroupByItemSourceNode, Self]],
-    ) -> None:
-        """Initializer.
-
-        Args:
-            metric_reference: The metric that this represents.
-            metric_input_location: If this is an input metric for a derived metric, the location within the derived
-            metric definition.
-            parent_nodes: The parent nodes of this metric.
-        """
-        self._metric_reference = metric_reference
-        self._metric_input_location = metric_input_location
-        self._parent_nodes = parent_nodes
-        super().__init__()
+        parent_nodes: Sequence[Union[MeasureGroupByItemSourceNode, MetricGroupByItemResolutionNode]],
+    ) -> MetricGroupByItemResolutionNode:
+        return MetricGroupByItemResolutionNode(
+            metric_reference=metric_reference,
+            metric_input_location=metric_input_location,
+            parent_nodes=tuple(parent_nodes),
+        )
 
     @override
     def accept(self, visitor: GroupByItemResolutionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
@@ -49,11 +54,6 @@ class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
     @override
     def description(self) -> str:
         return "Output group-by-items available for this metric."
-
-    @property
-    @override
-    def parent_nodes(self) -> Sequence[Union[MeasureGroupByItemSourceNode, Self]]:
-        return self._parent_nodes
 
     @classmethod
     @override
@@ -66,26 +66,18 @@ class MetricGroupByItemResolutionNode(GroupByItemResolutionNode):
         return tuple(super().displayed_properties) + (
             DisplayedProperty(
                 key="metric_reference",
-                value=str(self._metric_reference),
+                value=str(self.metric_reference),
             ),
         )
 
     @property
-    def metric_reference(self) -> MetricReference:  # noqa: D102
-        return self._metric_reference
-
-    @property
-    def metric_input_location(self) -> Optional[InputMetricDefinitionLocation]:  # noqa: D102
-        return self._metric_input_location
-
-    @property
     @override
     def ui_description(self) -> str:
-        if self._metric_input_location is None:
-            return f"Metric({repr(self._metric_reference.element_name)})"
+        if self.metric_input_location is None:
+            return f"Metric({repr(self.metric_reference.element_name)})"
         return (
-            f"Metric({repr(self._metric_reference.element_name)}, "
-            f"input_metric_index={self._metric_input_location.input_metric_list_index})"
+            f"Metric({repr(self.metric_reference.element_name)}, "
+            f"input_metric_index={self.metric_input_location.input_metric_list_index})"
         )
 
     @override

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/no_metrics_query_source_node.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/resolution_dag/resolution_nodes/no_metrics_query_source_node.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from dataclasses import dataclass
 
 from typing_extensions import override
 
@@ -10,17 +10,20 @@ from metricflow_semantics.query.group_by_item.resolution_dag.resolution_nodes.ba
     GroupByItemResolutionNodeSet,
     GroupByItemResolutionNodeVisitor,
 )
-from metricflow_semantics.query.group_by_item.resolution_dag.resolution_nodes.metric_resolution_node import (
-    MetricGroupByItemResolutionNode,
-)
 from metricflow_semantics.visitor import VisitorOutputT
 
 
+@dataclass(frozen=True)
 class NoMetricsGroupByItemSourceNode(GroupByItemResolutionNode):
     """Outputs group-by-items that can be queried without any metrics."""
 
-    def __init__(self) -> None:  # noqa: D107
-        super().__init__()
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 0
+
+    @staticmethod
+    def create() -> NoMetricsGroupByItemSourceNode:  # noqa: D102
+        return NoMetricsGroupByItemSourceNode(parent_nodes=())
 
     @override
     def accept(self, visitor: GroupByItemResolutionNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
@@ -30,11 +33,6 @@ class NoMetricsGroupByItemSourceNode(GroupByItemResolutionNode):
     @override
     def description(self) -> str:
         return "Output the available group-by-items for a query without any metrics."
-
-    @property
-    @override
-    def parent_nodes(self) -> Sequence[MetricGroupByItemResolutionNode]:
-        return ()
 
     @classmethod
     @override

--- a/metricflow-semantics/metricflow_semantics/query/query_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_resolver.py
@@ -381,7 +381,7 @@ class MetricFlowQueryResolver:
 
         # Define a resolution path for issues where the input is considered to be the whole query.
         query_resolution_path = MetricFlowQueryResolutionPath.from_path_item(
-            QueryGroupByItemResolutionNode(
+            QueryGroupByItemResolutionNode.create(
                 parent_nodes=(),
                 metrics_in_query=tuple(metric_input.spec_pattern.metric_reference for metric_input in metric_inputs),
                 where_filter_intersection=query_level_filter_input.where_filter_intersection,

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
@@ -131,7 +131,7 @@ def test_missing_parent_for_metric(
     or measures). However, in the event of a validation gap upstream, we sometimes encounter inscrutable errors
     caused by missing parent nodes for these input types, so we add a more informative error and test for it here.
     """
-    metric_node = MetricGroupByItemResolutionNode(
+    metric_node = MetricGroupByItemResolutionNode.create(
         metric_reference=MetricReference(element_name="bad_metric"), metric_input_location=None, parent_nodes=tuple()
     )
     resolution_dag = GroupByItemResolutionDag(sink_node=metric_node)

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -122,7 +122,7 @@ class JoinLinkableInstancesRecipe:
             ]
         )
 
-        filtered_node_to_join = FilterElementsNode(
+        filtered_node_to_join = FilterElementsNode.create(
             parent_node=self.node_to_join, include_specs=group_specs_by_type(include_specs)
         )
 

--- a/metricflow/dataflow/builder/source_node.py
+++ b/metricflow/dataflow/builder/source_node.py
@@ -59,8 +59,8 @@ class SourceNodeBuilder:
         time_spine_source = TimeSpineSource.create_from_manifest(semantic_manifest_lookup.semantic_manifest)
         time_spine_data_set = data_set_converter.build_time_spine_source_data_set(time_spine_source)
         time_dim_reference = TimeDimensionReference(element_name=time_spine_source.time_column_name)
-        self._time_spine_source_node = MetricTimeDimensionTransformNode(
-            parent_node=ReadSqlSourceNode(data_set=time_spine_data_set),
+        self._time_spine_source_node = MetricTimeDimensionTransformNode.create(
+            parent_node=ReadSqlSourceNode.create(data_set=time_spine_data_set),
             aggregation_time_dimension_reference=time_dim_reference,
         )
         self._query_parser = MetricFlowQueryParser(semantic_manifest_lookup)
@@ -71,7 +71,7 @@ class SourceNodeBuilder:
         source_nodes_for_metric_queries: List[DataflowPlanNode] = []
 
         for data_set in data_sets:
-            read_node = ReadSqlSourceNode(data_set)
+            read_node = ReadSqlSourceNode.create(data_set)
             group_by_item_source_nodes.append(read_node)
             agg_time_dim_to_measures_grouper = (
                 self._semantic_manifest_lookup.semantic_model_lookup.get_aggregation_time_dimensions_with_measures(
@@ -86,7 +86,7 @@ class SourceNodeBuilder:
             else:
                 # Splits the measures by distinct aggregate time dimension.
                 for time_dimension_reference in time_dimension_references:
-                    metric_time_transform_node = MetricTimeDimensionTransformNode(
+                    metric_time_transform_node = MetricTimeDimensionTransformNode.create(
                         parent_node=read_node,
                         aggregation_time_dimension_reference=time_dimension_reference,
                     )

--- a/metricflow/dataflow/dataflow_plan.py
+++ b/metricflow/dataflow/dataflow_plan.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import logging
 import typing
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import FrozenSet, Generic, Optional, Sequence, Set, Type, TypeVar
 
 import more_itertools
 from metricflow_semantics.dag.id_prefix import StaticIdPrefix
-from metricflow_semantics.dag.mf_dag import DagId, DagNode, MetricFlowDag, NodeId
+from metricflow_semantics.dag.mf_dag import DagId, DagNode, MetricFlowDag
 from metricflow_semantics.visitor import Visitable, VisitorOutputT
 
 if typing.TYPE_CHECKING:
@@ -42,27 +43,13 @@ logger = logging.getLogger(__name__)
 NodeSelfT = TypeVar("NodeSelfT", bound="DataflowPlanNode")
 
 
-class DataflowPlanNode(DagNode, Visitable, ABC):
+@dataclass(frozen=True)
+class DataflowPlanNode(DagNode["DataflowPlanNode"], Visitable, ABC):
     """A node in the graph representation of the dataflow.
 
     Each node in the graph performs an operation from the data that comes from the parent nodes, and the result is
     passed to the child nodes. The flow of data starts from source nodes, and ends at sink nodes.
     """
-
-    def __init__(self, node_id: NodeId, parent_nodes: Sequence[DataflowPlanNode]) -> None:
-        """Constructor.
-
-        Args:
-            node_id: the ID for the node
-            parent_nodes: data comes from the parent nodes.
-        """
-        self._parent_nodes = tuple(parent_nodes)
-        super().__init__(node_id=node_id)
-
-    @property
-    def parent_nodes(self) -> Sequence[DataflowPlanNode]:
-        """Return the nodes where data for this node comes from."""
-        return self._parent_nodes
 
     @property
     def _input_semantic_model(self) -> Optional[SemanticModelReference]:

--- a/metricflow/dataflow/nodes/add_generated_uuid.py
+++ b/metricflow/dataflow/nodes/add_generated_uuid.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -9,11 +10,17 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class AddGeneratedUuidColumnNode(DataflowPlanNode):
     """Adds a UUID column."""
 
-    def __init__(self, parent_node: DataflowPlanNode) -> None:  # noqa: D107
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=[parent_node])
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(parent_node: DataflowPlanNode) -> AddGeneratedUuidColumnNode:  # noqa: D102
+        return AddGeneratedUuidColumnNode(parent_nodes=(parent_node,))
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -28,7 +35,6 @@ class AddGeneratedUuidColumnNode(DataflowPlanNode):
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        assert len(self.parent_nodes) == 1
         return self.parent_nodes[0]
 
     @property
@@ -42,4 +48,4 @@ class AddGeneratedUuidColumnNode(DataflowPlanNode):
         self, new_parent_nodes: Sequence[DataflowPlanNode]
     ) -> AddGeneratedUuidColumnNode:
         assert len(new_parent_nodes) == 1
-        return AddGeneratedUuidColumnNode(parent_node=new_parent_nodes[0])
+        return AddGeneratedUuidColumnNode(parent_nodes=(new_parent_nodes[0],))

--- a/metricflow/dataflow/nodes/aggregate_measures.py
+++ b/metricflow/dataflow/nodes/aggregate_measures.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence, Tuple
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -9,6 +10,7 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class AggregateMeasuresNode(DataflowPlanNode):
     """A node that aggregates the measures by the associated group by elements.
 
@@ -16,23 +18,25 @@ class AggregateMeasuresNode(DataflowPlanNode):
     resulting from an operation on this node must apply the alias and transform the measure instances accordingly,
     otherwise this join could produce a query with two identically named measure columns with, e.g., different
     constraints applied to the measure.
+
+    The input measure specs are required for downstream nodes to be aware of any input measures with
+    user-provided aliases, such as we might encounter with constrained and unconstrained versions of the
+    same input measure.
     """
 
-    def __init__(
-        self,
-        parent_node: DataflowPlanNode,
-        metric_input_measure_specs: Sequence[MetricInputMeasureSpec],
-    ) -> None:
-        """Initializer for AggregateMeasuresNode.
+    metric_input_measure_specs: Tuple[MetricInputMeasureSpec, ...]
 
-        The input measure specs are required for downstream nodes to be aware of any input measures with
-        user-provided aliases, such as we might encounter with constrained and unconstrained versions of the
-        same input measure.
-        """
-        self._parent_node = parent_node
-        self._metric_input_measure_specs = tuple(metric_input_measure_specs)
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
 
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=[self._parent_node])
+    @staticmethod
+    def create(  # noqa: D102
+        parent_node: DataflowPlanNode, metric_input_measure_specs: Sequence[MetricInputMeasureSpec]
+    ) -> AggregateMeasuresNode:
+        return AggregateMeasuresNode(
+            parent_nodes=(parent_node,), metric_input_measure_specs=tuple(metric_input_measure_specs)
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -47,15 +51,7 @@ class AggregateMeasuresNode(DataflowPlanNode):
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._parent_node
-
-    @property
-    def metric_input_measure_specs(self) -> Tuple[MetricInputMeasureSpec, ...]:
-        """Iterable of specs for measure inputs to downstream metrics.
-
-        Used for assigning aliases to output columns produced by aggregated measures.
-        """
-        return self._metric_input_measure_specs
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
@@ -66,6 +62,6 @@ class AggregateMeasuresNode(DataflowPlanNode):
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> AggregateMeasuresNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return AggregateMeasuresNode(
-            parent_node=new_parent_nodes[0],
+            parent_nodes=tuple(new_parent_nodes),
             metric_input_measure_specs=self.metric_input_measure_specs,
         )

--- a/metricflow/dataflow/nodes/combine_aggregated_outputs.py
+++ b/metricflow/dataflow/nodes/combine_aggregated_outputs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -11,19 +12,21 @@ from metricflow.dataflow.dataflow_plan import (
 )
 
 
+@dataclass(frozen=True)
 class CombineAggregatedOutputsNode(DataflowPlanNode):
     """Combines metrics from different nodes into a single output."""
 
-    def __init__(  # noqa: D107
-        self,
-        parent_nodes: Sequence[DataflowPlanNode],
-    ) -> None:
-        num_parents = len(parent_nodes)
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        num_parents = len(self.parent_nodes)
         assert num_parents > 1, (
             "The CombineAggregatedOutputsNode is intended to merge the output datasets from 2 or more nodes, but this "
             f"node is being initialized with with only {num_parents} parent(s)."
         )
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=parent_nodes)
+
+    @staticmethod
+    def create(parent_nodes: Sequence[DataflowPlanNode]) -> CombineAggregatedOutputsNode:  # noqa: D102
+        return CombineAggregatedOutputsNode(parent_nodes=tuple(parent_nodes))
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -42,4 +45,4 @@ class CombineAggregatedOutputsNode(DataflowPlanNode):
     def with_new_parents(  # noqa: D102
         self, new_parent_nodes: Sequence[DataflowPlanNode]
     ) -> CombineAggregatedOutputsNode:
-        return CombineAggregatedOutputsNode(parent_nodes=new_parent_nodes)
+        return CombineAggregatedOutputsNode(parent_nodes=tuple(new_parent_nodes))

--- a/metricflow/dataflow/nodes/compute_metrics.py
+++ b/metricflow/dataflow/nodes/compute_metrics.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence, Set, Tuple
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DisplayedProperty
 from metricflow_semantics.specs.spec_classes import LinkableInstanceSpec, MetricSpec
 from metricflow_semantics.visitor import VisitorOutputT
+from typing_extensions import override
 
 from metricflow.dataflow.dataflow_plan import (
     DataflowPlanNode,
@@ -13,42 +15,40 @@ from metricflow.dataflow.dataflow_plan import (
 )
 
 
+@dataclass(frozen=True)
 class ComputeMetricsNode(DataflowPlanNode):
-    """A node that computes metrics from input measures. Dimensions / entities are passed through."""
+    """A node that computes metrics from input measures. Dimensions / entities are passed through.
 
-    def __init__(
-        self,
+    Attributes:
+        metric_specs: The specs for the metrics that this should compute.
+        for_group_by_source_node: Whether the node is part of a dataflow plan used for a group by source node.
+    """
+
+    metric_specs: Tuple[MetricSpec, ...]
+    for_group_by_source_node: bool
+    _aggregated_to_elements: Tuple[LinkableInstanceSpec, ...]
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(  # noqa: D102
         parent_node: DataflowPlanNode,
         metric_specs: Sequence[MetricSpec],
         aggregated_to_elements: Set[LinkableInstanceSpec],
         for_group_by_source_node: bool = False,
-    ) -> None:
-        """Constructor.
-
-        Args:
-            parent_node: Node where data is coming from.
-            metric_specs: The specs for the metrics that this should compute.
-            for_group_by_source_node: Whether the node is part of a dataflow plan used for a group by source node.
-        """
-        self._parent_node = parent_node
-        self._metric_specs = tuple(metric_specs)
-        self._for_group_by_source_node = for_group_by_source_node
-        self._aggregated_to_elements = aggregated_to_elements
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
+    ) -> ComputeMetricsNode:
+        return ComputeMetricsNode(
+            parent_nodes=(parent_node,),
+            metric_specs=tuple(metric_specs),
+            _aggregated_to_elements=tuple(aggregated_to_elements),
+            for_group_by_source_node=for_group_by_source_node,
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_COMPUTE_METRICS_ID_PREFIX
-
-    @property
-    def for_group_by_source_node(self) -> bool:
-        """Whether or not this node is part of a dataflow plan used for a group by source node."""
-        return self._for_group_by_source_node
-
-    @property
-    def metric_specs(self) -> Sequence[MetricSpec]:
-        """The metric instances that this node is supposed to compute and should have in the output."""
-        return self._metric_specs
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_compute_metrics_node(self)
@@ -60,7 +60,7 @@ class ComputeMetricsNode(DataflowPlanNode):
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         displayed_properties = tuple(super().displayed_properties) + tuple(
-            DisplayedProperty("metric_spec", metric_spec) for metric_spec in self._metric_specs
+            DisplayedProperty("metric_spec", metric_spec) for metric_spec in self.metric_specs
         )
         if self.for_group_by_source_node:
             displayed_properties += (DisplayedProperty("for_group_by_source_node", self.for_group_by_source_node),)
@@ -68,7 +68,7 @@ class ComputeMetricsNode(DataflowPlanNode):
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._parent_node
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         if not isinstance(other_node, self.__class__):
@@ -100,13 +100,14 @@ class ComputeMetricsNode(DataflowPlanNode):
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> ComputeMetricsNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
-        return ComputeMetricsNode(
+        return ComputeMetricsNode.create(
             parent_node=new_parent_nodes[0],
             metric_specs=self.metric_specs,
             for_group_by_source_node=self.for_group_by_source_node,
-            aggregated_to_elements=self._aggregated_to_elements,
+            aggregated_to_elements=self.aggregated_to_elements,
         )
 
     @property
-    def aggregated_to_elements(self) -> Set[LinkableInstanceSpec]:  # noqa: D102
-        return self._aggregated_to_elements
+    @override
+    def aggregated_to_elements(self) -> Set[LinkableInstanceSpec]:
+        return set(self._aggregated_to_elements)

--- a/metricflow/dataflow/nodes/filter_elements.py
+++ b/metricflow/dataflow/nodes/filter_elements.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional, Sequence, Tuple
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -11,60 +12,66 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class FilterElementsNode(DataflowPlanNode):
-    """Only passes the listed elements."""
+    """Only passes the listed elements.
 
-    def __init__(  # noqa: D107
-        self,
+    Attributes:
+        include_specs: The specs for the elements that it should pass.
+        replace_description: Replace the default description with this.
+        distinct: If you only want the distinct values for the selected specs..
+    """
+
+    include_specs: InstanceSpecSet
+    replace_description: Optional[str] = None
+    distinct: bool = False
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(  # noqa: D102
         parent_node: DataflowPlanNode,
         include_specs: InstanceSpecSet,
         replace_description: Optional[str] = None,
         distinct: bool = False,
-    ) -> None:
-        self._include_specs = include_specs
-        self._replace_description = replace_description
-        self._parent_node = parent_node
-        self._distinct = distinct
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
+    ) -> FilterElementsNode:
+        return FilterElementsNode(
+            parent_nodes=(parent_node,),
+            include_specs=include_specs,
+            replace_description=replace_description,
+            distinct=distinct,
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_PASS_FILTER_ELEMENTS_ID_PREFIX
-
-    @property
-    def include_specs(self) -> InstanceSpecSet:
-        """Returns the specs for the elements that it should pass."""
-        return self._include_specs
-
-    @property
-    def distinct(self) -> bool:
-        """True if you only want the distinct values for the selected specs."""
-        return self._distinct
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_filter_elements_node(self)
 
     @property
     def description(self) -> str:  # noqa: D102
-        if self._replace_description:
-            return self._replace_description
+        if self.replace_description:
+            return self.replace_description
 
-        return f"Pass Only Elements: {mf_pformat([x.qualified_name for x in self._include_specs.all_specs])}"
+        return f"Pass Only Elements: {mf_pformat([x.qualified_name for x in self.include_specs.all_specs])}"
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         additional_properties: Tuple[DisplayedProperty, ...] = ()
-        if not self._replace_description:
+        if not self.replace_description:
             additional_properties = tuple(
-                DisplayedProperty("include_spec", include_spec) for include_spec in self._include_specs.all_specs
+                DisplayedProperty("include_spec", include_spec) for include_spec in self.include_specs.all_specs
             ) + (
-                DisplayedProperty("distinct", self._distinct),
+                DisplayedProperty("distinct", self.distinct),
             )
         return tuple(super().displayed_properties) + additional_properties
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._parent_node
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
@@ -76,8 +83,8 @@ class FilterElementsNode(DataflowPlanNode):
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> FilterElementsNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
         return FilterElementsNode(
-            parent_node=new_parent_nodes[0],
+            parent_nodes=tuple(new_parent_nodes),
             include_specs=self.include_specs,
             distinct=self.distinct,
-            replace_description=self._replace_description,
+            replace_description=self.replace_description,
         )

--- a/metricflow/dataflow/nodes/join_conversion_events.py
+++ b/metricflow/dataflow/nodes/join_conversion_events.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.protocols import MetricTimeWindow
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -17,11 +18,35 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class JoinConversionEventsNode(DataflowPlanNode):
-    """Builds a data set containing successful conversion events."""
+    """Builds a data set containing successful conversion events.
 
-    def __init__(
-        self,
+    Attributes:
+        base_node: node containing dataset for computing base events.
+        base_time_dimension_spec: time dimension for the base events to compute against.
+        conversion_node: node containing dataset to join base node for computing conversion events.
+        conversion_measure_spec: expose this measure in the resulting dataset for aggregation.
+        conversion_time_dimension_spec: time dimension for the conversion events to compute against.
+        unique_identifier_keys: columns to uniquely identify each conversion event.
+        entity_spec: the specific entity in which the conversion is happening for.
+        window: time range bound for when a conversion is still considered valid (default: INF).
+        constant_properties: optional set of elements (either dimension/entity) to join the base
+                             event to the conversion event.
+    """
+
+    base_node: DataflowPlanNode
+    base_time_dimension_spec: TimeDimensionSpec
+    conversion_node: DataflowPlanNode
+    conversion_measure_spec: MeasureSpec
+    conversion_time_dimension_spec: TimeDimensionSpec
+    unique_identifier_keys: Tuple[InstanceSpec, ...]
+    entity_spec: EntitySpec
+    window: Optional[MetricTimeWindow]
+    constant_properties: Optional[Tuple[ConstantPropertySpec, ...]]
+
+    @staticmethod
+    def create(  # noqa: D102
         base_node: DataflowPlanNode,
         base_time_dimension_spec: TimeDimensionSpec,
         conversion_node: DataflowPlanNode,
@@ -31,31 +56,19 @@ class JoinConversionEventsNode(DataflowPlanNode):
         entity_spec: EntitySpec,
         window: Optional[MetricTimeWindow] = None,
         constant_properties: Optional[Sequence[ConstantPropertySpec]] = None,
-    ) -> None:
-        """Constructor.
-
-        Args:
-            base_node: node containing dataset for computing base events.
-            base_time_dimension_spec: time dimension for the base events to compute against.
-            conversion_node: node containing dataset to join base node for computing conversion events.
-            conversion_measure_spec: expose this measure in the resulting dataset for aggregation.
-            conversion_time_dimension_spec: time dimension for the conversion events to compute against.
-            unique_identifier_keys: columns to uniquely identify each conversion event.
-            entity_spec: the specific entity in which the conversion is happening for.
-            window: time range bound for when a conversion is still considered valid (default: INF).
-            constant_properties: optional set of elements (either dimension/entity) to join the base
-                                 event to the conversion event.
-        """
-        self._base_node = base_node
-        self._conversion_node = conversion_node
-        self._base_time_dimension_spec = base_time_dimension_spec
-        self._conversion_measure_spec = conversion_measure_spec
-        self._conversion_time_dimension_spec = conversion_time_dimension_spec
-        self._unique_identifier_keys = unique_identifier_keys
-        self._entity_spec = entity_spec
-        self._window = window
-        self._constant_properties = constant_properties
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(base_node, conversion_node))
+    ) -> JoinConversionEventsNode:
+        return JoinConversionEventsNode(
+            parent_nodes=(base_node, conversion_node),
+            base_node=base_node,
+            base_time_dimension_spec=base_time_dimension_spec,
+            conversion_node=conversion_node,
+            conversion_measure_spec=conversion_measure_spec,
+            conversion_time_dimension_spec=conversion_time_dimension_spec,
+            unique_identifier_keys=tuple(unique_identifier_keys),
+            entity_spec=entity_spec,
+            window=window,
+            constant_properties=tuple(constant_properties) if constant_properties is not None else None,
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -63,42 +76,6 @@ class JoinConversionEventsNode(DataflowPlanNode):
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_conversion_events_node(self)
-
-    @property
-    def base_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._base_node
-
-    @property
-    def conversion_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._conversion_node
-
-    @property
-    def conversion_measure_spec(self) -> MeasureSpec:  # noqa: D102
-        return self._conversion_measure_spec
-
-    @property
-    def base_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D102
-        return self._base_time_dimension_spec
-
-    @property
-    def conversion_time_dimension_spec(self) -> TimeDimensionSpec:  # noqa: D102
-        return self._conversion_time_dimension_spec
-
-    @property
-    def unique_identifier_keys(self) -> Sequence[InstanceSpec]:  # noqa: D102
-        return self._unique_identifier_keys
-
-    @property
-    def entity_spec(self) -> EntitySpec:  # noqa: D102
-        return self._entity_spec
-
-    @property
-    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D102
-        return self._window
-
-    @property
-    def constant_properties(self) -> Optional[Sequence[ConstantPropertySpec]]:  # noqa: D102
-        return self._constant_properties
 
     @property
     def description(self) -> str:  # noqa: D102
@@ -136,6 +113,7 @@ class JoinConversionEventsNode(DataflowPlanNode):
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> JoinConversionEventsNode:  # noqa: D102
         assert len(new_parent_nodes) == 2
         return JoinConversionEventsNode(
+            parent_nodes=tuple(new_parent_nodes),
             base_node=new_parent_nodes[0],
             base_time_dimension_spec=self.base_time_dimension_spec,
             conversion_node=new_parent_nodes[1],

--- a/metricflow/dataflow/nodes/join_to_time_spine.py
+++ b/metricflow/dataflow/nodes/join_to_time_spine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC
+from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from dbt_semantic_interfaces.protocols import MetricTimeWindow
@@ -15,11 +16,39 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class JoinToTimeSpineNode(DataflowPlanNode, ABC):
-    """Join parent dataset to time spine dataset."""
+    """Join parent dataset to time spine dataset.
 
-    def __init__(
-        self,
+    Attributes:
+        requested_agg_time_dimension_specs: Time dimensions requested in the query.
+        use_custom_agg_time_dimension: Indicates if agg_time_dimension should be used in join. If false, uses metric_time.
+        join_type: Join type to use when joining to time spine.
+        time_range_constraint: Time range to constrain the time spine to.
+        offset_window: Time window to offset the parent dataset by when joining to time spine.
+        offset_to_grain: Granularity period to offset the parent dataset to when joining to time spine.
+    """
+
+    requested_agg_time_dimension_specs: Sequence[TimeDimensionSpec]
+    use_custom_agg_time_dimension: bool
+    join_type: SqlJoinType
+    time_range_constraint: Optional[TimeRangeConstraint]
+    offset_window: Optional[MetricTimeWindow]
+    offset_to_grain: Optional[TimeGranularity]
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+        assert not (
+            self.offset_window and self.offset_to_grain
+        ), "Can't set both offset_window and offset_to_grain when joining to time spine. Choose one or the other."
+        assert (
+            len(self.requested_agg_time_dimension_specs) > 0
+        ), "Must have at least one value in requested_agg_time_dimension_specs for JoinToTimeSpineNode."
+
+    @staticmethod
+    def create(  # noqa: D102
         parent_node: DataflowPlanNode,
         requested_agg_time_dimension_specs: Sequence[TimeDimensionSpec],
         use_custom_agg_time_dimension: bool,
@@ -27,69 +56,20 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
         time_range_constraint: Optional[TimeRangeConstraint] = None,
         offset_window: Optional[MetricTimeWindow] = None,
         offset_to_grain: Optional[TimeGranularity] = None,
-    ) -> None:
-        """Constructor.
-
-        Args:
-            parent_node: Node that returns desired dataset to join to time spine.
-            requested_agg_time_dimension_specs: Time dimensions requested in query.
-            use_custom_agg_time_dimension: Indicates if agg_time_dimension should be used in join. If false, uses metric_time.
-            time_range_constraint: Time range to constrain the time spine to.
-            offset_window: Time window to offset the parent dataset by when joining to time spine.
-            offset_to_grain: Granularity period to offset the parent dataset to when joining to time spine.
-
-        Passing both offset_window and offset_to_grain not allowed.
-        """
-        assert not (
-            offset_window and offset_to_grain
-        ), "Can't set both offset_window and offset_to_grain when joining to time spine. Choose one or the other."
-        assert (
-            len(requested_agg_time_dimension_specs) > 0
-        ), "Must have at least one value in requested_agg_time_dimension_specs for JoinToTimeSpineNode."
-
-        self._parent_node = parent_node
-        self._requested_agg_time_dimension_specs = tuple(requested_agg_time_dimension_specs)
-        self._use_custom_agg_time_dimension = use_custom_agg_time_dimension
-        self._offset_window = offset_window
-        self._offset_to_grain = offset_to_grain
-        self._time_range_constraint = time_range_constraint
-        self._join_type = join_type
-
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
+    ) -> JoinToTimeSpineNode:
+        return JoinToTimeSpineNode(
+            parent_nodes=(parent_node,),
+            requested_agg_time_dimension_specs=tuple(requested_agg_time_dimension_specs),
+            use_custom_agg_time_dimension=use_custom_agg_time_dimension,
+            join_type=join_type,
+            time_range_constraint=time_range_constraint,
+            offset_window=offset_window,
+            offset_to_grain=offset_to_grain,
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_JOIN_TO_TIME_SPINE_ID_PREFIX
-
-    @property
-    def requested_agg_time_dimension_specs(self) -> Sequence[TimeDimensionSpec]:
-        """Time dimension specs to use when creating time spine table."""
-        return self._requested_agg_time_dimension_specs
-
-    @property
-    def use_custom_agg_time_dimension(self) -> bool:
-        """Whether or not metric_time was included in the query."""
-        return self._use_custom_agg_time_dimension
-
-    @property
-    def time_range_constraint(self) -> Optional[TimeRangeConstraint]:
-        """Time range constraint to apply when querying time spine table."""
-        return self._time_range_constraint
-
-    @property
-    def offset_window(self) -> Optional[MetricTimeWindow]:
-        """Time range constraint to apply when querying time spine table."""
-        return self._offset_window
-
-    @property
-    def offset_to_grain(self) -> Optional[TimeGranularity]:
-        """Time range constraint to apply when querying time spine table."""
-        return self._offset_to_grain
-
-    @property
-    def join_type(self) -> SqlJoinType:
-        """Join type to use when joining to time spine."""
-        return self._join_type
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_join_to_time_spine_node(self)
@@ -101,17 +81,17 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return tuple(super().displayed_properties) + (
-            DisplayedProperty("requested_agg_time_dimension_specs", self._requested_agg_time_dimension_specs),
-            DisplayedProperty("use_custom_agg_time_dimension", self._use_custom_agg_time_dimension),
-            DisplayedProperty("time_range_constraint", self._time_range_constraint),
-            DisplayedProperty("offset_window", self._offset_window),
-            DisplayedProperty("offset_to_grain", self._offset_to_grain),
-            DisplayedProperty("join_type", self._join_type),
+            DisplayedProperty("requested_agg_time_dimension_specs", self.requested_agg_time_dimension_specs),
+            DisplayedProperty("use_custom_agg_time_dimension", self.use_custom_agg_time_dimension),
+            DisplayedProperty("time_range_constraint", self.time_range_constraint),
+            DisplayedProperty("offset_window", self.offset_window),
+            DisplayedProperty("offset_to_grain", self.offset_to_grain),
+            DisplayedProperty("join_type", self.join_type),
         )
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._parent_node
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
@@ -126,7 +106,7 @@ class JoinToTimeSpineNode(DataflowPlanNode, ABC):
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> JoinToTimeSpineNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
-        return JoinToTimeSpineNode(
+        return JoinToTimeSpineNode.create(
             parent_node=new_parent_nodes[0],
             requested_agg_time_dimension_specs=self.requested_agg_time_dimension_specs,
             use_custom_agg_time_dimension=self.use_custom_agg_time_dimension,

--- a/metricflow/dataflow/nodes/min_max.py
+++ b/metricflow/dataflow/nodes/min_max.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -8,12 +9,17 @@ from metricflow_semantics.visitor import VisitorOutputT
 from metricflow.dataflow.dataflow_plan import DataflowPlanNode, DataflowPlanNodeVisitor
 
 
+@dataclass(frozen=True)
 class MinMaxNode(DataflowPlanNode):
     """Calculate the min and max of a single instance data set."""
 
-    def __init__(self, parent_node: DataflowPlanNode) -> None:  # noqa: D107
-        self._parent_node = parent_node
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(parent_node: DataflowPlanNode) -> MinMaxNode:  # noqa: D102
+        return MinMaxNode(parent_nodes=(parent_node,))
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -28,11 +34,11 @@ class MinMaxNode(DataflowPlanNode):
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        return self._parent_node
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
 
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> MinMaxNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
-        return MinMaxNode(parent_node=new_parent_nodes[0])
+        return MinMaxNode.create(parent_node=new_parent_nodes[0])

--- a/metricflow/dataflow/nodes/order_by_limit.py
+++ b/metricflow/dataflow/nodes/order_by_limit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence, Union
+from dataclasses import dataclass
+from typing import Optional, Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DisplayedProperty
@@ -13,61 +14,58 @@ from metricflow.dataflow.dataflow_plan import (
 )
 
 
+@dataclass(frozen=True)
 class OrderByLimitNode(DataflowPlanNode):
-    """A node that re-orders the input data with a limit."""
+    """A node that re-orders the input data with a limit.
 
-    def __init__(
-        self,
+    Attributes:
+        order_by_specs: Describes how to order the incoming data.
+        limit: Number of rows to limit.
+    """
+
+    order_by_specs: Sequence[OrderBySpec]
+    limit: Optional[int]
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(  # noqa: D102
         order_by_specs: Sequence[OrderBySpec],
-        parent_node: Union[DataflowPlanNode, DataflowPlanNode],
+        parent_node: DataflowPlanNode,
         limit: Optional[int] = None,
-    ) -> None:
-        """Constructor.
-
-        Args:
-            order_by_specs: describes how to order the incoming data.
-            limit: number of rows to limit.
-            parent_node: self-explanatory.
-        """
-        self._order_by_specs = tuple(order_by_specs)
-        self._limit = limit
-        self._parent_node = parent_node
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(self._parent_node,))
+    ) -> OrderByLimitNode:
+        return OrderByLimitNode(
+            parent_nodes=(parent_node,),
+            order_by_specs=tuple(order_by_specs),
+            limit=limit,
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
         return StaticIdPrefix.DATAFLOW_NODE_ORDER_BY_LIMIT_ID_PREFIX
-
-    @property
-    def order_by_specs(self) -> Sequence[OrderBySpec]:
-        """The elements that this node should order the input data."""
-        return self._order_by_specs
-
-    @property
-    def limit(self) -> Optional[int]:
-        """The number of rows to limit by."""
-        return self._limit
 
     def accept(self, visitor: DataflowPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_order_by_limit_node(self)
 
     @property
     def description(self) -> str:  # noqa: D102
-        return f"Order By {[order_by_spec.instance_spec.qualified_name for order_by_spec in self._order_by_specs]}" + (
-            f" Limit {self._limit}" if self.limit else ""
+        return f"Order By {[order_by_spec.instance_spec.qualified_name for order_by_spec in self.order_by_specs]}" + (
+            f" Limit {self.limit}" if self.limit else ""
         )
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102
         return (
             tuple(super().displayed_properties)
-            + tuple(DisplayedProperty("order_by_spec", order_by_spec) for order_by_spec in self._order_by_specs)
+            + tuple(DisplayedProperty("order_by_spec", order_by_spec) for order_by_spec in self.order_by_specs)
             + (DisplayedProperty("limit", str(self.limit)),)
         )
 
     @property
-    def parent_node(self) -> Union[DataflowPlanNode, DataflowPlanNode]:  # noqa: D102
-        return self._parent_node
+    def parent_node(self) -> DataflowPlanNode:  # noqa: D102
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return (
@@ -79,7 +77,7 @@ class OrderByLimitNode(DataflowPlanNode):
     def with_new_parents(self, new_parent_nodes: Sequence[DataflowPlanNode]) -> OrderByLimitNode:  # noqa: D102
         assert len(new_parent_nodes) == 1
 
-        return OrderByLimitNode(
+        return OrderByLimitNode.create(
             parent_node=new_parent_nodes[0],
             order_by_specs=self.order_by_specs,
             limit=self.limit,

--- a/metricflow/dataflow/nodes/write_to_data_table.py
+++ b/metricflow/dataflow/nodes/write_to_data_table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Sequence
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
@@ -11,12 +12,21 @@ from metricflow.dataflow.dataflow_plan import (
 )
 
 
+@dataclass(frozen=True)
 class WriteToResultDataTableNode(DataflowPlanNode):
     """A node where incoming data gets written to a data_table."""
 
-    def __init__(self, parent_node: DataflowPlanNode) -> None:  # noqa: D107
-        self._parent_node = parent_node
-        super().__init__(node_id=self.create_unique_id(), parent_nodes=(parent_node,))
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
+
+    @staticmethod
+    def create(  # noqa: D102
+        parent_node: DataflowPlanNode,
+    ) -> WriteToResultDataTableNode:
+        return WriteToResultDataTableNode(
+            parent_nodes=(parent_node,),
+        )
 
     @classmethod
     def id_prefix(cls) -> IdPrefix:  # noqa: D102
@@ -31,8 +41,7 @@ class WriteToResultDataTableNode(DataflowPlanNode):
 
     @property
     def parent_node(self) -> DataflowPlanNode:  # noqa: D102
-        assert len(self.parent_nodes) == 1
-        return self._parent_node
+        return self.parent_nodes[0]
 
     def functionally_identical(self, other_node: DataflowPlanNode) -> bool:  # noqa: D102
         return isinstance(other_node, self.__class__)
@@ -41,4 +50,4 @@ class WriteToResultDataTableNode(DataflowPlanNode):
         self, new_parent_nodes: Sequence[DataflowPlanNode]
     ) -> WriteToResultDataTableNode:
         assert len(new_parent_nodes) == 1
-        return WriteToResultDataTableNode(parent_node=new_parent_nodes[0])
+        return WriteToResultDataTableNode.create(parent_node=new_parent_nodes[0])

--- a/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
+++ b/metricflow/dataflow/optimizer/predicate_pushdown_optimizer.py
@@ -312,7 +312,7 @@ class PredicatePushdownOptimizer(
         optimized_node = self._default_handler(node=node, pushdown_state=updated_pushdown_state)
         if len(filters_to_apply) > 0:
             return OptimizeBranchResult(
-                optimized_branch=WhereConstraintNode(
+                optimized_branch=WhereConstraintNode.create(
                     parent_node=optimized_node.optimized_branch, where_specs=filters_to_apply
                 )
             )
@@ -397,7 +397,7 @@ class PredicatePushdownOptimizer(
                 )
             elif len(filter_specs_to_apply) > 0:
                 optimized_node = OptimizeBranchResult(
-                    optimized_branch=WhereConstraintNode(
+                    optimized_branch=WhereConstraintNode.create(
                         parent_node=optimized_parent.optimized_branch, where_specs=filter_specs_to_apply
                     )
                 )

--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -259,7 +259,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
                 )
                 return ComputeMetricsBranchCombinerResult()
 
-        combined_node = AggregateMeasuresNode(
+        combined_node = AggregateMeasuresNode.create(
             parent_node=combined_parent_node,
             metric_input_measure_specs=combined_metric_input_measure_specs,
         )
@@ -305,7 +305,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
             if metric_spec not in unique_metric_specs:
                 unique_metric_specs.append(metric_spec)
 
-        combined_node = ComputeMetricsNode(
+        combined_node = ComputeMetricsNode.create(
             parent_node=combined_parent_node,
             metric_specs=unique_metric_specs,
             aggregated_to_elements=current_right_node.aggregated_to_elements,
@@ -389,7 +389,7 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
 
         # De-dupe so that we don't see the same spec twice in include specs. For example, this can happen with dimension
         # specs since any branch that is merged together needs to output the same set of dimensions.
-        combined_node = FilterElementsNode(
+        combined_node = FilterElementsNode.create(
             parent_node=combined_parent_node,
             include_specs=self._current_left_node.include_specs.merge(current_right_node.include_specs).dedupe(),
         )

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -148,7 +148,7 @@ class SourceScanOptimizer(
         optimized_parent_result: OptimizeBranchResult = node.parent_node.accept(self)
         if optimized_parent_result.optimized_branch is not None:
             return OptimizeBranchResult(
-                optimized_branch=ComputeMetricsNode(
+                optimized_branch=ComputeMetricsNode.create(
                     parent_node=optimized_parent_result.optimized_branch,
                     metric_specs=node.metric_specs,
                     for_group_by_source_node=node.for_group_by_source_node,
@@ -264,7 +264,7 @@ class SourceScanOptimizer(
             return OptimizeBranchResult(optimized_branch=combined_parent_branches[0])
 
         return OptimizeBranchResult(
-            optimized_branch=CombineAggregatedOutputsNode(parent_nodes=combined_parent_branches)
+            optimized_branch=CombineAggregatedOutputsNode.create(parent_nodes=combined_parent_branches)
         )
 
     def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> OptimizeBranchResult:  # noqa: D102

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -169,15 +169,15 @@ class SemanticModelToDataSetConverter:
                 "FALSE",
                 "NULL",
             ):
-                return SqlColumnReferenceExpression(
+                return SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias=table_alias,
                         column_name=element_expr,
                     )
                 )
-            return SqlStringExpression(sql_expr=element_expr)
+            return SqlStringExpression.create(sql_expr=element_expr)
 
-        return SqlColumnReferenceExpression(
+        return SqlColumnReferenceExpression.create(
             SqlColumnReference(
                 table_alias=table_alias,
                 column_name=element_name,
@@ -368,7 +368,7 @@ class SemanticModelToDataSetConverter:
 
                 select_columns.append(
                     SqlSelectColumn(
-                        expr=SqlExtractExpression(date_part=date_part, arg=dimension_select_expr),
+                        expr=SqlExtractExpression.create(date_part=date_part, arg=dimension_select_expr),
                         column_alias=time_dimension_instance.associated_column.column_name,
                     )
                 )
@@ -379,7 +379,7 @@ class SemanticModelToDataSetConverter:
         self, time_granularity: TimeGranularity, expr: SqlExpressionNode, column_alias: str
     ) -> SqlSelectColumn:
         return SqlSelectColumn(
-            expr=SqlDateTruncExpression(time_granularity=time_granularity, arg=expr), column_alias=column_alias
+            expr=SqlDateTruncExpression.create(time_granularity=time_granularity, arg=expr), column_alias=column_alias
         )
 
     def _create_entity_instances(
@@ -493,9 +493,11 @@ class SemanticModelToDataSetConverter:
             all_select_columns.extend(select_columns)
 
         # Generate the "from" clause depending on whether it's an SQL query or an SQL table.
-        from_source = SqlTableFromClauseNode(sql_table=SqlTable.from_string(semantic_model.node_relation.relation_name))
+        from_source = SqlTableFromClauseNode.create(
+            sql_table=SqlTable.from_string(semantic_model.node_relation.relation_name)
+        )
 
-        select_statement_node = SqlSelectStatementNode(
+        select_statement_node = SqlSelectStatementNode.create(
             description=f"Read Elements From Semantic Model '{semantic_model.name}'",
             select_columns=tuple(all_select_columns),
             from_source=from_source,
@@ -549,10 +551,10 @@ class SemanticModelToDataSetConverter:
 
         return SqlDataSet(
             instance_set=InstanceSet(time_dimension_instances=tuple(time_dimension_instances)),
-            sql_select_node=SqlSelectStatementNode(
+            sql_select_node=SqlSelectStatementNode.create(
                 description=TIME_SPINE_DATA_SET_DESCRIPTION,
                 select_columns=tuple(select_columns),
-                from_source=SqlTableFromClauseNode(sql_table=time_spine_source.spine_table),
+                from_source=SqlTableFromClauseNode.create(sql_table=time_spine_source.spine_table),
                 from_source_alias=from_source_alias,
             ),
         )

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -33,6 +33,7 @@ from metricflow.execution.execution_plan import (
     ExecutionPlan,
     SelectSqlQueryToDataTableTask,
     SelectSqlQueryToTableTask,
+    SqlQuery,
 )
 from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -80,10 +81,9 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
         render_sql_result = self._render_sql(convert_to_sql_plan_result)
         execution_plan = ExecutionPlan(
             leaf_tasks=(
-                SelectSqlQueryToDataTableTask(
+                SelectSqlQueryToDataTableTask.create(
                     sql_client=self._sql_client,
-                    sql_query=render_sql_result.sql,
-                    bind_parameters=render_sql_result.bind_parameters,
+                    sql_query=SqlQuery(render_sql_result.sql, render_sql_result.bind_parameters),
                 ),
             )
         )
@@ -99,10 +99,12 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
         render_sql_result = self._render_sql(convert_to_sql_plan_result)
         execution_plan = ExecutionPlan(
             leaf_tasks=(
-                SelectSqlQueryToTableTask(
+                SelectSqlQueryToTableTask.create(
                     sql_client=self._sql_client,
-                    sql_query=render_sql_result.sql,
-                    bind_parameters=render_sql_result.bind_parameters,
+                    sql_query=SqlQuery(
+                        sql_query=render_sql_result.sql,
+                        bind_parameters=render_sql_result.bind_parameters,
+                    ),
                     output_table=node.output_sql_table,
                 ),
             ),

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -162,7 +162,7 @@ class CreateSelectColumnsForInstances(InstanceSetTransform[SelectColumnSet]):
                 input_column_name = self._output_to_input_column_mapping[output_column_name]
             select_columns.append(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(SqlColumnReference(self._table_alias, input_column_name)),
+                    expr=SqlColumnReferenceExpression.create(SqlColumnReference(self._table_alias, input_column_name)),
                     column_alias=output_column_name,
                 )
             )
@@ -223,7 +223,7 @@ class CreateSelectColumnsWithMeasuresAggregated(CreateSelectColumnsForInstances)
         measure = self._semantic_model_lookup.get_measure(measure_instance.spec.reference)
         aggregation_type = measure.agg
 
-        expression_to_get_measure = SqlColumnReferenceExpression(
+        expression_to_get_measure = SqlColumnReferenceExpression.create(
             SqlColumnReference(self._table_alias, column_name_in_table)
         )
 
@@ -824,7 +824,7 @@ class CreateSqlColumnReferencesForInstances(InstanceSetTransform[Tuple[SqlColumn
             self._column_resolver.resolve_spec(spec).column_name for spec in instance_set.spec_set.all_specs
         ]
         return tuple(
-            SqlColumnReferenceExpression(
+            SqlColumnReferenceExpression.create(
                 SqlColumnReference(
                     table_alias=self._table_alias,
                     column_name=column_name,
@@ -854,7 +854,7 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
     def _create_select_column(self, spec: InstanceSpec, fill_nulls_with: Optional[int] = None) -> SqlSelectColumn:
         """Creates the select column for the given spec and the fill value."""
         column_name = self._column_resolver.resolve_spec(spec).column_name
-        column_reference_expression = SqlColumnReferenceExpression(
+        column_reference_expression = SqlColumnReferenceExpression.create(
             col_ref=SqlColumnReference(
                 table_alias=self._table_alias,
                 column_name=column_name,
@@ -864,11 +864,11 @@ class CreateSelectColumnForCombineOutputNode(InstanceSetTransform[SelectColumnSe
             aggregation_type=AggregationType.MAX, sql_column_expression=column_reference_expression
         )
         if fill_nulls_with is not None:
-            select_expression = SqlAggregateFunctionExpression(
+            select_expression = SqlAggregateFunctionExpression.create(
                 sql_function=SqlFunction.COALESCE,
                 sql_function_args=[
                     select_expression,
-                    SqlStringExpression(str(fill_nulls_with)),
+                    SqlStringExpression.create(str(fill_nulls_with)),
                 ],
             )
         return SqlSelectColumn(

--- a/metricflow/plan_conversion/node_processor.py
+++ b/metricflow/plan_conversion/node_processor.py
@@ -379,7 +379,9 @@ class PreJoinNodeProcessor:
                         break
                 if constrain_time:
                     processed_nodes.append(
-                        ConstrainTimeRangeNode(parent_node=source_node, time_range_constraint=time_range_constraint)
+                        ConstrainTimeRangeNode.create(
+                            parent_node=source_node, time_range_constraint=time_range_constraint
+                        )
                     )
                 else:
                     processed_nodes.append(source_node)
@@ -421,7 +423,7 @@ class PreJoinNodeProcessor:
                     filtered_nodes.append(source_node)
                 else:
                     filtered_nodes.append(
-                        WhereConstraintNode(parent_node=source_node, where_specs=matching_filter_specs)
+                        WhereConstraintNode.create(parent_node=source_node, where_specs=matching_filter_specs)
                     )
             else:
                 filtered_nodes.append(source_node)
@@ -531,7 +533,7 @@ class PreJoinNodeProcessor:
 
                 # filter measures out of joinable_node
                 specs = data_set_of_second_node_that_can_be_joined.instance_set.spec_set
-                filtered_joinable_node = FilterElementsNode(
+                filtered_joinable_node = FilterElementsNode.create(
                     parent_node=second_node_that_could_be_joined,
                     include_specs=group_specs_by_type(
                         specs.dimension_specs
@@ -552,7 +554,7 @@ class PreJoinNodeProcessor:
 
                 multi_hop_join_candidates.append(
                     MultiHopJoinCandidate(
-                        node_with_multi_hop_elements=JoinOnEntitiesNode(
+                        node_with_multi_hop_elements=JoinOnEntitiesNode.create(
                             left_node=first_node_that_could_be_joined,
                             join_targets=[
                                 JoinDescription(

--- a/metricflow/plan_conversion/sql_expression_builders.py
+++ b/metricflow/plan_conversion/sql_expression_builders.py
@@ -25,7 +25,7 @@ def make_coalesced_expr(table_aliases: Sequence[str], column_alias: str) -> SqlE
     COALESCE(a.is_instant, b.is_instant)
     """
     if len(table_aliases) == 1:
-        return SqlColumnReferenceExpression(
+        return SqlColumnReferenceExpression.create(
             col_ref=SqlColumnReference(
                 table_alias=table_aliases[0],
                 column_name=column_alias,
@@ -35,14 +35,14 @@ def make_coalesced_expr(table_aliases: Sequence[str], column_alias: str) -> SqlE
         columns_to_coalesce: List[SqlExpressionNode] = []
         for table_alias in table_aliases:
             columns_to_coalesce.append(
-                SqlColumnReferenceExpression(
+                SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(
                         table_alias=table_alias,
                         column_name=column_alias,
                     )
                 )
             )
-        return SqlAggregateFunctionExpression(
+        return SqlAggregateFunctionExpression.create(
             sql_function=SqlFunction.COALESCE,
             sql_function_args=columns_to_coalesce,
         )

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -98,12 +98,12 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             else:
                 pruned_join_descriptions.append(join_description)
 
-        return SqlSelectStatementNode(
+        return SqlSelectStatementNode.create(
             description=node.description,
             select_columns=pruned_select_columns,
             from_source=pruned_from_source,
             from_source_alias=node.from_source_alias,
-            joins_descs=tuple(pruned_join_descriptions),
+            join_descs=tuple(pruned_join_descriptions),
             group_bys=node.group_bys,
             order_bys=node.order_bys,
             where=node.where,
@@ -178,12 +178,12 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                 )
             )
 
-        return SqlSelectStatementNode(
+        return SqlSelectStatementNode.create(
             description=node.description,
             select_columns=tuple(pruned_select_columns),
             from_source=pruned_from_source,
             from_source_alias=node.from_source_alias,
-            joins_descs=tuple(pruned_join_descriptions),
+            join_descs=tuple(pruned_join_descriptions),
             group_bys=node.group_bys,
             order_bys=node.order_bys,
             where=node.where,
@@ -200,7 +200,7 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         return node
 
     def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
-        return SqlCreateTableAsNode(
+        return SqlCreateTableAsNode.create(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
         )

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -27,12 +27,12 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         node: SqlSelectStatementNode,
     ) -> SqlSelectStatementNode:
         """Apply the reducing operation to the parent select statements."""
-        return SqlSelectStatementNode(
+        return SqlSelectStatementNode.create(
             description=node.description,
             select_columns=node.select_columns,
             from_source=node.from_source.accept(self),
             from_source_alias=node.from_source_alias,
-            joins_descs=tuple(
+            join_descs=tuple(
                 SqlJoinDescription(
                     right_source=x.right_source.accept(self),
                     right_source_alias=x.right_source_alias,
@@ -158,7 +158,7 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                     return node_with_reduced_parents
                 new_order_by.append(
                     SqlOrderByDescription(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             SqlColumnReference(
                                 table_alias=table_alias_in_parent,
                                 column_name=order_by_item_expr.col_ref.column_name,
@@ -175,12 +175,12 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         elif parent_select_node.limit is not None:
             new_limit = min(new_limit, parent_select_node.limit)
 
-        return SqlSelectStatementNode(
+        return SqlSelectStatementNode.create(
             description="\n".join([parent_select_node.description, node_with_reduced_parents.description]),
             select_columns=parent_select_node.select_columns,
             from_source=parent_select_node.from_source,
             from_source_alias=parent_select_node.from_source_alias,
-            joins_descs=parent_select_node.join_descs,
+            join_descs=parent_select_node.join_descs,
             group_bys=parent_select_node.group_bys,
             order_bys=tuple(new_order_by),
             where=parent_select_node.where,
@@ -195,7 +195,7 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         return node
 
     def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
-        return SqlCreateTableAsNode(
+        return SqlCreateTableAsNode.create(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
         )

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -26,7 +26,7 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         should_simplify_table_aliases = len(node.parent_nodes) <= 1
 
         if should_simplify_table_aliases:
-            return SqlSelectStatementNode(
+            return SqlSelectStatementNode.create(
                 description=node.description,
                 select_columns=tuple(
                     SqlSelectColumn(expr=x.expr.rewrite(should_render_table_alias=False), column_alias=x.column_alias)
@@ -47,12 +47,12 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                 distinct=node.distinct,
             )
 
-        return SqlSelectStatementNode(
+        return SqlSelectStatementNode.create(
             description=node.description,
             select_columns=node.select_columns,
             from_source=node.from_source.accept(self),
             from_source_alias=node.from_source_alias,
-            joins_descs=tuple(
+            join_descs=tuple(
                 SqlJoinDescription(
                     right_source=x.right_source.accept(self),
                     right_source_alias=x.right_source_alias,
@@ -75,7 +75,7 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         return node
 
     def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> SqlQueryPlanNode:  # noqa: D102
-        return SqlCreateTableAsNode(
+        return SqlCreateTableAsNode.create(
             sql_table=node.sql_table,
             parent_node=node.parent_node.accept(self),
         )

--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -201,7 +201,7 @@ class DataWarehouseTaskBuilder:
                 spec_filter_tuples.append(
                     (
                         spec,
-                        FilterElementsNode(
+                        FilterElementsNode.create(
                             parent_node=source_node, include_specs=InstanceSpecSet(dimension_specs=(spec,))
                         ),
                     )
@@ -214,7 +214,7 @@ class DataWarehouseTaskBuilder:
                 spec_filter_tuples.append(
                     (
                         spec,
-                        FilterElementsNode(
+                        FilterElementsNode.create(
                             parent_node=source_node, include_specs=InstanceSpecSet(time_dimension_specs=(spec,))
                         ),
                     )
@@ -241,7 +241,7 @@ class DataWarehouseTaskBuilder:
                     )
                 )
 
-            filter_elements_node = FilterElementsNode(
+            filter_elements_node = FilterElementsNode.create(
                 parent_node=source_node,
                 include_specs=InstanceSpecSet(
                     dimension_specs=dimension_specs,
@@ -299,7 +299,7 @@ class DataWarehouseTaskBuilder:
                 dataset.instance_set.spec_set.entity_specs
             )
             for spec in semantic_model_specs:
-                filter_elements_node = FilterElementsNode(
+                filter_elements_node = FilterElementsNode.create(
                     parent_node=source_node, include_specs=InstanceSpecSet(entity_specs=(spec,))
                 )
                 semantic_model_sub_tasks.append(
@@ -322,7 +322,7 @@ class DataWarehouseTaskBuilder:
                     )
                 )
 
-            filter_elements_node = FilterElementsNode(
+            filter_elements_node = FilterElementsNode.create(
                 parent_node=source_node,
                 include_specs=InstanceSpecSet(
                     entity_specs=tuple(semantic_model_specs),
@@ -392,7 +392,7 @@ class DataWarehouseTaskBuilder:
                 obtained_source_node = source_node_by_measure_spec.get(spec)
                 assert obtained_source_node, f"Unable to find generated source node for measure: {spec.element_name}"
 
-                filter_elements_node = FilterElementsNode(
+                filter_elements_node = FilterElementsNode.create(
                     parent_node=obtained_source_node,
                     include_specs=InstanceSpecSet(
                         measure_specs=(spec,),
@@ -419,7 +419,7 @@ class DataWarehouseTaskBuilder:
                 )
 
             for measure_specs, source_node in measure_specs_source_node_pair:
-                filter_elements_node = FilterElementsNode(
+                filter_elements_node = FilterElementsNode.create(
                     parent_node=source_node, include_specs=InstanceSpecSet(measure_specs=measure_specs)
                 )
                 tasks.append(

--- a/scripts/ci_tests/metricflow_package_test.py
+++ b/scripts/ci_tests/metricflow_package_test.py
@@ -36,7 +36,7 @@ def _data_set_to_read_nodes(data_sets: OrderedDict[str, SemanticModelDataSet]) -
     # Moved from model_fixtures.py.
     return_dict: OrderedDict[str, ReadSqlSourceNode] = OrderedDict()
     for semantic_model_name, data_set in data_sets.items():
-        return_dict[semantic_model_name] = ReadSqlSourceNode(data_set)
+        return_dict[semantic_model_name] = ReadSqlSourceNode.create(data_set)
 
     return return_dict
 

--- a/tests_metricflow/dataflow/builder/test_node_data_set.py
+++ b/tests_metricflow/dataflow/builder/test_node_data_set.py
@@ -68,20 +68,24 @@ def test_no_parent_node_data_set(
             time_dimension_instances=(),
             entity_instances=(),
         ),
-        sql_select_node=SqlSelectStatementNode(
+        sql_select_node=SqlSelectStatementNode.create(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(SqlColumnReference(table_alias="src", column_name="bookings")),
+                    expr=SqlColumnReferenceExpression.create(
+                        SqlColumnReference(table_alias="src", column_name="bookings")
+                    ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="src",
         ),
     )
 
-    node = ReadSqlSourceNode(data_set=data_set)
+    node = ReadSqlSourceNode.create(data_set=data_set)
 
     assert resolver.get_output_data_set(node).instance_set == data_set.instance_set
 
@@ -102,7 +106,7 @@ def test_joined_node_data_set(
     # Join "revenue" with "users_latest" to get "user__home_state_latest"
     revenue_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping["revenue"]
     users_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping["users_latest"]
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=revenue_node,
         join_targets=[
             JoinDescription(

--- a/tests_metricflow/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
+++ b/tests_metricflow/dataflow/optimizer/source_scan/test_cm_branch_combiner.py
@@ -27,7 +27,7 @@ from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixt
 
 def make_dataflow_plan(node: DataflowPlanNode) -> DataflowPlan:  # noqa: D103
     return DataflowPlan(
-        sink_nodes=[WriteToResultDataTableNode(node)],
+        sink_nodes=[WriteToResultDataTableNode.create(node)],
         plan_id=DagId.from_id_prefix(StaticIdPrefix.OPTIMIZED_DATAFLOW_PLAN_PREFIX),
     )
 
@@ -69,11 +69,11 @@ def test_filter_combination(
 ) -> None:
     """Tests combining a single node."""
     source0 = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping["bookings_source"]
-    filter0 = FilterElementsNode(
+    filter0 = FilterElementsNode.create(
         parent_node=source0, include_specs=InstanceSpecSet(measure_specs=(MeasureSpec(element_name="bookings"),))
     )
     source1 = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping["bookings_source"]
-    filter1 = FilterElementsNode(
+    filter1 = FilterElementsNode.create(
         parent_node=source1,
         include_specs=InstanceSpecSet(
             measure_specs=(MeasureSpec(element_name="booking_value"),),

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -51,7 +51,7 @@ def test_view_sql_generated_at_a_node(
 
     # Show SQL and spec set at a source node.
     bookings_source_data_set = to_data_set_converter.create_sql_source_data_set(bookings_semantic_model)
-    read_source_node = ReadSqlSourceNode(bookings_source_data_set)
+    read_source_node = ReadSqlSourceNode.create(bookings_source_data_set)
     conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=read_source_node,
@@ -63,13 +63,13 @@ def test_view_sql_generated_at_a_node(
     logger.info(f"SQL generated at {read_source_node} is:\n\n{sql_at_read_node}")
     logger.info(f"Spec set at {read_source_node} is:\n\n{mf_pformat(spec_set_at_read_node)}")
 
-    metric_time_node = MetricTimeDimensionTransformNode(
+    metric_time_node = MetricTimeDimensionTransformNode.create(
         parent_node=read_source_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds"),
     )
 
     # Show SQL and spec set at a filter node.
-    filter_elements_node = FilterElementsNode(
+    filter_elements_node = FilterElementsNode.create(
         parent_node=metric_time_node,
         include_specs=InstanceSpecSet(
             time_dimension_specs=(

--- a/tests_metricflow/execution/test_sequential_executor.py
+++ b/tests_metricflow/execution/test_sequential_executor.py
@@ -9,7 +9,7 @@ from tests_metricflow.execution.noop_task import NoOpExecutionPlanTask
 
 def test_single_task() -> None:
     """Tests running an execution plan with a single task."""
-    task = NoOpExecutionPlanTask()
+    task = NoOpExecutionPlanTask.create()
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))
     results = SequentialPlanExecutor().execute_plan(execution_plan)
     assert results.get_result(task.task_id)
@@ -17,7 +17,7 @@ def test_single_task() -> None:
 
 def test_single_task_error() -> None:
     """Check that an error is properly returned in the results if a task errors out."""
-    task = NoOpExecutionPlanTask(should_error=True)
+    task = NoOpExecutionPlanTask.create(should_error=True)
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))
     executor = SequentialPlanExecutor()
     results = executor.execute_plan(execution_plan)
@@ -27,9 +27,9 @@ def test_single_task_error() -> None:
 
 def test_task_with_parents() -> None:
     """Tests a plan with a task that has 2 direct parents."""
-    parent_task1 = NoOpExecutionPlanTask()
-    parent_task2 = NoOpExecutionPlanTask()
-    leaf_task = NoOpExecutionPlanTask(parent_tasks=[parent_task1, parent_task2])
+    parent_task1 = NoOpExecutionPlanTask.create()
+    parent_task2 = NoOpExecutionPlanTask.create()
+    leaf_task = NoOpExecutionPlanTask.create(parent_tasks=[parent_task1, parent_task2])
     execution_plan = ExecutionPlan(leaf_tasks=[leaf_task], dag_id=DagId.from_str("plan0"))
     results = SequentialPlanExecutor().execute_plan(execution_plan)
 
@@ -47,9 +47,9 @@ def test_task_with_parents() -> None:
 
 def test_parent_task_error() -> None:
     """Check that a child task is not run if a parent task fails."""
-    parent_task1 = NoOpExecutionPlanTask(should_error=True)
-    parent_task2 = NoOpExecutionPlanTask()
-    leaf_task = NoOpExecutionPlanTask(parent_tasks=[parent_task1, parent_task2])
+    parent_task1 = NoOpExecutionPlanTask.create(should_error=True)
+    parent_task2 = NoOpExecutionPlanTask.create()
+    leaf_task = NoOpExecutionPlanTask.create(parent_tasks=[parent_task1, parent_task2])
     execution_plan = ExecutionPlan(leaf_tasks=[leaf_task], dag_id=DagId.from_str("plan0"))
 
     executor = SequentialPlanExecutor()

--- a/tests_metricflow/execution/test_tasks.py
+++ b/tests_metricflow/execution/test_tasks.py
@@ -10,6 +10,7 @@ from metricflow.execution.execution_plan import (
     ExecutionPlan,
     SelectSqlQueryToDataTableTask,
     SelectSqlQueryToTableTask,
+    SqlQuery,
 )
 from metricflow.execution.executor import SequentialPlanExecutor
 from metricflow.protocols.sql_client import SqlClient, SqlEngine
@@ -18,7 +19,7 @@ from tests_metricflow.sql.compare_data_table import assert_data_tables_equal
 
 
 def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D103
-    task = SelectSqlQueryToDataTableTask(sql_client, "SELECT 1 AS foo", SqlBindParameters())
+    task = SelectSqlQueryToDataTableTask.create(sql_client, SqlQuery("SELECT 1 AS foo", SqlBindParameters()))
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))
 
     results = SequentialPlanExecutor().execute_plan(execution_plan)
@@ -41,10 +42,12 @@ def test_write_table_task(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration, sql_client: SqlClient
 ) -> None:  # noqa: D103
     output_table = SqlTable(schema_name=mf_test_configuration.mf_system_schema, table_name=f"test_table_{random_id()}")
-    task = SelectSqlQueryToTableTask(
+    task = SelectSqlQueryToTableTask.create(
         sql_client=sql_client,
-        sql_query=f"CREATE TABLE {output_table.sql} AS SELECT 1 AS foo",
-        bind_parameters=SqlBindParameters(),
+        sql_query=SqlQuery(
+            sql_query=f"CREATE TABLE {output_table.sql} AS SELECT 1 AS foo",
+            bind_parameters=SqlBindParameters(),
+        ),
         output_table=output_table,
     )
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))

--- a/tests_metricflow/fixtures/manifest_fixtures.py
+++ b/tests_metricflow/fixtures/manifest_fixtures.py
@@ -221,7 +221,7 @@ class MetricFlowEngineTestFixture:
         # Moved from model_fixtures.py.
         return_dict: OrderedDict[str, ReadSqlSourceNode] = OrderedDict()
         for semantic_model_name, data_set in data_sets.items():
-            return_dict[semantic_model_name] = ReadSqlSourceNode(data_set)
+            return_dict[semantic_model_name] = ReadSqlSourceNode.create(data_set)
             logger.debug(
                 f"For semantic model {semantic_model_name}, creating node_id {return_dict[semantic_model_name].node_id}"
             )

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -97,8 +97,8 @@ class CheckQueryHelpers:
         granularity: TimeGranularity,
     ) -> str:
         """Renders a date subtract expression."""
-        expr = SqlSubtractTimeIntervalExpression(
-            arg=SqlColumnReferenceExpression(SqlColumnReference(table_alias, column_alias)),
+        expr = SqlSubtractTimeIntervalExpression.create(
+            arg=SqlColumnReferenceExpression.create(SqlColumnReference(table_alias, column_alias)),
             count=count,
             granularity=granularity,
         )
@@ -106,10 +106,10 @@ class CheckQueryHelpers:
 
     def render_date_trunc(self, expr: str, granularity: TimeGranularity) -> str:
         """Return the DATE_TRUNC() call that can be used for converting the given expr to the granularity."""
-        renderable_expr = SqlDateTruncExpression(
+        renderable_expr = SqlDateTruncExpression.create(
             time_granularity=granularity,
-            arg=SqlCastToTimestampExpression(
-                arg=SqlStringExpression(
+            arg=SqlCastToTimestampExpression.create(
+                arg=SqlStringExpression.create(
                     sql_expr=expr,
                     requires_parenthesis=False,
                 )
@@ -119,10 +119,10 @@ class CheckQueryHelpers:
 
     def render_extract(self, expr: str, date_part: DatePart) -> str:
         """Return the EXTRACT call that can be used for converting the given expr to the date_part."""
-        renderable_expr = SqlExtractExpression(
+        renderable_expr = SqlExtractExpression.create(
             date_part=date_part,
-            arg=SqlCastToTimestampExpression(
-                arg=SqlStringExpression(
+            arg=SqlCastToTimestampExpression.create(
+                arg=SqlStringExpression.create(
                     sql_expr=expr,
                     requires_parenthesis=False,
                 )
@@ -142,8 +142,8 @@ class CheckQueryHelpers:
             )
         )
 
-        renderable_expr = SqlPercentileExpression(
-            order_by_arg=SqlStringExpression(
+        renderable_expr = SqlPercentileExpression.create(
+            order_by_arg=SqlStringExpression.create(
                 sql_expr=expr,
                 requires_parenthesis=False,
             ),
@@ -191,7 +191,7 @@ class CheckQueryHelpers:
 
     def generate_random_uuid(self) -> str:
         """Returns the generate random UUID SQL function."""
-        expr = SqlGenerateUuidExpression()
+        expr = SqlGenerateUuidExpression.create()
         return self._sql_client.sql_query_plan_renderer.expr_renderer.render_sql_expr(expr).sql
 
 

--- a/tests_metricflow/mf_logging/test_dag_to_text.py
+++ b/tests_metricflow/mf_logging/test_dag_to_text.py
@@ -33,15 +33,15 @@ def test_multithread_dag_to_text() -> None:
     dag_to_text_formatter = MetricFlowDagTextFormatter(max_width=1)
     dag = SqlQueryPlan(
         plan_id=DagId("plan"),
-        render_node=SqlSelectStatementNode(
+        render_node=SqlSelectStatementNode.create(
             description="test",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlStringExpression("'foo'"),
+                    expr=SqlStringExpression.create("'foo'"),
                     column_alias="bar",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="schema", table_name="table")),
+            from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="schema", table_name="table")),
             from_source_alias="src",
         ),
     )

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_metric_time_dimension_to_sql.py
@@ -30,7 +30,7 @@ def test_metric_time_dimension_transform_node_using_primary_time(
     source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    metric_time_dimension_transform_node = MetricTimeDimensionTransformNode(
+    metric_time_dimension_transform_node = MetricTimeDimensionTransformNode.create(
         parent_node=source_node, aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds")
     )
     convert_and_check(
@@ -54,7 +54,7 @@ def test_metric_time_dimension_transform_node_using_non_primary_time(
     source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    metric_time_dimension_transform_node = MetricTimeDimensionTransformNode(
+    metric_time_dimension_transform_node = MetricTimeDimensionTransformNode.create(
         parent_node=source_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="paid_at"),
     )

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -153,7 +153,7 @@ def test_filter_node(
     source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filter_node = FilterElementsNode(
+    filter_node = FilterElementsNode.create(
         parent_node=source_node, include_specs=InstanceSpecSet(measure_specs=(measure_spec,))
     )
 
@@ -184,11 +184,11 @@ def test_filter_with_where_constraint_node(
     ]
 
     ds_spec = TimeDimensionSpec(element_name="ds", entity_links=(), time_granularity=TimeGranularity.DAY)
-    filter_node = FilterElementsNode(
+    filter_node = FilterElementsNode.create(
         parent_node=source_node,
         include_specs=InstanceSpecSet(measure_specs=(measure_spec,), time_dimension_specs=(ds_spec,)),
     )  # need to include ds_spec because where constraint operates on ds
-    where_constraint_node = WhereConstraintNode(
+    where_constraint_node = WhereConstraintNode.create(
         parent_node=filter_node,
         where_specs=(
             WhereFilterSpec(
@@ -258,12 +258,12 @@ def test_measure_aggregation_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=tuple(measure_specs)),
     )
 
-    aggregated_measure_node = AggregateMeasuresNode(
+    aggregated_measure_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
 
@@ -292,7 +292,7 @@ def test_single_join_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,),
@@ -307,7 +307,7 @@ def test_single_join_node(
     dimension_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "listings_latest"
     ]
-    filtered_dimension_node = FilterElementsNode(
+    filtered_dimension_node = FilterElementsNode.create(
         parent_node=dimension_source_node,
         include_specs=InstanceSpecSet(
             entity_specs=(entity_spec,),
@@ -315,7 +315,7 @@ def test_single_join_node(
         ),
     )
 
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=filtered_measure_node,
         join_targets=[
             JoinDescription(
@@ -353,7 +353,7 @@ def test_multi_join_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=(measure_spec,), entity_specs=(entity_spec,)),
     )
@@ -365,7 +365,7 @@ def test_multi_join_node(
     dimension_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "listings_latest"
     ]
-    filtered_dimension_node = FilterElementsNode(
+    filtered_dimension_node = FilterElementsNode.create(
         parent_node=dimension_source_node,
         include_specs=InstanceSpecSet(
             entity_specs=(entity_spec,),
@@ -373,7 +373,7 @@ def test_multi_join_node(
         ),
     )
 
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=filtered_measure_node,
         join_targets=[
             JoinDescription(
@@ -419,7 +419,7 @@ def test_compute_metrics_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,),
@@ -434,7 +434,7 @@ def test_compute_metrics_node(
     dimension_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "listings_latest"
     ]
-    filtered_dimension_node = FilterElementsNode(
+    filtered_dimension_node = FilterElementsNode.create(
         parent_node=dimension_source_node,
         include_specs=InstanceSpecSet(
             entity_specs=(entity_spec,),
@@ -442,7 +442,7 @@ def test_compute_metrics_node(
         ),
     )
 
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=filtered_measure_node,
         join_targets=[
             JoinDescription(
@@ -455,12 +455,12 @@ def test_compute_metrics_node(
         ],
     )
 
-    aggregated_measure_node = AggregateMeasuresNode(
+    aggregated_measure_node = AggregateMeasuresNode.create(
         parent_node=join_node, metric_input_measure_specs=metric_input_measure_specs
     )
 
     metric_spec = MetricSpec(element_name="bookings")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measure_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec, dimension_spec},
@@ -492,7 +492,7 @@ def test_compute_metrics_node_simple_expr(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=(measure_spec,), entity_specs=(entity_spec,)),
     )
@@ -504,7 +504,7 @@ def test_compute_metrics_node_simple_expr(
     dimension_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "listings_latest"
     ]
-    filtered_dimension_node = FilterElementsNode(
+    filtered_dimension_node = FilterElementsNode.create(
         parent_node=dimension_source_node,
         include_specs=InstanceSpecSet(
             entity_specs=(entity_spec,),
@@ -512,7 +512,7 @@ def test_compute_metrics_node_simple_expr(
         ),
     )
 
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=filtered_measure_node,
         join_targets=[
             JoinDescription(
@@ -525,17 +525,17 @@ def test_compute_metrics_node_simple_expr(
         ],
     )
 
-    aggregated_measures_node = AggregateMeasuresNode(
+    aggregated_measures_node = AggregateMeasuresNode.create(
         parent_node=join_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measures_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec, dimension_spec},
     )
 
-    sink_node = WriteToResultDataTableNode(compute_metrics_node)
+    sink_node = WriteToResultDataTableNode.create(compute_metrics_node)
     dataflow_plan = DataflowPlan(sink_nodes=[sink_node], plan_id=DagId.from_str("plan0"))
 
     assert_plan_snapshot_text_equal(
@@ -578,27 +578,27 @@ def test_join_to_time_spine_node_without_offset(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    metric_time_node = MetricTimeDimensionTransformNode(
+    metric_time_node = MetricTimeDimensionTransformNode.create(
         parent_node=measure_source_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds"),
     )
 
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=metric_time_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,), entity_specs=(entity_spec,), dimension_specs=(metric_time_spec,)
         ),
     )
-    aggregated_measures_node = AggregateMeasuresNode(
+    aggregated_measures_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measures_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec},
     )
-    join_to_time_spine_node = JoinToTimeSpineNode(
+    join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         use_custom_agg_time_dimension=False,
@@ -608,7 +608,7 @@ def test_join_to_time_spine_node_without_offset(
         join_type=SqlJoinType.INNER,
     )
 
-    sink_node = WriteToResultDataTableNode(join_to_time_spine_node)
+    sink_node = WriteToResultDataTableNode.create(join_to_time_spine_node)
     dataflow_plan = DataflowPlan(sink_nodes=[sink_node], plan_id=DagId.from_str("plan0"))
 
     assert_plan_snapshot_text_equal(
@@ -651,26 +651,26 @@ def test_join_to_time_spine_node_with_offset_window(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    metric_time_node = MetricTimeDimensionTransformNode(
+    metric_time_node = MetricTimeDimensionTransformNode.create(
         parent_node=measure_source_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds"),
     )
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=metric_time_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,), entity_specs=(entity_spec,), dimension_specs=(metric_time_spec,)
         ),
     )
-    aggregated_measures_node = AggregateMeasuresNode(
+    aggregated_measures_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measures_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec, metric_time_spec},
     )
-    join_to_time_spine_node = JoinToTimeSpineNode(
+    join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         use_custom_agg_time_dimension=False,
@@ -681,7 +681,7 @@ def test_join_to_time_spine_node_with_offset_window(
         join_type=SqlJoinType.INNER,
     )
 
-    sink_node = WriteToResultDataTableNode(join_to_time_spine_node)
+    sink_node = WriteToResultDataTableNode.create(join_to_time_spine_node)
     dataflow_plan = DataflowPlan(sink_nodes=[sink_node], plan_id=DagId.from_str("plan0"))
 
     assert_plan_snapshot_text_equal(
@@ -724,26 +724,26 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    metric_time_node = MetricTimeDimensionTransformNode(
+    metric_time_node = MetricTimeDimensionTransformNode.create(
         parent_node=measure_source_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds"),
     )
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=metric_time_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,), entity_specs=(entity_spec,), dimension_specs=(metric_time_spec,)
         ),
     )
-    aggregated_measures_node = AggregateMeasuresNode(
+    aggregated_measures_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="booking_fees")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measures_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec, metric_time_spec},
     )
-    join_to_time_spine_node = JoinToTimeSpineNode(
+    join_to_time_spine_node = JoinToTimeSpineNode.create(
         parent_node=compute_metrics_node,
         requested_agg_time_dimension_specs=[MTD_SPEC_DAY],
         use_custom_agg_time_dimension=False,
@@ -755,7 +755,7 @@ def test_join_to_time_spine_node_with_offset_to_grain(
         join_type=SqlJoinType.INNER,
     )
 
-    sink_node = WriteToResultDataTableNode(join_to_time_spine_node)
+    sink_node = WriteToResultDataTableNode.create(join_to_time_spine_node)
     dataflow_plan = DataflowPlan(sink_nodes=[sink_node], plan_id=DagId.from_str("plan0"))
 
     assert_plan_snapshot_text_equal(
@@ -803,7 +803,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measures_node = FilterElementsNode(
+    filtered_measures_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=(numerator_spec, denominator_spec), entity_specs=(entity_spec,)),
     )
@@ -815,7 +815,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
     dimension_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "listings_latest"
     ]
-    filtered_dimension_node = FilterElementsNode(
+    filtered_dimension_node = FilterElementsNode.create(
         parent_node=dimension_source_node,
         include_specs=InstanceSpecSet(
             entity_specs=(entity_spec,),
@@ -823,7 +823,7 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
         ),
     )
 
-    join_node = JoinOnEntitiesNode(
+    join_node = JoinOnEntitiesNode.create(
         left_node=filtered_measures_node,
         join_targets=[
             JoinDescription(
@@ -836,11 +836,11 @@ def test_compute_metrics_node_ratio_from_single_semantic_model(
         ],
     )
 
-    aggregated_measures_node = AggregateMeasuresNode(
+    aggregated_measures_node = AggregateMeasuresNode.create(
         parent_node=join_node, metric_input_measure_specs=metric_input_measure_specs
     )
     metric_spec = MetricSpec(element_name="bookings_per_booker")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measures_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={entity_spec, dimension_spec},
@@ -882,7 +882,7 @@ def test_order_by_node(
         "bookings_source"
     ]
 
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(
             measure_specs=(measure_spec,),
@@ -891,18 +891,18 @@ def test_order_by_node(
         ),
     )
 
-    aggregated_measure_node = AggregateMeasuresNode(
+    aggregated_measure_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node, metric_input_measure_specs=metric_input_measure_specs
     )
 
     metric_spec = MetricSpec(element_name="bookings")
-    compute_metrics_node = ComputeMetricsNode(
+    compute_metrics_node = ComputeMetricsNode.create(
         parent_node=aggregated_measure_node,
         metric_specs=[metric_spec],
         aggregated_to_elements={dimension_spec, time_dimension_spec},
     )
 
-    order_by_node = OrderByLimitNode(
+    order_by_node = OrderByLimitNode.create(
         order_by_specs=[
             OrderBySpec(
                 instance_spec=time_dimension_spec,
@@ -940,7 +940,7 @@ def test_semi_additive_join_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "accounts_source"
     ]
-    semi_additive_join_node = SemiAdditiveJoinNode(
+    semi_additive_join_node = SemiAdditiveJoinNode.create(
         parent_node=measure_source_node,
         entity_specs=tuple(),
         time_dimension_spec=time_dimension_spec,
@@ -974,7 +974,7 @@ def test_semi_additive_join_node_with_queried_group_by(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "accounts_source"
     ]
-    semi_additive_join_node = SemiAdditiveJoinNode(
+    semi_additive_join_node = SemiAdditiveJoinNode.create(
         parent_node=measure_source_node,
         entity_specs=tuple(),
         time_dimension_spec=time_dimension_spec,
@@ -1010,7 +1010,7 @@ def test_semi_additive_join_node_with_grouping(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "accounts_source"
     ]
-    semi_additive_join_node = SemiAdditiveJoinNode(
+    semi_additive_join_node = SemiAdditiveJoinNode.create(
         parent_node=measure_source_node,
         entity_specs=(entity_spec,),
         time_dimension_spec=time_dimension_spec,
@@ -1037,7 +1037,7 @@ def test_constrain_time_range_node(
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
     ]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(
             measure_specs=(
@@ -1050,12 +1050,12 @@ def test_constrain_time_range_node(
             ),
         ),
     )
-    metric_time_node = MetricTimeDimensionTransformNode(
+    metric_time_node = MetricTimeDimensionTransformNode.create(
         parent_node=filtered_measure_node,
         aggregation_time_dimension_reference=TimeDimensionReference(element_name="ds"),
     )
 
-    constrain_time_node = ConstrainTimeRangeNode(
+    constrain_time_node = ConstrainTimeRangeNode.create(
         parent_node=metric_time_node,
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"),
@@ -1136,29 +1136,29 @@ def test_combine_output_node(
 
     # Build compute measures node
     measure_specs: List[MeasureSpec] = [sum_spec]
-    filtered_measure_node = FilterElementsNode(
+    filtered_measure_node = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=tuple(measure_specs), dimension_specs=(dimension_spec,)),
     )
-    aggregated_measure_node = AggregateMeasuresNode(
+    aggregated_measure_node = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node,
         metric_input_measure_specs=tuple(MetricInputMeasureSpec(measure_spec=x) for x in measure_specs),
     )
 
     # Build agg measures node
     measure_specs_2 = [sum_boolean_spec, count_distinct_spec]
-    filtered_measure_node_2 = FilterElementsNode(
+    filtered_measure_node_2 = FilterElementsNode.create(
         parent_node=measure_source_node,
         include_specs=InstanceSpecSet(measure_specs=tuple(measure_specs_2), dimension_specs=(dimension_spec,)),
     )
-    aggregated_measure_node_2 = AggregateMeasuresNode(
+    aggregated_measure_node_2 = AggregateMeasuresNode.create(
         parent_node=filtered_measure_node_2,
         metric_input_measure_specs=tuple(
             MetricInputMeasureSpec(measure_spec=x, fill_nulls_with=1) for x in measure_specs_2
         ),
     )
 
-    combine_output_node = CombineAggregatedOutputsNode([aggregated_measure_node, aggregated_measure_node_2])
+    combine_output_node = CombineAggregatedOutputsNode.create([aggregated_measure_node, aggregated_measure_node_2])
     convert_and_check(
         request=request,
         mf_test_configuration=mf_test_configuration,

--- a/tests_metricflow/sql/optimizer/test_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_column_pruner.py
@@ -70,51 +70,51 @@ def base_select_statement() -> SqlSelectStatementNode:
     ON
       from_source.join_col = joined_source.join_col
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col0")
                 ),
                 column_alias="from_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col1")
                 ),
                 column_alias="from_source_col1",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="join_col")
                 ),
                 column_alias="from_source_join_col",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col0")
                 ),
                 column_alias="joined_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col1")
                 ),
                 column_alias="joined_source_col1",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="join_col")
                 ),
                 column_alias="joined_source_join_col",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="from_source",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="col0",
@@ -123,7 +123,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="col0",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="col1",
@@ -132,7 +132,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="col1",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="join_col",
@@ -141,17 +141,19 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
+            ),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="joined_source",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="col0",
@@ -160,7 +162,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="col0",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="col1",
@@ -169,7 +171,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="col1",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="join_col",
@@ -178,18 +180,18 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",
                 ),
                 right_source_alias="joined_source",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="from_source", column_name="join_col")
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="joined_source", column_name="join_col")
                     ),
                 ),
@@ -228,29 +230,29 @@ def test_prune_from_source(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where columns should be pruned from the FROM clause."""
-    select_statement_with_some_from_source_column_removed = SqlSelectStatementNode(
+    select_statement_with_some_from_source_column_removed = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col0")
                 ),
                 column_alias="from_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col0")
                 ),
                 column_alias="joined_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col1")
                 ),
                 column_alias="joined_source_col1",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="join_col")
                 ),
                 column_alias="joined_source_join_col",
@@ -258,7 +260,7 @@ def test_prune_from_source(
         ),
         from_source=base_select_statement.from_source,
         from_source_alias=base_select_statement.from_source_alias,
-        joins_descs=base_select_statement.join_descs,
+        join_descs=base_select_statement.join_descs,
         group_bys=base_select_statement.group_bys,
         order_bys=base_select_statement.order_bys,
         where=base_select_statement.where,
@@ -287,29 +289,29 @@ def test_prune_joined_source(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where columns should be pruned from the JOIN clause."""
-    select_statement_with_some_joined_source_column_removed = SqlSelectStatementNode(
+    select_statement_with_some_joined_source_column_removed = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col0")
                 ),
                 column_alias="from_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col1")
                 ),
                 column_alias="from_source_col1",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="join_col")
                 ),
                 column_alias="from_source_join_col",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col0")
                 ),
                 column_alias="joined_source_col0",
@@ -317,7 +319,7 @@ def test_prune_joined_source(
         ),
         from_source=base_select_statement.from_source,
         from_source_alias=base_select_statement.from_source_alias,
-        joins_descs=base_select_statement.join_descs,
+        join_descs=base_select_statement.join_descs,
         group_bys=base_select_statement.group_bys,
         order_bys=base_select_statement.order_bys,
         where=base_select_statement.where,
@@ -346,11 +348,11 @@ def test_dont_prune_if_in_where(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests that columns aren't pruned from parent sources if columns are used in a where."""
-    select_statement_with_other_exprs = SqlSelectStatementNode(
+    select_statement_with_other_exprs = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col0")
                 ),
                 column_alias="from_source_col0",
@@ -358,9 +360,11 @@ def test_dont_prune_if_in_where(
         ),
         from_source=base_select_statement.from_source,
         from_source_alias=base_select_statement.from_source_alias,
-        joins_descs=base_select_statement.join_descs,
-        where=SqlIsNullExpression(
-            SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="from_source", column_name="col1"))
+        join_descs=base_select_statement.join_descs,
+        where=SqlIsNullExpression.create(
+            SqlColumnReferenceExpression.create(
+                col_ref=SqlColumnReference(table_alias="from_source", column_name="col1")
+            )
         ),
         group_bys=base_select_statement.group_bys,
         order_bys=base_select_statement.order_bys,
@@ -389,17 +393,17 @@ def test_dont_prune_with_str_expr(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests that columns aren't pruned from parent sources if there's a string expression in the select."""
-    select_statement_with_other_exprs = SqlSelectStatementNode(
+    select_statement_with_other_exprs = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlStringExpression("from_source.col0", requires_parenthesis=False),
+                expr=SqlStringExpression.create("from_source.col0", requires_parenthesis=False),
                 column_alias="some_string_expr",
             ),
         ),
         from_source=base_select_statement.from_source,
         from_source_alias=base_select_statement.from_source_alias,
-        joins_descs=base_select_statement.join_descs,
+        join_descs=base_select_statement.join_descs,
         where=base_select_statement.where,
         group_bys=base_select_statement.group_bys,
         order_bys=base_select_statement.order_bys,
@@ -428,17 +432,17 @@ def test_prune_with_str_expr(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests that columns are from parent sources if there's a string expression in the select with known cols."""
-    select_statement_with_other_exprs = SqlSelectStatementNode(
+    select_statement_with_other_exprs = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlStringExpression("from_source.col0", requires_parenthesis=False, used_columns=("col0",)),
+                expr=SqlStringExpression.create("from_source.col0", requires_parenthesis=False, used_columns=("col0",)),
                 column_alias="some_string_expr",
             ),
         ),
         from_source=base_select_statement.from_source,
         from_source_alias=base_select_statement.from_source_alias,
-        joins_descs=base_select_statement.join_descs,
+        join_descs=base_select_statement.join_descs,
         where=base_select_statement.where,
         group_bys=base_select_statement.group_bys,
         order_bys=base_select_statement.order_bys,
@@ -486,19 +490,19 @@ def string_select_statement() -> SqlSelectStatementNode:
     ON
       from_source.join_col = joined_source.join_col
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlStringExpression(sql_expr="col0", used_columns=("col0",)),
+                expr=SqlStringExpression.create(sql_expr="col0", used_columns=("col0",)),
                 column_alias="from_source_col0",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="from_source",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="col0",
@@ -507,7 +511,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                     column_alias="col0",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="col1",
@@ -516,7 +520,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                     column_alias="col1",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="join_col",
@@ -525,17 +529,19 @@ def string_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
+            ),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="joined_source",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="col2",
@@ -544,7 +550,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                             column_alias="col0",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="col3",
@@ -553,7 +559,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                             column_alias="col1",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="join_col",
@@ -562,18 +568,18 @@ def string_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",
                 ),
                 right_source_alias="joined_source",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="from_source", column_name="join_col")
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="joined_source", column_name="join_col")
                     ),
                 ),
@@ -631,19 +637,19 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
       ) src1
     ) src2
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="src2",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlStringExpression(sql_expr="col0"),
+                expr=SqlStringExpression.create(sql_expr="col0"),
                 column_alias="col0",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="src1",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="src1",
                             column_name="col0",
@@ -652,7 +658,7 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                     column_alias="col0",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="src1",
                             column_name="col1",
@@ -661,11 +667,11 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                     column_alias="col1",
                 ),
             ),
-            from_source=SqlSelectStatementNode(
+            from_source=SqlSelectStatementNode.create(
                 description="src0",
                 select_columns=(
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="col0",
@@ -674,7 +680,7 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                         column_alias="col0",
                     ),
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="col1",
@@ -683,7 +689,7 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                         column_alias="col1",
                     ),
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="col2",
@@ -692,7 +698,7 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                         column_alias="col2",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="src0")),
+                from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
                 from_source_alias="src0",
             ),
             from_source_alias="src1",
@@ -751,23 +757,25 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
     ON
       src3.join_col = src4.join_col
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="4",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlStringExpression(sql_expr="col0"),
+                expr=SqlStringExpression.create(sql_expr="col0"),
                 column_alias="col0",
             ),
         ),
-        from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
+        from_source=SqlTableFromClauseNode.create(
+            sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
+        ),
         from_source_alias="src3",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="src1",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="src1",
                                     column_name="col0",
@@ -776,7 +784,7 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                             column_alias="col0",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="src1",
                                     column_name="join_col",
@@ -785,11 +793,11 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlSelectStatementNode(
+                    from_source=SqlSelectStatementNode.create(
                         description="src0",
                         select_columns=(
                             SqlSelectColumn(
-                                expr=SqlColumnReferenceExpression(
+                                expr=SqlColumnReferenceExpression.create(
                                     col_ref=SqlColumnReference(
                                         table_alias="src0",
                                         column_name="col0",
@@ -798,7 +806,7 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                                 column_alias="col0",
                             ),
                             SqlSelectColumn(
-                                expr=SqlColumnReferenceExpression(
+                                expr=SqlColumnReferenceExpression.create(
                                     col_ref=SqlColumnReference(
                                         table_alias="src0",
                                         column_name="col1",
@@ -807,7 +815,7 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                                 column_alias="col1",
                             ),
                             SqlSelectColumn(
-                                expr=SqlColumnReferenceExpression(
+                                expr=SqlColumnReferenceExpression.create(
                                     col_ref=SqlColumnReference(
                                         table_alias="src0",
                                         column_name="join_col",
@@ -816,18 +824,20 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                                 column_alias="join_col",
                             ),
                         ),
-                        from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="src0")),
+                        from_source=SqlTableFromClauseNode.create(
+                            sql_table=SqlTable(schema_name="demo", table_name="src0")
+                        ),
                         from_source_alias="src0",
                     ),
                     from_source_alias="src1",
                 ),
                 right_source_alias="src4",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="src3", column_name="join_col")
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="src4", column_name="join_col")
                     ),
                 ),
@@ -866,33 +876,35 @@ def test_prune_distinct_select(
     column_pruner: SqlColumnPrunerOptimizer,
 ) -> None:
     """Test that distinct select node shouldn't be pruned."""
-    select_node = SqlSelectStatementNode(
+    select_node = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                 ),
                 column_alias="booking_value",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="test1",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     column_alias="booking_value",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
@@ -54,14 +54,14 @@ def base_select_statement() -> SqlSelectStatementNode:
     GROUP BY src2.ds
     ORDER BY src2.ds
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="src3",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlAggregateFunctionExpression(
+                expr=SqlAggregateFunctionExpression.create(
                     sql_function=SqlFunction.SUM,
                     sql_function_args=[
-                        SqlColumnReferenceExpression(
+                        SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="src2", column_name="bookings")
                         )
                     ],
@@ -69,29 +69,33 @@ def base_select_statement() -> SqlSelectStatementNode:
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src2", column_name="ds")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="ds")
+                ),
                 column_alias="ds",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="src2",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="src1", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src1", column_name="ds")),
+                    expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="src1", column_name="ds")
+                    ),
                     column_alias="ds",
                 ),
             ),
-            from_source=SqlSelectStatementNode(
+            from_source=SqlSelectStatementNode.create(
                 description="src1",
                 select_columns=(
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="bookings",
@@ -100,7 +104,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="bookings",
                     ),
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="ds",
@@ -109,27 +113,29 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="ds",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+                from_source=SqlTableFromClauseNode.create(
+                    sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+                ),
                 from_source_alias="src0",
                 limit=2,
             ),
             from_source_alias="src1",
-            where=SqlComparisonExpression(
-                left_expr=SqlColumnReferenceExpression(
+            where=SqlComparisonExpression.create(
+                left_expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="src1",
                         column_name="ds",
                     )
                 ),
                 comparison=SqlComparison.GREATER_THAN_OR_EQUALS,
-                right_expr=SqlStringLiteralExpression("2020-01-01"),
+                right_expr=SqlStringLiteralExpression.create("2020-01-01"),
             ),
             limit=1,
         ),
         from_source_alias="src2",
         group_bys=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="src2",
                         column_name="ds",
@@ -138,19 +144,19 @@ def base_select_statement() -> SqlSelectStatementNode:
                 column_alias="ds",
             ),
         ),
-        where=SqlComparisonExpression(
-            left_expr=SqlColumnReferenceExpression(
+        where=SqlComparisonExpression.create(
+            left_expr=SqlColumnReferenceExpression.create(
                 SqlColumnReference(
                     table_alias="src2",
                     column_name="ds",
                 )
             ),
             comparison=SqlComparison.LESS_THAN_OR_EQUALS,
-            right_expr=SqlStringLiteralExpression("2020-01-05"),
+            right_expr=SqlStringLiteralExpression.create("2020-01-05"),
         ),
         order_bys=(
             SqlOrderByDescription(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="src2",
                         column_name="ds",
@@ -210,14 +216,14 @@ def join_select_statement() -> SqlSelectStatementNode:
     ON bookings_src.listing = listings_src.listing
     GROUP BY bookings_src.ds
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="query",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlAggregateFunctionExpression(
+                expr=SqlAggregateFunctionExpression.create(
                     sql_function=SqlFunction.SUM,
                     sql_function_args=[
-                        SqlColumnReferenceExpression(
+                        SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="bookings_src", column_name="bookings")
                         )
                     ],
@@ -225,72 +231,74 @@ def join_select_statement() -> SqlSelectStatementNode:
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="listings_src", column_name="country_latest")
                 ),
                 column_alias="listing__country_latest",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="bookings_src", column_name="ds")
                 ),
                 column_alias="ds",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="bookings_src",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="fct_bookings_src", column_name="booking")
                     ),
                     column_alias="bookings",
                 ),
                 SqlSelectColumn(
-                    expr=SqlStringExpression(sql_expr="1", requires_parenthesis=False, used_columns=()),
+                    expr=SqlStringExpression.create(sql_expr="1", requires_parenthesis=False, used_columns=()),
                     column_alias="ds",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="fct_bookings_src", column_name="listing_id")
                     ),
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="fct_bookings_src",
         ),
         from_source_alias="bookings_src",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="listings_src",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src", column_name="country")
                             ),
                             column_alias="country_latest",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src", column_name="listing_id")
                             ),
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
                     ),
                     from_source_alias="dim_listings_src",
                 ),
                 right_source_alias="listings_src",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="bookings_src", column_name="listing"),
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="listings_src", column_name="listing"),
                     ),
                 ),
@@ -299,7 +307,7 @@ def join_select_statement() -> SqlSelectStatementNode:
         ),
         group_bys=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="bookings_src",
                         column_name="ds",
@@ -308,15 +316,15 @@ def join_select_statement() -> SqlSelectStatementNode:
                 column_alias="ds",
             ),
         ),
-        where=SqlComparisonExpression(
-            left_expr=SqlColumnReferenceExpression(
+        where=SqlComparisonExpression.create(
+            left_expr=SqlColumnReferenceExpression.create(
                 SqlColumnReference(
                     table_alias="bookings_src",
                     column_name="ds",
                 )
             ),
             comparison=SqlComparison.LESS_THAN_OR_EQUALS,
-            right_expr=SqlStringLiteralExpression("2020-01-05"),
+            right_expr=SqlStringLiteralExpression.create("2020-01-05"),
         ),
     )
 
@@ -369,14 +377,14 @@ def colliding_select_statement() -> SqlSelectStatementNode:
     ON bookings_src.listing = listings_src.listing
     GROUP BY bookings_src.ds
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="query",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlAggregateFunctionExpression(
+                expr=SqlAggregateFunctionExpression.create(
                     sql_function=SqlFunction.SUM,
                     sql_function_args=[
-                        SqlColumnReferenceExpression(
+                        SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="bookings_src", column_name="bookings")
                         )
                     ],
@@ -384,74 +392,76 @@ def colliding_select_statement() -> SqlSelectStatementNode:
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="listings_src", column_name="listing__country_latest")
                 ),
                 column_alias="listing__country_latest",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="bookings_src", column_name="ds")
                 ),
                 column_alias="ds",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="bookings_src",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="colliding_alias", column_name="booking")
                     ),
                     column_alias="bookings",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="colliding_alias", column_name="ds")
                     ),
                     column_alias="ds",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="colliding_alias", column_name="listing_id")
                     ),
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="colliding_alias",
         ),
         from_source_alias="bookings_src",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="listings_src",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="colliding_alias", column_name="country")
                             ),
                             column_alias="country_latest",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="colliding_alias", column_name="listing_id")
                             ),
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
                     ),
                     from_source_alias="colliding_alias",
                 ),
                 right_source_alias="listings_src",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="bookings_src", column_name="listing"),
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="listings_src", column_name="listing"),
                     ),
                 ),
@@ -460,7 +470,7 @@ def colliding_select_statement() -> SqlSelectStatementNode:
         ),
         group_bys=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="bookings_src",
                         column_name="ds",
@@ -469,15 +479,15 @@ def colliding_select_statement() -> SqlSelectStatementNode:
                 column_alias="ds",
             ),
         ),
-        where=SqlComparisonExpression(
-            left_expr=SqlColumnReferenceExpression(
+        where=SqlComparisonExpression.create(
+            left_expr=SqlColumnReferenceExpression.create(
                 SqlColumnReference(
                     table_alias="bookings_src",
                     column_name="ds",
                 )
             ),
             comparison=SqlComparison.LESS_THAN_OR_EQUALS,
-            right_expr=SqlStringLiteralExpression("2020-01-05"),
+            right_expr=SqlStringLiteralExpression.create("2020-01-05"),
         ),
     )
 
@@ -538,14 +548,14 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
     ON listing_src1.listing = listings_src2.listing
     GROUP BY bookings_src.ds, listings_src1.country_latest, listings_src2.capacity_latest
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="query",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlAggregateFunctionExpression(
+                expr=SqlAggregateFunctionExpression.create(
                     sql_function=SqlFunction.SUM,
                     sql_function_args=[
-                        SqlColumnReferenceExpression(
+                        SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="bookings_src", column_name="bookings")
                         )
                     ],
@@ -553,114 +563,116 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="listings_src1", column_name="country_latest")
                 ),
                 column_alias="listing__country_latest",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="listings_src2", column_name="capacity_latest")
                 ),
                 column_alias="listing__capacity_latest",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="bookings_src", column_name="ds")
                 ),
                 column_alias="ds",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="bookings_src",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="fct_bookings_src", column_name="booking")
                     ),
                     column_alias="bookings",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="fct_bookings_src", column_name="ds")
                     ),
                     column_alias="ds",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="fct_bookings_src", column_name="listing_id")
                     ),
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="fct_bookings_src",
         ),
         from_source_alias="bookings_src",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="listings_src1",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src1", column_name="country")
                             ),
                             column_alias="country_latest",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src1", column_name="listing_id")
                             ),
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
                     ),
                     from_source_alias="dim_listings_src1",
                 ),
                 right_source_alias="listings_src1",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="bookings_src", column_name="listing"),
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="listings_src1", column_name="listing"),
                     ),
                 ),
                 join_type=SqlJoinType.LEFT_OUTER,
             ),
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="listings_src2",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src2", column_name="capacity")
                             ),
                             column_alias="capacity_latest",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="dim_listings_src2", column_name="listing_id")
                             ),
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
                     ),
                     from_source_alias="dim_listings_src2",
                 ),
                 right_source_alias="listings_src2",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="listings_src1", column_name="listing"),
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         SqlColumnReference(table_alias="listings_src2", column_name="listing"),
                     ),
                 ),
@@ -669,7 +681,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
         ),
         group_bys=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="bookings_src",
                         column_name="ds",
@@ -678,7 +690,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                 column_alias="ds",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="listings_src1",
                         column_name="country_latest",
@@ -687,7 +699,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                 column_alias="listing__country_latest",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="listings_src2",
                         column_name="capacity_latest",
@@ -748,30 +760,30 @@ def reducing_join_statement() -> SqlSelectStatementNode:
       FROM demo.fct_listings src4
     ) src3
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="query",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="src2", column_name="bookings")
                 ),
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="src3", column_name="listings")
                 ),
                 column_alias="listings",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="src2",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlAggregateFunctionExpression(
+                    expr=SqlAggregateFunctionExpression.create(
                         sql_function=SqlFunction.SUM,
                         sql_function_args=[
-                            SqlColumnReferenceExpression(
+                            SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="src1", column_name="bookings")
                             )
                         ],
@@ -779,30 +791,32 @@ def reducing_join_statement() -> SqlSelectStatementNode:
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlSelectStatementNode(
+            from_source=SqlSelectStatementNode.create(
                 description="src1",
                 select_columns=(
                     SqlSelectColumn(
-                        expr=SqlStringExpression(sql_expr="1", requires_parenthesis=False, used_columns=()),
+                        expr=SqlStringExpression.create(sql_expr="1", requires_parenthesis=False, used_columns=()),
                         column_alias="bookings",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+                from_source=SqlTableFromClauseNode.create(
+                    sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+                ),
                 from_source_alias="src0",
             ),
             from_source_alias="src1",
         ),
         from_source_alias="src2",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="src4",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlAggregateFunctionExpression(
+                            expr=SqlAggregateFunctionExpression.create(
                                 sql_function=SqlFunction.SUM,
                                 sql_function_args=[
-                                    SqlColumnReferenceExpression(
+                                    SqlColumnReferenceExpression.create(
                                         col_ref=SqlColumnReference(table_alias="src4", column_name="listings")
                                     )
                                 ],
@@ -810,7 +824,7 @@ def reducing_join_statement() -> SqlSelectStatementNode:
                             column_alias="listings",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="fct_listings")
                     ),
                     from_source_alias="src4",
@@ -872,30 +886,30 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
       FROM demo.fct_listings src4
     ) src3
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="query",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="src2", column_name="bookings")
                 ),
                 column_alias="bookings",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="src3", column_name="listings")
                 ),
                 column_alias="listings",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="src4",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlAggregateFunctionExpression(
+                    expr=SqlAggregateFunctionExpression.create(
                         sql_function=SqlFunction.SUM,
                         sql_function_args=[
-                            SqlColumnReferenceExpression(
+                            SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="src4", column_name="listings")
                             )
                         ],
@@ -903,20 +917,22 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
                     column_alias="listings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_listings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_listings")
+            ),
             from_source_alias="src4",
         ),
         from_source_alias="src2",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="src2",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlAggregateFunctionExpression(
+                            expr=SqlAggregateFunctionExpression.create(
                                 sql_function=SqlFunction.SUM,
                                 sql_function_args=[
-                                    SqlColumnReferenceExpression(
+                                    SqlColumnReferenceExpression.create(
                                         col_ref=SqlColumnReference(table_alias="src1", column_name="bookings")
                                     )
                                 ],
@@ -924,15 +940,17 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
                             column_alias="bookings",
                         ),
                     ),
-                    from_source=SqlSelectStatementNode(
+                    from_source=SqlSelectStatementNode.create(
                         description="src1",
                         select_columns=(
                             SqlSelectColumn(
-                                expr=SqlStringExpression(sql_expr="1", requires_parenthesis=False, used_columns=()),
+                                expr=SqlStringExpression.create(
+                                    sql_expr="1", requires_parenthesis=False, used_columns=()
+                                ),
                                 column_alias="bookings",
                             ),
                         ),
-                        from_source=SqlTableFromClauseNode(
+                        from_source=SqlTableFromClauseNode.create(
                             sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
                         ),
                         from_source_alias="src0",
@@ -975,33 +993,35 @@ def test_rewriting_distinct_select_node_is_not_reduced(
     mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     """Tests to ensure distinct select node doesn't get overwritten."""
-    select_node = SqlSelectStatementNode(
+    select_node = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                 ),
                 column_alias="booking_value",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="test1",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     column_alias="booking_value",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_sub_query_reducer.py
@@ -46,39 +46,43 @@ def base_select_statement() -> SqlSelectStatementNode:
     ) src2
     ORDER BY src2.col0
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="src3",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src2", column_name="col0")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="col0")
+                ),
                 column_alias="col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src2", column_name="col1")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="col1")
+                ),
                 column_alias="col1",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="src2",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="src1", column_name="col0")
                     ),
                     column_alias="col0",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="src1", column_name="col1")
                     ),
                     column_alias="col1",
                 ),
             ),
-            from_source=SqlSelectStatementNode(
+            from_source=SqlSelectStatementNode.create(
                 description="src1",
                 select_columns=(
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="col0",
@@ -87,7 +91,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="col0",
                     ),
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(
                                 table_alias="src0",
                                 column_name="col1",
@@ -96,7 +100,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="col1",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode(
+                from_source=SqlTableFromClauseNode.create(
                     sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
                 ),
                 from_source_alias="src0",
@@ -108,7 +112,7 @@ def base_select_statement() -> SqlSelectStatementNode:
         from_source_alias="src2",
         order_bys=(
             SqlOrderByDescription(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="src2",
                         column_name="col0",
@@ -163,47 +167,53 @@ def rewrite_order_by_statement() -> SqlSelectStatementNode:
     ORDER BY
     src2.col1
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="src3",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src2", column_name="col0")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="col0")
+                ),
                 column_alias="col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="src2", column_name="col1")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="src2", column_name="col1")
+                ),
                 column_alias="col1",
             ),
         ),
         from_source=(
-            SqlSelectStatementNode(
+            SqlSelectStatementNode.create(
                 description="src2",
                 select_columns=(
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="src0", column_name="col0")
                         ),
                         column_alias="col0",
                     ),
                     SqlSelectColumn(
-                        expr=SqlColumnReferenceExpression(
+                        expr=SqlColumnReferenceExpression.create(
                             col_ref=SqlColumnReference(table_alias="src1", column_name="col1")
                         ),
                         column_alias="col1",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="src0")),
+                from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
                 from_source_alias="src0",
-                joins_descs=(
+                join_descs=(
                     SqlJoinDescription(
-                        right_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="src1")),
+                        right_source=SqlTableFromClauseNode.create(
+                            sql_table=SqlTable(schema_name="demo", table_name="src1")
+                        ),
                         right_source_alias="src1",
-                        on_condition=SqlComparisonExpression(
-                            left_expr=SqlColumnReferenceExpression(
+                        on_condition=SqlComparisonExpression.create(
+                            left_expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="src0", column_name="join_col")
                             ),
                             comparison=SqlComparison.EQUALS,
-                            right_expr=SqlColumnReferenceExpression(
+                            right_expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(table_alias="src1", column_name="join_col")
                             ),
                         ),
@@ -215,7 +225,7 @@ def rewrite_order_by_statement() -> SqlSelectStatementNode:
         from_source_alias="src2",
         order_bys=(
             SqlOrderByDescription(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     SqlColumnReference(
                         table_alias="src2",
                         column_name="col1",
@@ -255,33 +265,35 @@ def test_distinct_select_node_is_not_reduced(
     mf_test_configuration: MetricFlowTestConfiguration,
 ) -> None:
     """Tests to ensure distinct select node doesn't get overwritten."""
-    select_node = SqlSelectStatementNode(
+    select_node = SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                 ),
                 column_alias="booking_value",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="test1",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     column_alias="booking_value",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
@@ -53,27 +53,27 @@ def base_select_statement() -> SqlSelectStatementNode:
     ON
       from_source.join_col = joined_source.join_col
     """
-    return SqlSelectStatementNode(
+    return SqlSelectStatementNode.create(
         description="test0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="from_source", column_name="col0")
                 ),
                 column_alias="from_source_col0",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(
+                expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="joined_source", column_name="col0")
                 ),
                 column_alias="joined_source_col0",
             ),
         ),
-        from_source=SqlSelectStatementNode(
+        from_source=SqlSelectStatementNode.create(
             description="from_source",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="col0",
@@ -82,7 +82,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="col0",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(
                             table_alias="from_source_table",
                             column_name="join_col",
@@ -91,17 +91,19 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
+            ),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
-        joins_descs=(
+        join_descs=(
             SqlJoinDescription(
-                right_source=SqlSelectStatementNode(
+                right_source=SqlSelectStatementNode.create(
                     description="joined_source",
                     select_columns=(
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="col0",
@@ -110,7 +112,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="col0",
                         ),
                         SqlSelectColumn(
-                            expr=SqlColumnReferenceExpression(
+                            expr=SqlColumnReferenceExpression.create(
                                 col_ref=SqlColumnReference(
                                     table_alias="joined_source_table",
                                     column_name="join_col",
@@ -119,18 +121,18 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode(
+                    from_source=SqlTableFromClauseNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",
                 ),
                 right_source_alias="joined_source",
-                on_condition=SqlComparisonExpression(
-                    left_expr=SqlColumnReferenceExpression(
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="from_source", column_name="join_col")
                     ),
                     comparison=SqlComparison.EQUALS,
-                    right_expr=SqlColumnReferenceExpression(
+                    right_expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="joined_source", column_name="join_col")
                     ),
                 ),

--- a/tests_metricflow/sql/test_engine_specific_rendering.py
+++ b/tests_metricflow/sql/test_engine_specific_rendering.py
@@ -37,8 +37,8 @@ def test_cast_to_timestamp(
     """Tests rendering of the cast to timestamp expression in a query."""
     select_columns = [
         SqlSelectColumn(
-            expr=SqlCastToTimestampExpression(
-                arg=SqlStringLiteralExpression(
+            expr=SqlCastToTimestampExpression.create(
+                arg=SqlStringLiteralExpression.create(
                     literal_value="2020-01-01",
                 )
             ),
@@ -46,7 +46,7 @@ def test_cast_to_timestamp(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -56,12 +56,12 @@ def test_cast_to_timestamp(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Cast to Timestamp Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -80,17 +80,17 @@ def test_generate_uuid(
     """Tests rendering of the generate uuid expression in a query."""
     select_columns = [
         SqlSelectColumn(
-            expr=SqlGenerateUuidExpression(),
+            expr=SqlGenerateUuidExpression.create(),
             column_alias="uuid",
         ),
     ]
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
 
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Generate UUID Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
@@ -115,8 +115,8 @@ def test_continuous_percentile_expr(
 
     select_columns = [
         SqlSelectColumn(
-            expr=SqlPercentileExpression(
-                order_by_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
+            expr=SqlPercentileExpression.create(
+                order_by_arg=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
                 percentile_args=SqlPercentileExpressionArgument(
                     percentile=0.5, function_type=SqlPercentileFunctionType.CONTINUOUS
                 ),
@@ -125,7 +125,7 @@ def test_continuous_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -135,12 +135,12 @@ def test_continuous_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Continuous Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -164,8 +164,8 @@ def test_discrete_percentile_expr(
 
     select_columns = [
         SqlSelectColumn(
-            expr=SqlPercentileExpression(
-                order_by_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
+            expr=SqlPercentileExpression.create(
+                order_by_arg=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
                 percentile_args=SqlPercentileExpressionArgument(
                     percentile=0.5, function_type=SqlPercentileFunctionType.DISCRETE
                 ),
@@ -174,7 +174,7 @@ def test_discrete_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -184,12 +184,12 @@ def test_discrete_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Discrete Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -213,8 +213,8 @@ def test_approximate_continuous_percentile_expr(
 
     select_columns = [
         SqlSelectColumn(
-            expr=SqlPercentileExpression(
-                order_by_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
+            expr=SqlPercentileExpression.create(
+                order_by_arg=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
                 percentile_args=SqlPercentileExpressionArgument(
                     percentile=0.5, function_type=SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS
                 ),
@@ -223,7 +223,7 @@ def test_approximate_continuous_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -233,12 +233,12 @@ def test_approximate_continuous_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Approximate Continuous Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -262,8 +262,8 @@ def test_approximate_discrete_percentile_expr(
 
     select_columns = [
         SqlSelectColumn(
-            expr=SqlPercentileExpression(
-                order_by_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
+            expr=SqlPercentileExpression.create(
+                order_by_arg=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
                 percentile_args=SqlPercentileExpressionArgument(
                     percentile=0.5, function_type=SqlPercentileFunctionType.APPROXIMATE_DISCRETE
                 ),
@@ -272,7 +272,7 @@ def test_approximate_discrete_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -282,12 +282,12 @@ def test_approximate_discrete_percentile_expr(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="Test Approximate Discrete Percentile Expression",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),

--- a/tests_metricflow/sql/test_sql_expr_render.py
+++ b/tests_metricflow/sql/test_sql_expr_render.py
@@ -45,14 +45,14 @@ def default_expr_renderer() -> DefaultSqlExpressionRenderer:  # noqa: D103
 
 
 def test_str_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
-    actual = default_expr_renderer.render_sql_expr(SqlStringExpression("a + b")).sql
+    actual = default_expr_renderer.render_sql_expr(SqlStringExpression.create("a + b")).sql
     expected = "a + b"
     assert actual == expected
 
 
 def test_col_ref_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlColumnReferenceExpression(SqlColumnReference("my_table", "my_col"))
+        SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "my_col"))
     ).sql
     expected = "my_table.my_col"
     assert actual == expected
@@ -60,10 +60,10 @@ def test_col_ref_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
 
 def test_comparison_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlComparisonExpression(
-            left_expr=SqlColumnReferenceExpression(SqlColumnReference("my_table", "my_col")),
+        SqlComparisonExpression.create(
+            left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "my_col")),
             comparison=SqlComparison.EQUALS,
-            right_expr=SqlStringExpression("a + b"),
+            right_expr=SqlStringExpression.create("a + b"),
         )
     ).sql
     assert actual == "my_table.my_col = (a + b)"
@@ -71,10 +71,10 @@ def test_comparison_expr(default_expr_renderer: DefaultSqlExpressionRenderer) ->
 
 def test_require_parenthesis(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlComparisonExpression(
-            left_expr=SqlColumnReferenceExpression(SqlColumnReference("a", "booking_value")),
+        SqlComparisonExpression.create(
+            left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "booking_value")),
             comparison=SqlComparison.GREATER_THAN,
-            right_expr=SqlStringExpression("100", requires_parenthesis=False),
+            right_expr=SqlStringExpression.create("100", requires_parenthesis=False),
         )
     ).sql
 
@@ -83,11 +83,11 @@ def test_require_parenthesis(default_expr_renderer: DefaultSqlExpressionRenderer
 
 def test_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlAggregateFunctionExpression(
+        SqlAggregateFunctionExpression.create(
             sql_function=SqlFunction.SUM,
             sql_function_args=[
-                SqlColumnReferenceExpression(SqlColumnReference("my_table", "a")),
-                SqlColumnReferenceExpression(SqlColumnReference("my_table", "b")),
+                SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "a")),
+                SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "b")),
             ],
         )
     ).sql
@@ -97,11 +97,11 @@ def test_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> N
 def test_distinct_agg_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:
     """Distinct aggregation functions require the insertion of the DISTINCT keyword in the rendered function expr."""
     actual = default_expr_renderer.render_sql_expr(
-        SqlAggregateFunctionExpression(
+        SqlAggregateFunctionExpression.create(
             sql_function=SqlFunction.COUNT_DISTINCT,
             sql_function_args=[
-                SqlColumnReferenceExpression(SqlColumnReference("my_table", "a")),
-                SqlColumnReferenceExpression(SqlColumnReference("my_table", "b")),
+                SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "a")),
+                SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "b")),
             ],
         )
     ).sql
@@ -111,15 +111,15 @@ def test_distinct_agg_expr(default_expr_renderer: DefaultSqlExpressionRenderer) 
 
 def test_nested_function_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlAggregateFunctionExpression(
+        SqlAggregateFunctionExpression.create(
             sql_function=SqlFunction.CONCAT,
             sql_function_args=[
-                SqlColumnReferenceExpression(SqlColumnReference("my_table", "a")),
-                SqlAggregateFunctionExpression(
+                SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "a")),
+                SqlAggregateFunctionExpression.create(
                     sql_function=SqlFunction.CONCAT,
                     sql_function_args=[
-                        SqlColumnReferenceExpression(SqlColumnReference("my_table", "b")),
-                        SqlColumnReferenceExpression(SqlColumnReference("my_table", "c")),
+                        SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "b")),
+                        SqlColumnReferenceExpression.create(SqlColumnReference("my_table", "c")),
                     ],
                 ),
             ],
@@ -129,17 +129,17 @@ def test_nested_function_expr(default_expr_renderer: DefaultSqlExpressionRendere
 
 
 def test_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
-    actual = default_expr_renderer.render_sql_expr(SqlNullExpression()).sql
+    actual = default_expr_renderer.render_sql_expr(SqlNullExpression.create()).sql
     assert actual == "NULL"
 
 
 def test_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlLogicalExpression(
+        SqlLogicalExpression.create(
             operator=SqlLogicalOperator.AND,
             args=(
-                SqlStringExpression("1 < 2", requires_parenthesis=True),
-                SqlStringExpression("foo", requires_parenthesis=False),
+                SqlStringExpression.create("1 < 2", requires_parenthesis=True),
+                SqlStringExpression.create("foo", requires_parenthesis=False),
             ),
         )
     ).sql
@@ -155,12 +155,12 @@ def test_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None: 
 
 def test_long_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlLogicalExpression(
+        SqlLogicalExpression.create(
             operator=SqlLogicalOperator.AND,
             args=(
-                SqlStringExpression("some_long_expression1"),
-                SqlStringExpression("some_long_expression2"),
-                SqlStringExpression("some_long_expression3"),
+                SqlStringExpression.create("some_long_expression1"),
+                SqlStringExpression.create("some_long_expression2"),
+                SqlStringExpression.create("some_long_expression3"),
             ),
         )
     ).sql
@@ -181,56 +181,59 @@ def test_long_and_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> N
 
 
 def test_string_literal_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
-    actual = default_expr_renderer.render_sql_expr(SqlStringLiteralExpression("foo")).sql
+    actual = default_expr_renderer.render_sql_expr(SqlStringLiteralExpression.create("foo")).sql
     assert actual == "'foo'"
 
 
 def test_is_null_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlIsNullExpression(SqlStringExpression("foo", requires_parenthesis=False))
+        SqlIsNullExpression.create(SqlStringExpression.create("foo", requires_parenthesis=False))
     ).sql
     assert actual == "foo IS NULL"
 
 
 def test_date_trunc_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlDateTruncExpression(time_granularity=TimeGranularity.MONTH, arg=SqlStringExpression("ds"))
+        SqlDateTruncExpression.create(time_granularity=TimeGranularity.MONTH, arg=SqlStringExpression.create("ds"))
     ).sql
     assert actual == "DATE_TRUNC('month', ds)"
 
 
 def test_extract_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlExtractExpression(date_part=DatePart.DOY, arg=SqlStringExpression("ds"))
+        SqlExtractExpression.create(date_part=DatePart.DOY, arg=SqlStringExpression.create("ds"))
     ).sql
     assert actual == "EXTRACT(doy FROM ds)"
 
 
 def test_ratio_computation_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlRatioComputationExpression(
-            numerator=SqlAggregateFunctionExpression(
-                SqlFunction.SUM, sql_function_args=[SqlStringExpression(sql_expr="1", requires_parenthesis=False)]
+        SqlRatioComputationExpression.create(
+            numerator=SqlAggregateFunctionExpression.create(
+                SqlFunction.SUM,
+                sql_function_args=[SqlStringExpression.create(sql_expr="1", requires_parenthesis=False)],
             ),
-            denominator=SqlColumnReferenceExpression(SqlColumnReference(column_name="divide_by_me", table_alias="a")),
+            denominator=SqlColumnReferenceExpression.create(
+                SqlColumnReference(column_name="divide_by_me", table_alias="a")
+            ),
         ),
     ).sql
     assert actual == "CAST(SUM(1) AS DOUBLE) / CAST(NULLIF(a.divide_by_me, 0) AS DOUBLE)"
 
 
 def test_expr_rewrite(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
-    expr = SqlLogicalExpression(
+    expr = SqlLogicalExpression.create(
         operator=SqlLogicalOperator.AND,
         args=(
-            SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
-            SqlColumnReferenceExpression(SqlColumnReference("a", "col1")),
+            SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
+            SqlColumnReferenceExpression.create(SqlColumnReference("a", "col1")),
         ),
     )
 
     column_replacements = SqlColumnReplacements(
         {
-            SqlColumnReference("a", "col0"): SqlStringExpression("foo", requires_parenthesis=False),
-            SqlColumnReference("a", "col1"): SqlStringExpression("bar", requires_parenthesis=False),
+            SqlColumnReference("a", "col0"): SqlStringExpression.create("foo", requires_parenthesis=False),
+            SqlColumnReference("a", "col1"): SqlStringExpression.create("bar", requires_parenthesis=False),
         }
     )
     expr_rewritten = expr.rewrite(column_replacements)
@@ -239,15 +242,15 @@ def test_expr_rewrite(default_expr_renderer: DefaultSqlExpressionRenderer) -> No
 
 def test_between_expr(default_expr_renderer: DefaultSqlExpressionRenderer) -> None:  # noqa: D103
     actual = default_expr_renderer.render_sql_expr(
-        SqlBetweenExpression(
-            column_arg=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
-            start_expr=SqlCastToTimestampExpression(
-                arg=SqlStringLiteralExpression(
+        SqlBetweenExpression.create(
+            column_arg=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
+            start_expr=SqlCastToTimestampExpression.create(
+                arg=SqlStringLiteralExpression.create(
                     literal_value="2020-01-01",
                 )
             ),
-            end_expr=SqlCastToTimestampExpression(
-                arg=SqlStringLiteralExpression(
+            end_expr=SqlCastToTimestampExpression.create(
+                arg=SqlStringLiteralExpression.create(
                     literal_value="2020-01-10",
                 )
             ),
@@ -262,17 +265,17 @@ def test_window_function_expr(  # noqa: D103
     default_expr_renderer: DefaultSqlExpressionRenderer,
 ) -> None:
     partition_by_args = (
-        SqlColumnReferenceExpression(SqlColumnReference("b", "col0")),
-        SqlColumnReferenceExpression(SqlColumnReference("b", "col1")),
+        SqlColumnReferenceExpression.create(SqlColumnReference("b", "col0")),
+        SqlColumnReferenceExpression.create(SqlColumnReference("b", "col1")),
     )
     order_by_args = (
         SqlWindowOrderByArgument(
-            expr=SqlColumnReferenceExpression(SqlColumnReference("a", "col0")),
+            expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0")),
             descending=True,
             nulls_last=False,
         ),
         SqlWindowOrderByArgument(
-            expr=SqlColumnReferenceExpression(SqlColumnReference("b", "col0")),
+            expr=SqlColumnReferenceExpression.create(SqlColumnReference("b", "col0")),
             descending=False,
             nulls_last=True,
         ),
@@ -284,9 +287,9 @@ def test_window_function_expr(  # noqa: D103
         rendered_sql_lines.append(f"-- Window function with {num_partition_by_args} PARTITION BY items(s)")
         rendered_sql_lines.append(
             default_expr_renderer.render_sql_expr(
-                SqlWindowFunctionExpression(
+                SqlWindowFunctionExpression.create(
                     sql_function=SqlWindowFunction.FIRST_VALUE,
-                    sql_function_args=[SqlColumnReferenceExpression(SqlColumnReference("a", "col0"))],
+                    sql_function_args=[SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0"))],
                     partition_by_args=partition_by_args[:num_partition_by_args],
                     order_by_args=(),
                 )
@@ -298,9 +301,9 @@ def test_window_function_expr(  # noqa: D103
         rendered_sql_lines.append(f"-- Window function with {num_order_by_args} ORDER BY items(s)")
         rendered_sql_lines.append(
             default_expr_renderer.render_sql_expr(
-                SqlWindowFunctionExpression(
+                SqlWindowFunctionExpression.create(
                     sql_function=SqlWindowFunction.FIRST_VALUE,
-                    sql_function_args=[SqlColumnReferenceExpression(SqlColumnReference("a", "col0"))],
+                    sql_function_args=[SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0"))],
                     partition_by_args=(),
                     order_by_args=order_by_args[:num_order_by_args],
                 )
@@ -311,9 +314,9 @@ def test_window_function_expr(  # noqa: D103
     rendered_sql_lines.append("-- Window function with PARTITION BY and ORDER BY items")
     rendered_sql_lines.append(
         default_expr_renderer.render_sql_expr(
-            SqlWindowFunctionExpression(
+            SqlWindowFunctionExpression.create(
                 sql_function=SqlWindowFunction.FIRST_VALUE,
-                sql_function_args=[SqlColumnReferenceExpression(SqlColumnReference("a", "col0"))],
+                sql_function_args=[SqlColumnReferenceExpression.create(SqlColumnReference("a", "col0"))],
                 partition_by_args=partition_by_args,
                 order_by_args=order_by_args,
             )

--- a/tests_metricflow/sql/test_sql_plan_render.py
+++ b/tests_metricflow/sql/test_sql_plan_render.py
@@ -42,14 +42,14 @@ def test_component_rendering(
     # Test single SELECT column
     select_columns = [
         SqlSelectColumn(
-            expr=SqlAggregateFunctionExpression(
-                sql_function=SqlFunction.SUM, sql_function_args=[SqlStringExpression("1")]
+            expr=SqlAggregateFunctionExpression.create(
+                sql_function=SqlFunction.SUM, sql_function_args=[SqlStringExpression.create("1")]
             ),
             column_alias="bookings",
         ),
     ]
 
-    from_source = SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings"))
+    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings"))
 
     from_source = from_source
     from_source_alias = "a"
@@ -61,12 +61,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test0",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -79,11 +79,11 @@ def test_component_rendering(
     select_columns.extend(
         [
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(SqlColumnReference("b", "country")),
+                expr=SqlColumnReferenceExpression.create(SqlColumnReference("b", "country")),
                 column_alias="user__country",
             ),
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(SqlColumnReference("c", "country")),
+                expr=SqlColumnReferenceExpression.create(SqlColumnReference("c", "country")),
                 column_alias="listing__country",
             ),
         ]
@@ -92,12 +92,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test1",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -109,12 +109,12 @@ def test_component_rendering(
     # Test single join
     joins_descs.append(
         SqlJoinDescription(
-            right_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="dim_users")),
+            right_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_users")),
             right_source_alias="b",
-            on_condition=SqlComparisonExpression(
-                left_expr=SqlColumnReferenceExpression(SqlColumnReference("a", "user_id")),
+            on_condition=SqlComparisonExpression.create(
+                left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "user_id")),
                 comparison=SqlComparison.EQUALS,
-                right_expr=SqlColumnReferenceExpression(SqlColumnReference("b", "user_id")),
+                right_expr=SqlColumnReferenceExpression.create(SqlColumnReference("b", "user_id")),
             ),
             join_type=SqlJoinType.LEFT_OUTER,
         )
@@ -123,12 +123,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test2",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -140,12 +140,14 @@ def test_component_rendering(
     # Test multiple join
     joins_descs.append(
         SqlJoinDescription(
-            right_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
+            right_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
+            ),
             right_source_alias="c",
-            on_condition=SqlComparisonExpression(
-                left_expr=SqlColumnReferenceExpression(SqlColumnReference("a", "user_id")),
+            on_condition=SqlComparisonExpression.create(
+                left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "user_id")),
                 comparison=SqlComparison.EQUALS,
-                right_expr=SqlColumnReferenceExpression(SqlColumnReference("c", "user_id")),
+                right_expr=SqlColumnReferenceExpression.create(SqlColumnReference("c", "user_id")),
             ),
             join_type=SqlJoinType.LEFT_OUTER,
         )
@@ -154,12 +156,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test3",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -171,7 +173,7 @@ def test_component_rendering(
     # Test single group by
     group_bys.append(
         SqlSelectColumn(
-            expr=SqlColumnReferenceExpression(SqlColumnReference("b", "country")),
+            expr=SqlColumnReferenceExpression.create(SqlColumnReference("b", "country")),
             column_alias="user__country",
         ),
     )
@@ -179,12 +181,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test4",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -196,7 +198,7 @@ def test_component_rendering(
     # Test multiple group bys
     group_bys.append(
         SqlSelectColumn(
-            expr=SqlColumnReferenceExpression(SqlColumnReference("c", "country")),
+            expr=SqlColumnReferenceExpression.create(SqlColumnReference("c", "country")),
             column_alias="listing__country",
         ),
     )
@@ -204,12 +206,12 @@ def test_component_rendering(
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test5",
             select_columns=tuple(select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
-            joins_descs=tuple(joins_descs),
+            join_descs=tuple(joins_descs),
             where=where,
             group_bys=tuple(group_bys),
             order_bys=tuple(order_bys),
@@ -228,24 +230,26 @@ def test_render_where(  # noqa: D103
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     column_alias="booking_value",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
-            where=SqlComparisonExpression(
-                left_expr=SqlColumnReferenceExpression(
+            where=SqlComparisonExpression.create(
+                left_expr=SqlColumnReferenceExpression.create(
                     col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                 ),
                 comparison=SqlComparison.GREATER_THAN,
-                right_expr=SqlStringExpression(
+                right_expr=SqlStringExpression.create(
                     sql_expr="100",
                     requires_parenthesis=False,
                     used_columns=(),
@@ -266,33 +270,35 @@ def test_render_order_by(  # noqa: D103
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     column_alias="booking_value",
                 ),
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
             order_bys=(
                 SqlOrderByDescription(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="booking_value")
                     ),
                     desc=False,
                 ),
                 SqlOrderByDescription(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     desc=True,
@@ -313,17 +319,19 @@ def test_render_limit(  # noqa: D103
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlSelectStatementNode(
+        sql_plan_node=SqlSelectStatementNode.create(
             description="test0",
             select_columns=(
                 SqlSelectColumn(
-                    expr=SqlColumnReferenceExpression(
+                    expr=SqlColumnReferenceExpression.create(
                         col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
                     ),
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+            from_source=SqlTableFromClauseNode.create(
+                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
+            ),
             from_source_alias="a",
             limit=1,
         ),
@@ -338,22 +346,24 @@ def test_render_create_table_as(  # noqa: D103
     mf_test_configuration: MetricFlowTestConfiguration,
     sql_client: SqlClient,
 ) -> None:
-    select_node = SqlSelectStatementNode(
+    select_node = SqlSelectStatementNode.create(
         description="select_0",
         select_columns=(
             SqlSelectColumn(
-                expr=SqlColumnReferenceExpression(col_ref=SqlColumnReference(table_alias="a", column_name="bookings")),
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="a", column_name="bookings")
+                ),
                 column_alias="bookings",
             ),
         ),
-        from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+        from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
         from_source_alias="a",
         limit=1,
     )
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlCreateTableAsNode(
+        sql_plan_node=SqlCreateTableAsNode.create(
             sql_table=SqlTable(
                 schema_name="schema_name",
                 table_name="table_name",
@@ -367,7 +377,7 @@ def test_render_create_table_as(  # noqa: D103
     assert_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
-        sql_plan_node=SqlCreateTableAsNode(
+        sql_plan_node=SqlCreateTableAsNode.create(
             sql_table=SqlTable(
                 schema_name="schema_name",
                 table_name="table_name",

--- a/tests_metricflow/sql_clients/test_date_time_operations.py
+++ b/tests_metricflow/sql_clients/test_date_time_operations.py
@@ -44,8 +44,8 @@ def _extract_data_table_value(df: MetricFlowDataTable) -> Any:  # type: ignore[m
 
 
 def _build_date_trunc_expression(date_string: str, time_granularity: TimeGranularity) -> SqlDateTruncExpression:
-    cast_expr = SqlCastToTimestampExpression(SqlStringLiteralExpression(literal_value=date_string))
-    return SqlDateTruncExpression(time_granularity=time_granularity, arg=cast_expr)
+    cast_expr = SqlCastToTimestampExpression.create(SqlStringLiteralExpression.create(literal_value=date_string))
+    return SqlDateTruncExpression.create(time_granularity=time_granularity, arg=cast_expr)
 
 
 def test_date_trunc_to_year(sql_client: SqlClient) -> None:
@@ -118,8 +118,8 @@ def test_date_trunc_to_week(sql_client: SqlClient, input: str, expected: datetim
 
 
 def _build_extract_expression(date_string: str, date_part: DatePart) -> SqlExtractExpression:
-    cast_expr = SqlCastToTimestampExpression(SqlStringLiteralExpression(literal_value=date_string))
-    return SqlExtractExpression(date_part=date_part, arg=cast_expr)
+    cast_expr = SqlCastToTimestampExpression.create(SqlStringLiteralExpression.create(literal_value=date_string))
+    return SqlExtractExpression.create(date_part=date_part, arg=cast_expr)
 
 
 def test_date_part_year(sql_client: SqlClient) -> None:


### PR DESCRIPTION
* Previously, the DAG-node classes in MF were not dataclasses due to issues with class inheritance. These have since been resolved via hierarchy changes, so this PR updates those classes to be dataclasses. In general, dataclasses make these easier to use, and there are upcoming use cases where dataclasses will simplify implementation (e.g. graph component comparison, serialization).
* A `create()` method was added to simplify many initialization use cases while not overriding the one generated by `dataclasses`.
* There is an update to how the `node_id` field is set - please see `mf_dag.py`.
* Otherwise, this should be a mechanical update with no substantive logic changes.
* There are no snapshot changes, so that should simplify review.
* Please view by commit.