### PR TITLE
Resolve candidate filters for suggestions dynamically

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
+++ b/metricflow-semantics/metricflow_semantics/model/dbt_manifest_parser.py
@@ -11,6 +11,7 @@ from dbt_semantic_interfaces.transformations.convert_median import (
     ConvertMedianToPercentileRule,
 )
 from dbt_semantic_interfaces.transformations.cumulative_type_params import SetCumulativeTypeParamsRule
+from dbt_semantic_interfaces.transformations.default_granularity import SetDefaultGranularityRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
@@ -38,6 +39,7 @@ def parse_manifest_from_dbt_generated_manifest(manifest_json_string: str) -> Pyd
             ConvertMedianToPercentileRule(),
             DedupeMetricInputMeasuresRule(),  # Remove once fix is in core
             SetCumulativeTypeParamsRule(),
+            SetDefaultGranularityRule(),
         ),
     )
     model = PydanticSemanticManifestTransformer.transform(raw_model, rules)

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -386,7 +386,7 @@ class LinkableElementSet(SemanticModelDerivation):
         """
         start_time = time.time()
 
-        # Spec patterns need all specs to match properly e.g. `BaseTimeGrainPattern`.
+        # Spec patterns need all specs to match properly e.g. `MinimumTimeGrainPattern`.
         matching_specs: Sequence[InstanceSpec] = self.specs
 
         for spec_pattern in spec_patterns:

--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -210,3 +210,18 @@ class MetricLookup:
                     minimum_queryable_granularity = defined_time_granularity
 
         return minimum_queryable_granularity
+
+    def get_default_granularity_for_metrics(
+        self, metric_references: Sequence[MetricReference]
+    ) -> Optional[TimeGranularity]:
+        """When querying a group of metrics, the default granularity will be the largest of the metrics' default granularities."""
+        max_default_granularity: Optional[TimeGranularity] = None
+        for metric_reference in metric_references:
+            default_granularity = self.get_metric(metric_reference).default_granularity
+            assert (
+                default_granularity
+            ), f"No default_granularity set for {metric_reference}. Something has been misconfigured."
+            if not max_default_granularity or default_granularity.to_int() > max_default_granularity.to_int():
+                max_default_granularity = default_granularity
+
+        return max_default_granularity

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
@@ -347,6 +347,7 @@ class _ResolveWhereFilterSpecVisitor(GroupByItemResolutionNodeVisitor[FilterSpec
                 input_str=group_by_item_in_where_filter.object_builder_str,
                 spec_pattern=group_by_item_in_where_filter.spec_pattern,
                 resolution_node=current_node,
+                filter_location=filter_location,
             )
             # The paths in the issue set are generated relative to the current node. For error messaging, it seems more
             # helpful for those paths to be relative to the query. To do, we have to add nodes from the resolution path.

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
@@ -27,7 +27,7 @@ from metricflow_semantics.query.issues.issues_base import (
     MetricFlowQueryResolutionIssueSet,
 )
 from metricflow_semantics.query.suggestion_generator import QueryItemSuggestionGenerator
-from metricflow_semantics.specs.patterns.base_time_grain import BaseTimeGrainPattern
+from metricflow_semantics.specs.patterns.minimum_time_grain import MinimumTimeGrainPattern
 from metricflow_semantics.specs.patterns.no_group_by_metric import NoGroupByMetricPattern
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 from metricflow_semantics.specs.patterns.typed_patterns import TimeDimensionPattern
@@ -102,7 +102,7 @@ class GroupByItemResolver:
             )
 
         push_down_result = push_down_result.filter_candidates_by_pattern(
-            BaseTimeGrainPattern(),
+            MinimumTimeGrainPattern(),
         )
         logger.info(
             f"Spec pattern:\n"
@@ -152,7 +152,7 @@ class GroupByItemResolver:
 
         push_down_visitor = _PushDownGroupByItemCandidatesVisitor(
             manifest_lookup=self._manifest_lookup,
-            source_spec_patterns=(spec_pattern, BaseTimeGrainPattern()),
+            source_spec_patterns=(spec_pattern, MinimumTimeGrainPattern()),
             suggestion_generator=suggestion_generator,
         )
 

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
@@ -20,13 +20,14 @@ from metricflow_semantics.query.group_by_item.candidate_push_down.push_down_visi
     PushDownResult,
     _PushDownGroupByItemCandidatesVisitor,
 )
