### PR TITLE
Decouple `InstanceSpecSet` and `LinkableSpecSet`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
@@ -124,15 +124,6 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
     def is_subset_of(self, other_set: LinkableSpecSet) -> bool:  # noqa: D102
         return set(self.as_tuple).issubset(set(other_set.as_tuple))
 
-    @property
-    def as_spec_set(self) -> InstanceSpecSet:  # noqa: D102
-        return InstanceSpecSet(
-            dimension_specs=self.dimension_specs,
-            time_dimension_specs=self.time_dimension_specs,
-            entity_specs=self.entity_specs,
-            group_by_metric_specs=self.group_by_metric_specs,
-        )
-
     def difference(self, other: LinkableSpecSet) -> LinkableSpecSet:  # noqa: D102
         return LinkableSpecSet(
             dimension_specs=tuple(set(self.dimension_specs) - set(other.dimension_specs)),

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_available_group_by_items.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_available_group_by_items.py
@@ -9,7 +9,6 @@ from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifest
 from metricflow_semantics.query.group_by_item.group_by_item_resolver import GroupByItemResolver
 from metricflow_semantics.query.group_by_item.resolution_dag.dag import GroupByItemResolutionDag
 from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
-from metricflow_semantics.specs.spec_set import group_specs_by_type
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_linkable_spec_set_snapshot_equal
 
@@ -37,5 +36,5 @@ def test_available_group_by_items(  # noqa: D103
         request=request,
         mf_test_configuration=mf_test_configuration,
         set_id="set0",
-        spec_set=LinkableSpecSet.create_from_spec_set(group_specs_by_type(result.specs)),
+        spec_set=LinkableSpecSet.create_from_specs(result.specs),
     )

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -338,7 +338,7 @@ class DataflowPlanBuilder:
         filtered_unaggregated_base_node = FilterElementsNode.create(
             parent_node=unaggregated_base_measure_node,
             include_specs=group_specs_by_type(required_local_specs)
-            .merge(base_required_linkable_specs.as_spec_set)
+            .merge(InstanceSpecSet.create_from_specs(base_required_linkable_specs.as_tuple))
             .dedupe(),
         )
 
@@ -645,7 +645,7 @@ class DataflowPlanBuilder:
                 output_node = FilterElementsNode.create(
                     parent_node=output_node,
                     include_specs=InstanceSpecSet(metric_specs=(metric_spec,)).merge(
-                        queried_linkable_specs.as_spec_set
+                        InstanceSpecSet.create_from_specs(queried_linkable_specs.as_tuple)
                     ),
                 )
         return output_node
@@ -792,7 +792,9 @@ class DataflowPlanBuilder:
             )
 
         output_node = FilterElementsNode.create(
-            parent_node=output_node, include_specs=query_spec.linkable_specs.as_spec_set, distinct=True
+            parent_node=output_node,
+            include_specs=InstanceSpecSet.create_from_specs(query_spec.linkable_specs.as_tuple),
+            distinct=True,
         )
 
         if query_spec.min_max_only:
@@ -1506,7 +1508,7 @@ class DataflowPlanBuilder:
             )
 
             specs_to_keep_after_join = InstanceSpecSet(measure_specs=(measure_spec,)).merge(
-                required_linkable_specs.as_spec_set,
+                InstanceSpecSet.create_from_specs(required_linkable_specs.as_tuple),
             )
 
             after_join_filtered_node = FilterElementsNode.create(
@@ -1569,7 +1571,9 @@ class DataflowPlanBuilder:
             # e.g. for "bookings" by "ds" where "is_instant", "is_instant" should not be in the results.
             pre_aggregate_node = FilterElementsNode.create(
                 parent_node=pre_aggregate_node,
-                include_specs=InstanceSpecSet(measure_specs=(measure_spec,)).merge(queried_linkable_specs.as_spec_set),
+                include_specs=InstanceSpecSet(measure_specs=(measure_spec,)).merge(
+                    InstanceSpecSet.create_from_specs(queried_linkable_specs.as_tuple)
+                ),
             )
 
         aggregate_measures_node = AggregateMeasuresNode.create(

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
@@ -14,15 +14,15 @@
                     <!-- node_id = NodeId(id_str='am_0') -->
                     <FilterElementsNode>
                         <!-- description =                                                                       -->
-                        <!--   "Pass Only Elements: ['bookings', 'metric_time__day', 'listing__country_latest']" -->
+                        <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- include_spec =                                               -->
                         <!--   DimensionSpec(                                             -->
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
+                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -81,15 +81,15 @@
                     <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description =                                                                            -->
-                        <!--   "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing__country_latest']" -->
+                        <!--   "Pass Only Elements: ['booking_value', 'listing__country_latest', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_5') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- include_spec =                                               -->
                         <!--   DimensionSpec(                                             -->
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
+                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
@@ -14,15 +14,15 @@
                     <!-- node_id = NodeId(id_str='am_0') -->
                     <FilterElementsNode>
                         <!-- description =                                                                       -->
-                        <!--   "Pass Only Elements: ['bookings', 'metric_time__day', 'listing__country_latest']" -->
+                        <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- include_spec =                                               -->
                         <!--   DimensionSpec(                                             -->
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
+                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -81,15 +81,15 @@
                     <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description =                                                                            -->
-                        <!--   "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing__country_latest']" -->
+                        <!--   "Pass Only Elements: ['booking_value', 'listing__country_latest', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_5') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- include_spec =                                               -->
                         <!--   DimensionSpec(                                             -->
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
+                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -11,18 +11,18 @@
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_4') -->
                 <FilterElementsNode>
-                    <!-- description =                                                               -->
-                    <!--   ("Pass Only Elements: ['bookings', 'booking_value', 'metric_time__day', " -->
-                    <!--    "'listing__country_latest']")                                            -->
+                    <!-- description =                                                                      -->
+                    <!--   ("Pass Only Elements: ['bookings', 'booking_value', 'listing__country_latest', " -->
+                    <!--    "'metric_time__day']")                                                          -->
                     <!-- node_id = NodeId(id_str='pfe_14') -->
                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
                     <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                     <!-- include_spec =                                               -->
                     <!--   DimensionSpec(                                             -->
                     <!--     element_name='country_latest',                           -->
                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                     <!--   )                                                          -->
+                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
                     <!-- distinct = False -->
                     <JoinOnEntitiesNode>
                         <!-- description = 'Join Standard Outputs' -->


### PR DESCRIPTION
`LinkableSpecSet` depends on `InstanceSpecSet`, which leads to circular dependencies in downstream changes. This PR updates a few methods in `LinkableSpecSet` to remove that dependency. 