### PR TITLE
Remove `LinkableElementSet.__len__()`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
@@ -135,9 +135,6 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
             group_by_metric_specs=tuple(set(self.group_by_metric_specs) - set(other.group_by_metric_specs)),
         )
 
-    def __len__(self) -> int:  # noqa: D105
-        return len(self.dimension_specs) + len(self.time_dimension_specs) + len(self.entity_specs)
-
     @staticmethod
     def create_from_specs(specs: Sequence[LinkableInstanceSpec]) -> LinkableSpecSet:  # noqa: D102
         return _group_specs_by_type(specs)


### PR DESCRIPTION
`LinkableElementSet.__len__()` currently has a bug as `group_by_metric_specs` is not included. Since the current code base does not depend on that method, this PR removes it.