+from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag, ResolutionDagSinkNode
 from metricflow_semantics.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
 from metricflow_semantics.query.issues.group_by_item_resolver.ambiguous_group_by_item import AmbiguousGroupByItemIssue
 from metricflow_semantics.query.issues.issues_base import (
     MetricFlowQueryResolutionIssueSet,
 )
-from metricflow_semantics.query.suggestion_generator import QueryItemSuggestionGenerator
+from metricflow_semantics.query.suggestion_generator import QueryItemSuggestionGenerator, QueryPartForSuggestions
 from metricflow_semantics.specs.patterns.minimum_time_grain import MinimumTimeGrainPattern
 from metricflow_semantics.specs.patterns.no_group_by_metric import NoGroupByMetricPattern
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -135,6 +136,7 @@ class GroupByItemResolver:
         input_str: str,
         spec_pattern: SpecPattern,
         resolution_node: ResolutionDagSinkNode,
+        filter_location: WhereFilterLocation,
     ) -> GroupByItemResolution:
         """Returns the spec that matches the spec_pattern associated with the filter in the given node.
 
@@ -147,7 +149,9 @@ class GroupByItemResolver:
         suggestion_generator = QueryItemSuggestionGenerator(
             input_naming_scheme=ObjectBuilderNamingScheme(),
             input_str=input_str,
-            candidate_filters=QueryItemSuggestionGenerator.FILTER_ITEM_CANDIDATE_FILTERS,
+            query_part=QueryPartForSuggestions.WHERE_FILTER,
+            metric_lookup=self._manifest_lookup.metric_lookup,
+            queried_metrics=filter_location.metric_references,
         )
 
         push_down_visitor = _PushDownGroupByItemCandidatesVisitor(

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -52,8 +52,8 @@ from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
     ResolverInputForQuery,
     ResolverInputForQueryLevelWhereFilterIntersection,
 )
-from metricflow_semantics.specs.patterns.base_time_grain import BaseTimeGrainPattern
 from metricflow_semantics.specs.patterns.metric_time_pattern import MetricTimePattern
+from metricflow_semantics.specs.patterns.minimum_time_grain import MinimumTimeGrainPattern
 from metricflow_semantics.specs.patterns.none_date_part import NoneDatePartPattern
 from metricflow_semantics.specs.query_param_implementations import DimensionOrEntityParameter, MetricParameter
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
@@ -153,7 +153,7 @@ class MetricFlowQueryParser:
 
         for pattern_to_apply in (
             MetricTimePattern(),
-            BaseTimeGrainPattern(),
+            MinimumTimeGrainPattern(),
             NoneDatePartPattern(),
         ):
             matching_specs = pattern_to_apply.match(matching_specs)
@@ -164,7 +164,7 @@ class MetricFlowQueryParser:
 
         assert (
             len(time_dimension_specs) == 1
-        ), f"Bug with BaseTimeGrainPattern - should have returned exactly 1 spec but got {time_dimension_specs}"
+        ), f"Bug with MinimumTimeGrainPattern - should have returned exactly 1 spec but got {time_dimension_specs}"
 
         return time_dimension_specs[0].time_granularity
 

--- a/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
+++ b/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
@@ -5,7 +5,7 @@ from typing import Sequence, Tuple
 
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.query.similarity import top_fuzzy_matches
-from metricflow_semantics.specs.patterns.base_time_grain import BaseTimeGrainPattern
+from metricflow_semantics.specs.patterns.minimum_time_grain import MinimumTimeGrainPattern
 from metricflow_semantics.specs.patterns.no_group_by_metric import NoGroupByMetricPattern
 from metricflow_semantics.specs.patterns.none_date_part import NoneDatePartPattern
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
@@ -24,9 +24,9 @@ class QueryItemSuggestionGenerator:
 
     # Adding these filters so that we don't get multiple suggestions that are similar, but with different
     # grains. Some additional thought is needed to tweak this as the base grain may not be the best suggestion.
-    FILTER_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (BaseTimeGrainPattern(), NoneDatePartPattern())
+    FILTER_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (MinimumTimeGrainPattern(), NoneDatePartPattern())
     GROUP_BY_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (
-        BaseTimeGrainPattern(),
+        MinimumTimeGrainPattern(),
         NoneDatePartPattern(),
         NoGroupByMetricPattern(),
     )

--- a/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
+++ b/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
@@ -1,17 +1,32 @@
 from __future__ import annotations
 
 import logging
-from typing import Sequence, Tuple
+from enum import Enum
+from typing import Optional, Sequence, Tuple
 
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.references import MetricReference
+
+from metricflow_semantics.model.semantics.metric_lookup import MetricLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.query.similarity import top_fuzzy_matches
-from metricflow_semantics.specs.patterns.minimum_time_grain import MinimumTimeGrainPattern
+from metricflow_semantics.specs.patterns.match_list_pattern import MatchListSpecPattern
+from metricflow_semantics.specs.patterns.metric_time_default_granularity import MetricTimeDefaultGranularityPattern
+from metricflow_semantics.specs.patterns.min_time_grain import MinimumTimeGrainPattern
 from metricflow_semantics.specs.patterns.no_group_by_metric import NoGroupByMetricPattern
 from metricflow_semantics.specs.patterns.none_date_part import NoneDatePartPattern
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
-from metricflow_semantics.specs.spec_classes import InstanceSpec
+from metricflow_semantics.specs.spec_classes import InstanceSpec, LinkableInstanceSpec
 
 logger = logging.getLogger(__name__)
+
+
+class QueryPartForSuggestions(Enum):
+    """Indicates which type of query parameter is being suggested."""
+
+    WHERE_FILTER = "where_filter"
+    GROUP_BY = "group_by"
+    METRIC = "metric"
 
 
 class QueryItemSuggestionGenerator:
@@ -22,29 +37,67 @@ class QueryItemSuggestionGenerator:
     a candidate filter is not needed as any available spec at a resolution node can be used.
     """
 
