### PR TITLE
Streamline `LinkableElementProperty.all_properties()`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/linkable_element_property.py
+++ b/metricflow-semantics/metricflow_semantics/model/linkable_element_property.py
@@ -30,14 +30,4 @@ class LinkableElementProperty(Enum):
 
     @staticmethod
     def all_properties() -> FrozenSet[LinkableElementProperty]:  # noqa: D102
-        return frozenset(
-            {
-                LinkableElementProperty.LOCAL,
-                LinkableElementProperty.LOCAL_LINKED,
-                LinkableElementProperty.JOINED,
-                LinkableElementProperty.MULTI_HOP,
-                LinkableElementProperty.DERIVED_TIME_GRANULARITY,
-                LinkableElementProperty.METRIC_TIME,
-                LinkableElementProperty.METRIC,
-            }
-        )
+        return frozenset({linkable_element_property for linkable_element_property in LinkableElementProperty})


### PR DESCRIPTION
This PR updates `LinkableElementProperty.all_properties()` to iterate over the enum to make it less error prone when new properties are added.