### PR TITLE
Set `max_metric_default_time_granularity` property on `PushDownResult`

### DIFF
--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.6.5
+dbt-semantic-interfaces==0.6.6
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 # dbt Cloud depends on metricflow-semantics (dependency set in dbt-mantle), so DSI must always point to a production version here.
-dbt-semantic-interfaces>=0.6.5, <2.0.0
+dbt-semantic-interfaces>=0.6.6, <2.0.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0


### PR DESCRIPTION
Per title. Set this property when visiting the metric node and narrow down to the max when visiting a query node.