-    # Adding these filters so that we don't get multiple suggestions that are similar, but with different
-    # grains. Some additional thought is needed to tweak this as the base grain may not be the best suggestion.
-    FILTER_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (MinimumTimeGrainPattern(), NoneDatePartPattern())
-    GROUP_BY_ITEM_CANDIDATE_FILTERS: Tuple[SpecPattern, ...] = (
-        MinimumTimeGrainPattern(),
-        NoneDatePartPattern(),
-        NoGroupByMetricPattern(),
-    )
-
     def __init__(  # noqa: D107
-        self, input_naming_scheme: QueryItemNamingScheme, input_str: str, candidate_filters: Sequence[SpecPattern]
+        self,
+        input_naming_scheme: QueryItemNamingScheme,
+        input_str: str,
+        query_part: QueryPartForSuggestions,
+        metric_lookup: MetricLookup,
+        queried_metrics: Sequence[MetricReference],
+        valid_group_by_item_specs_for_querying: Optional[Sequence[LinkableInstanceSpec]] = None,
     ) -> None:
         self._input_naming_scheme = input_naming_scheme
         self._input_str = input_str
-        self._candidate_filters = candidate_filters
+        self._query_part = query_part
+        self._metric_lookup = metric_lookup
+        self._queried_metrics = queried_metrics
+        self._valid_group_by_item_specs_for_querying = valid_group_by_item_specs_for_querying
+
+        if self._query_part is QueryPartForSuggestions.GROUP_BY and valid_group_by_item_specs_for_querying is None:
+            raise ValueError(
+                "QueryItemSuggestionGenerator requires valid_group_by_item_specs_for_querying param when used on group by items."
+            )
+
+    @property
+    def candidate_filters(self) -> Tuple[SpecPattern, ...]:
+        """Filters to apply before determining suggestions.
+
+        These ensure we don't get multiple suggestions that are similar, but with different grains or date_parts.
+        """
+        default_filters = (
+            NoneDatePartPattern(),
+            # MetricTimeDefaultGranularityPattern must come before MinimumTimeGrainPattern to ensure we don't remove the
+            # default grain from candiate set prematurely.
+            MetricTimeDefaultGranularityPattern(
+                metric_lookup=self._metric_lookup, queried_metrics=self._queried_metrics
+            ),
+            MinimumTimeGrainPattern(),
+        )
+        if self._query_part is QueryPartForSuggestions.WHERE_FILTER:
+            return default_filters
+        elif self._query_part is QueryPartForSuggestions.GROUP_BY:
+            assert self._valid_group_by_item_specs_for_querying, (
+                "Group by suggestions require valid_group_by_item_specs_for_querying param."
+                "This should have been validated on init."
+            )
+            return default_filters + (
+                NoGroupByMetricPattern(),
+                MatchListSpecPattern(
+                    listed_specs=self._valid_group_by_item_specs_for_querying,
+                ),
+            )
+        elif self._query_part is QueryPartForSuggestions.METRIC:
+            return ()
+        else:
+            assert_values_exhausted(self._query_part)
 
     def input_suggestions(
         self,
         candidate_specs: Sequence[InstanceSpec],
         max_suggestions: int = 6,
     ) -> Sequence[str]:
