### PR TITLE
Default granularity prep

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -11,6 +11,7 @@ from dbt_semantic_interfaces.transformations.convert_median import (
     ConvertMedianToPercentileRule,
 )
 from dbt_semantic_interfaces.transformations.cumulative_type_params import SetCumulativeTypeParamsRule
+from dbt_semantic_interfaces.transformations.default_granularity import SetDefaultGranularityRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
@@ -38,6 +39,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
             ConvertMedianToPercentileRule(),
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
             SetCumulativeTypeParamsRule(),
+            SetDefaultGranularityRule(),
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -210,3 +210,18 @@ class MetricLookup:
                     minimum_queryable_granularity = defined_time_granularity
 
         return minimum_queryable_granularity
+
+    def get_default_granularity_for_metrics(
+        self, metric_references: Sequence[MetricReference]
+    ) -> Optional[TimeGranularity]:
+        """When querying a group of metrics, the default granularity will be the largest of the metrics' default granularities."""
+        max_default_granularity: Optional[TimeGranularity] = None
+        for metric_reference in metric_references:
+            default_granularity = self.get_metric(metric_reference).default_granularity
+            assert (
+                default_granularity
+            ), f"No default_granularity set for {metric_reference}. Something has been misconfigured."
+            if not max_default_granularity or default_granularity.to_int() > max_default_granularity.to_int():
+                max_default_granularity = default_granularity
+
+        return max_default_granularity

--- a/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
+++ b/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
@@ -570,6 +570,7 @@ class MetricSpec(InstanceSpec):  # noqa: D101
     alias: Optional[str] = None
     offset_window: Optional[PydanticMetricTimeWindow] = None
     offset_to_grain: Optional[TimeGranularity] = None
+    default_granularity: Optional[TimeGranularity] = None
 
     @staticmethod
     def from_element_name(element_name: str) -> MetricSpec:  # noqa: D102
@@ -598,7 +599,12 @@ class MetricSpec(InstanceSpec):  # noqa: D101
 
     def without_offset(self) -> MetricSpec:
         """Represents the metric spec with any time offsets removed."""
-        return MetricSpec(element_name=self.element_name, filter_specs=self.filter_specs, alias=self.alias)
+        return MetricSpec(
+            element_name=self.element_name,
+            filter_specs=self.filter_specs,
+            alias=self.alias,
+            default_granularity=self.default_granularity,
+        )
 
 
 @dataclass(frozen=True)

--- a/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
+++ b/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
@@ -570,7 +570,6 @@ class MetricSpec(InstanceSpec):  # noqa: D101
     alias: Optional[str] = None
     offset_window: Optional[PydanticMetricTimeWindow] = None
     offset_to_grain: Optional[TimeGranularity] = None
-    default_granularity: Optional[TimeGranularity] = None
 
     @staticmethod
     def from_element_name(element_name: str) -> MetricSpec:  # noqa: D102
@@ -603,7 +602,6 @@ class MetricSpec(InstanceSpec):  # noqa: D101
             element_name=self.element_name,
             filter_specs=self.filter_specs,
             alias=self.alias,
-            default_granularity=self.default_granularity,
         )
 
 


### PR DESCRIPTION
A few changes preparing to use the `default_granularity` field to resolve `metric_time` granularity.
- [Use `SetDefaultGranularityRule` in CLI rule set](https://github.com/dbt-labs/metricflow/commit/66dd77c0ff6e4aaeeaf1f6a718ac81de51710faf)
- [Add `default_granularity` to `MetricSpec`](https://github.com/dbt-labs/metricflow/commit/6e68ad6214616092c5cd1deef95dbbedb9694dec)
- [Add `MetricLookup` method to `get_default_granularity_for_metrics`](https://github.com/dbt-labs/metricflow/commit/fd57e01957e664c594625d8d15796fc3f6c1f8cf)