-        """Return the best specs that match the given pattern from candidate_specs and match the candidate_filer."""
-        for candidate_filter in self._candidate_filters:
+        """Return the best specs that match the given pattern from candidate_specs and match the candidate_filter."""
+        for candidate_filter in self.candidate_filters:
             candidate_specs = candidate_filter.match(candidate_specs)
 
         # Use edit distance to figure out the closest matches, so convert the specs to strings.

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Sequence, Set
+
+from dbt_semantic_interfaces.references import MetricReference
+from dbt_semantic_interfaces.type_enums import TimeGranularity
+from typing_extensions import override
+
+from metricflow_semantics.model.semantics.metric_lookup import MetricLookup
+from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
+from metricflow_semantics.specs.spec_classes import (
+    InstanceSpec,
+    LinkableInstanceSpec,
+    TimeDimensionSpec,
+    TimeDimensionSpecComparisonKey,
+    TimeDimensionSpecField,
+)
+from metricflow_semantics.specs.spec_set import group_specs_by_type
+
+
+class MetricTimeDefaultGranularityPattern(SpecPattern):
+    """A pattern that matches metric_time specs if they have the default granularity for the requested metrics.
+
+    This is used to determine the granularity that should be used for metric_time if no granularity is specified.
+    Spec passes through if granularity is already selected or if no metrics were queried, since no default is needed.
+    All non-metric_time specs are passed through.
+
+    e.g., if a metric with default_granularity MONTH is queried
+
+    inputs:
+        [
+            TimeDimensionSpec('metric_time', 'day'),
+            TimeDimensionSpec('metric_time', 'week'),
+            TimeDimensionSpec('metric_time', 'month'),
+            DimensionSpec('listing__country'),
+        ]
+
+    matches:
+        [
+            TimeDimensionSpec('metric_time', 'month'),
+            DimensionSpec('listing__country'),
+        ]
+    """
+
+    def __init__(self, metric_lookup: MetricLookup, queried_metrics: Sequence[MetricReference] = ()) -> None:
+        """Match only time dimensions with the default granularity for a given query.
+
+        Only affects time dimensions. All other items pass through.
+        """
+        self._metric_lookup = metric_lookup
+        self._queried_metrics = queried_metrics
+
+    @override
+    def match(self, candidate_specs: Sequence[InstanceSpec]) -> Sequence[InstanceSpec]:
+        default_granularity_for_metrics = self._metric_lookup.get_default_granularity_for_metrics(self._queried_metrics)
+        spec_set = group_specs_by_type(candidate_specs)
+
+        # If there are no metrics or metric_time specs in the query, skip this filter.
+        if not (default_granularity_for_metrics and spec_set.metric_time_specs):
+            return candidate_specs
+
+        spec_key_to_grains: Dict[TimeDimensionSpecComparisonKey, Set[TimeGranularity]] = defaultdict(set)
+        spec_key_to_specs: Dict[TimeDimensionSpecComparisonKey, List[TimeDimensionSpec]] = defaultdict(list)
+        for metric_time_spec in spec_set.metric_time_specs:
+            spec_key = metric_time_spec.comparison_key(exclude_fields=(TimeDimensionSpecField.TIME_GRANULARITY,))
+            spec_key_to_grains[spec_key].add(metric_time_spec.time_granularity)
+            spec_key_to_specs[spec_key].append(metric_time_spec)
+
+        matched_metric_time_specs: List[TimeDimensionSpec] = []
+        for spec_key, time_grains in spec_key_to_grains.items():
+            if default_granularity_for_metrics in time_grains:
+                matched_metric_time_specs.append(
+                    spec_key_to_specs[spec_key][0].with_grain(default_granularity_for_metrics)
+                )
+            else:
+                # If default_granularity is not in the available options, then time granularity was specified in the request
+                # and a default is not needed here. Pass all options through for this spec key.
+                matched_metric_time_specs.extend(spec_key_to_specs[spec_key])
+
+        matching_specs: Sequence[LinkableInstanceSpec] = (
+            spec_set.dimension_specs
+            + tuple(matched_metric_time_specs)
+            + tuple(spec for spec in spec_set.time_dimension_specs if not spec.is_metric_time)
+            + spec_set.entity_specs
+            + spec_set.group_by_metric_specs
+        )
+
+        return matching_specs

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/min_time_grain.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/min_time_grain.py
@@ -40,6 +40,9 @@ class MinimumTimeGrainPattern(SpecPattern):
 
     This pattern helps to implement matching of group-by-items for where filters - in those cases, an ambiguously
     specified group-by-item can only match to time dimension spec with the base grain.
+
+    Also, this is currently used to help implement restrictions on cumulative metrics where they can only be queried
+    by the base grain of metric_time.
     """
 
     @override

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/minimum_time_grain.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/minimum_time_grain.py
@@ -18,7 +18,7 @@ from metricflow_semantics.specs.spec_classes import (
 from metricflow_semantics.specs.spec_set import group_specs_by_type
 
 
-class BaseTimeGrainPattern(SpecPattern):
+class MinimumTimeGrainPattern(SpecPattern):
     """A pattern that matches linkable specs, but for time dimension specs, only the one with the finest grain.
 
     e.g.
@@ -63,7 +63,9 @@ class BaseTimeGrainPattern(SpecPattern):
             metric_time_specs = MetricTimePattern().match(candidate_specs)
             other_specs = tuple(spec for spec in candidate_specs if spec not in metric_time_specs)
 
-            return other_specs + tuple(BaseTimeGrainPattern(only_apply_for_metric_time=False).match(metric_time_specs))
+            return other_specs + tuple(
+                MinimumTimeGrainPattern(only_apply_for_metric_time=False).match(metric_time_specs)
+            )
 
         spec_set = group_specs_by_type(candidate_specs)
 

--- a/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
+++ b/metricflow-semantics/metricflow_semantics/specs/spec_classes.py
@@ -570,6 +570,7 @@ class MetricSpec(InstanceSpec):  # noqa: D101
     alias: Optional[str] = None
     offset_window: Optional[PydanticMetricTimeWindow] = None
     offset_to_grain: Optional[TimeGranularity] = None
+    default_granularity: Optional[TimeGranularity] = None
 
     @staticmethod
     def from_element_name(element_name: str) -> MetricSpec:  # noqa: D102
@@ -598,7 +599,12 @@ class MetricSpec(InstanceSpec):  # noqa: D101
 
     def without_offset(self) -> MetricSpec:
         """Represents the metric spec with any time offsets removed."""
-        return MetricSpec(element_name=self.element_name, filter_specs=self.filter_specs, alias=self.alias)
+        return MetricSpec(
+            element_name=self.element_name,
+            filter_specs=self.filter_specs,
+            alias=self.alias,
+            default_granularity=self.default_granularity,
+        )
 
 
 @dataclass(frozen=True)

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
@@ -9,6 +9,7 @@ from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.naming.object_builder_scheme import ObjectBuilderNamingScheme
+from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow_semantics.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
@@ -42,6 +43,7 @@ def test_ambiguous_metric_time_in_query_filter(  # noqa: D103
         input_str=input_str,
         spec_pattern=spec_pattern,
         resolution_node=resolution_dag.sink_node,
+        filter_location=WhereFilterLocation(metric_references=()),
     )
 
     assert_object_snapshot_equal(


### PR DESCRIPTION
The new `SpecPattern` `MetricTimeDefaultGranularity` requires some inputs that must be resolved at query time, so we can no longer use constants to store the set of candidate filters we use. Here is the logic to resolve them dynamically.