### PR TITLE
Use `LinkableSpecSet` in `WhereFilterSpec`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -87,7 +87,7 @@ class ElementPathKey:
 
 
 @dataclass(frozen=True)
-class SemanticModelJoinPathElement:
+class SemanticModelJoinPathElement(SerializableDataclass):
     """Describes joining a semantic model by the given entity."""
 
     semantic_model_reference: SemanticModelReference
@@ -308,7 +308,7 @@ class LinkableMetric(LinkableElement, SerializableDataclass):
 
 
 @dataclass(frozen=True)
-class SemanticModelJoinPath(SemanticModelDerivation):
+class SemanticModelJoinPath(SemanticModelDerivation, SerializableDataclass):
     """Describes a series of joins between the measure semantic model, and other semantic models by entity.
 
     For example:
@@ -368,14 +368,14 @@ class SemanticModelJoinPath(SemanticModelDerivation):
 
 
 @dataclass(frozen=True)
-class MetricSubqueryJoinPathElement:
+class MetricSubqueryJoinPathElement(SerializableDataclass):
     """Describes joining from a semantic model to a metric subquery.
 
     Args:
         metric_reference: The metric that's aggregated in the subquery.
         derived_from_semantic_models: The semantic models that the measure's input metrics are defined in.
         join_on_entity: The entity that the metric is grouped by in the subquery. This will be updated in V2 to allow a list
-            of entitites & dimensions.
+            of entities & dimensions.
         entity_links: Sequence of entities joined to get from a metric source to the `join_on_entity`. Should not include
             the `join_on_entity`.
         metric_to_entity_join_path: Describes the join path used in the subquery to join the metric to the `join_on_entity`.
@@ -395,7 +395,7 @@ class MetricSubqueryJoinPathElement:
 
 
 @dataclass(frozen=True)
-class SemanticModelToMetricSubqueryJoinPath:
+class SemanticModelToMetricSubqueryJoinPath(SerializableDataclass):
     """Describes how to join from a semantic model to a metric subquery.
 
     Starts with semantic model join path, if needed. Always ends with metric subquery join path.

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
@@ -13,6 +13,7 @@ from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec
     FilterSpecResolutionLookUp,
 )
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
+from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
 from metricflow_semantics.specs.rendered_spec_tracker import RenderedSpecTracker
 from metricflow_semantics.specs.where_filter.where_filter_dimension import WhereFilterDimensionFactory
 from metricflow_semantics.specs.where_filter.where_filter_entity import WhereFilterEntityFactory
@@ -108,7 +109,7 @@ class WhereSpecFactory:
                 WhereFilterSpec(
                     where_sql=where_sql,
                     bind_parameters=SqlBindParameters(),
-                    linkable_specs=rendered_specs,
+                    linkable_spec_set=LinkableSpecSet.create_from_specs(rendered_specs),
                     linkable_elements=linkable_elements,
                 )
             )

--- a/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
@@ -7,6 +7,7 @@ from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilter
 from metricflow_semantics.filters.time_constraint import TimeRangeConstraint
 from metricflow_semantics.query.query_parser import MetricFlowQueryParser
+from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
 from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
@@ -76,7 +77,10 @@ def test_branch_state_propagation(branch_state_tracker: PredicatePushdownBranchS
         original_pushdown_state=base_state,
         where_filter_specs=(
             WhereFilterSpec(
-                where_sql="x is true", bind_parameters=SqlBindParameters(), linkable_elements=(), linkable_specs=()
+                where_sql="x is true",
+                bind_parameters=SqlBindParameters(),
+                linkable_elements=(),
+                linkable_spec_set=LinkableSpecSet(),
             ),
         ),
     )
@@ -110,10 +114,16 @@ def test_applied_filter_back_propagation(branch_state_tracker: PredicatePushdown
     """
     base_state = branch_state_tracker.last_pushdown_state
     where_spec_x_is_true = WhereFilterSpec(
-        where_sql="x is true", bind_parameters=SqlBindParameters(), linkable_elements=(), linkable_specs=()
+        where_sql="x is true",
+        bind_parameters=SqlBindParameters(),
+        linkable_elements=(),
+        linkable_spec_set=LinkableSpecSet(),
     )
     where_spec_y_is_null = WhereFilterSpec(
-        where_sql="y is null", bind_parameters=SqlBindParameters(), linkable_elements=(), linkable_specs=()
+        where_sql="y is null",
+        bind_parameters=SqlBindParameters(),
+        linkable_elements=(),
+        linkable_spec_set=LinkableSpecSet(),
     )
 
     where_state = PredicatePushdownState.with_where_filter_specs(

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -17,6 +17,7 @@ from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.dimension_spec import DimensionSpec
 from metricflow_semantics.specs.entity_spec import LinklessEntitySpec
+from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
 from metricflow_semantics.specs.measure_spec import MeasureSpec, MetricInputMeasureSpec
 from metricflow_semantics.specs.metric_spec import MetricSpec
 from metricflow_semantics.specs.non_additive_dimension_spec import NonAdditiveDimensionSpec
@@ -191,11 +192,13 @@ def test_filter_with_where_constraint_node(
             WhereFilterSpec(
                 where_sql="booking__ds__day = '2020-01-01'",
                 bind_parameters=SqlBindParameters(),
-                linkable_specs=(
-                    TimeDimensionSpec(
-                        element_name="ds",
-                        entity_links=(EntityReference(element_name="booking"),),
-                        time_granularity=TimeGranularity.DAY,
+                linkable_spec_set=LinkableSpecSet(
+                    time_dimension_specs=(
+                        TimeDimensionSpec(
+                            element_name="ds",
+                            entity_links=(EntityReference(element_name="booking"),),
+                            time_granularity=TimeGranularity.DAY,
+                        ),
                     ),
                 ),
                 linkable_elements=(

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -30,12 +30,6 @@
                     <!--   WhereFilterSpec(                                               -->
                     <!--     where_sql="listing__country_latest = 'us'",                  -->
                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                    <!--     linkable_specs=(                                             -->
-                    <!--       DimensionSpec(                                             -->
-                    <!--         element_name='country_latest',                           -->
-                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--       ),                                                         -->
-                    <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -50,6 +44,18 @@
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
                     <!--         properties=frozenset('LOCAL',),                          -->
+                    <!--       ),                                                         -->
+                    <!--     ),                                                           -->
+                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                    <!--       dimension_specs=(                                          -->
+                    <!--         DimensionSpec(                                           -->
+                    <!--           element_name='country_latest',                         -->
+                    <!--           entity_links=(                                         -->
+                    <!--             EntityReference(                                     -->
+                    <!--               element_name='listing',                            -->
+                    <!--             ),                                                   -->
+                    <!--           ),                                                     -->
+                    <!--         ),                                                       -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -35,12 +35,6 @@
                     <!--   WhereFilterSpec(                                               -->
                     <!--     where_sql="listing__country_latest = 'us'",                  -->
                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                    <!--     linkable_specs=(                                             -->
-                    <!--       DimensionSpec(                                             -->
-                    <!--         element_name='country_latest',                           -->
-                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--       ),                                                         -->
-                    <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -55,6 +49,18 @@
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
                     <!--         properties=frozenset('LOCAL',),                          -->
+                    <!--       ),                                                         -->
+                    <!--     ),                                                           -->
+                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                    <!--       dimension_specs=(                                          -->
+                    <!--         DimensionSpec(                                           -->
+                    <!--           element_name='country_latest',                         -->
+                    <!--           entity_links=(                                         -->
+                    <!--             EntityReference(                                     -->
+                    <!--               element_name='listing',                            -->
+                    <!--             ),                                                   -->
+                    <!--           ),                                                     -->
+                    <!--         ),                                                       -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_0') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='bookings_fill_nulls_with_0',                                 -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day = '2020-01-01'",                           -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='bookings_fill_nulls_with_0',                      -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day = '2020-01-01'",                -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <ConstrainTimeRangeNode>
                 <!-- description = 'Constrain Time Range to [2020-01-03T00:00:00, 2020-01-05T00:00:00]' -->
                 <!-- node_id = NodeId(id_str='ctr_1') -->
@@ -42,28 +47,35 @@
                 <WhereConstraintNode>
                     <!-- description = 'Constrain Output with WHERE' -->
                     <!-- node_id = NodeId(id_str='wcc_1') -->
-                    <!-- where_condition =                                                                          -->
-                    <!--   WhereFilterSpec(                                                                         -->
-                    <!--     where_sql="metric_time__day = '2020-01-01'",                                           -->
-                    <!--     bind_parameters=SqlBindParameters(),                                                   -->
-                    <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
-                    <!--     linkable_elements=(                                                                    -->
-                    <!--       LinkableDimension(                                                                   -->
-                    <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
-                    <!--           semantic_model_name='bookings_source',                                           -->
-                    <!--         ),                                                                                 -->
-                    <!--         element_name='metric_time',                                                        -->
-                    <!--         dimension_type=TIME,                                                               -->
-                    <!--         join_path=SemanticModelJoinPath(                                                   -->
-                    <!--           left_semantic_model_reference=SemanticModelReference(                            -->
-                    <!--             semantic_model_name='bookings_source',                                         -->
-                    <!--           ),                                                                               -->
-                    <!--         ),                                                                                 -->
-                    <!--         properties=frozenset('METRIC_TIME',),                                              -->
-                    <!--         time_granularity=DAY,                                                              -->
-                    <!--       ),                                                                                   -->
-                    <!--     ),                                                                                     -->
-                    <!--   )                                                                                        -->
+                    <!-- where_condition =                                               -->
+                    <!--   WhereFilterSpec(                                              -->
+                    <!--     where_sql="metric_time__day = '2020-01-01'",                -->
+                    <!--     bind_parameters=SqlBindParameters(),                        -->
+                    <!--     linkable_elements=(                                         -->
+                    <!--       LinkableDimension(                                        -->
+                    <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--           semantic_model_name='bookings_source',                -->
+                    <!--         ),                                                      -->
+                    <!--         element_name='metric_time',                             -->
+                    <!--         dimension_type=TIME,                                    -->
+                    <!--         join_path=SemanticModelJoinPath(                        -->
+                    <!--           left_semantic_model_reference=SemanticModelReference( -->
+                    <!--             semantic_model_name='bookings_source',              -->
+                    <!--           ),                                                    -->
+                    <!--         ),                                                      -->
+                    <!--         properties=frozenset('METRIC_TIME',),                   -->
+                    <!--         time_granularity=DAY,                                   -->
+                    <!--       ),                                                        -->
+                    <!--     ),                                                          -->
+                    <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--       time_dimension_specs=(                                    -->
+                    <!--         TimeDimensionSpec(                                      -->
+                    <!--           element_name='metric_time',                           -->
+                    <!--           time_granularity=DAY,                                 -->
+                    <!--         ),                                                      -->
+                    <!--       ),                                                        -->
+                    <!--     ),                                                          -->
+                    <!--   )                                                             -->
                     <!-- All filters always applied: = True -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
@@ -89,12 +101,6 @@
                                 <!--   WhereFilterSpec(                                              -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                -->
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
-                                <!--     linkable_specs=(                                            -->
-                                <!--       TimeDimensionSpec(                                        -->
-                                <!--         element_name='metric_time',                             -->
-                                <!--         time_granularity=DAY,                                   -->
-                                <!--       ),                                                        -->
-                                <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -109,6 +115,14 @@
                                 <!--         ),                                                      -->
                                 <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
+                                <!--       ),                                                        -->
+                                <!--     ),                                                          -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                <!--       time_dimension_specs=(                                    -->
+                                <!--         TimeDimensionSpec(                                      -->
+                                <!--           element_name='metric_time',                           -->
+                                <!--           time_granularity=DAY,                                 -->
+                                <!--         ),                                                      -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->
                                 <!--   )                                                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -12,50 +12,56 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='average_booking_value',                            -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='listing__is_lux_latest',                          -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_lux_latest',                            -->
-                    <!--             entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='listings_latest',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_lux_latest',                            -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='listing'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--               path_elements=(                                        -->
-                    <!--                 SemanticModelJoinPathElement(                        -->
-                    <!--                   semantic_model_reference=SemanticModelReference(   -->
-                    <!--                     semantic_model_name='listings_latest',           -->
-                    <!--                   ),                                                 -->
-                    <!--                   join_on_entity=EntityReference(                    -->
-                    <!--                     element_name='listing',                          -->
-                    <!--                   ),                                                 -->
-                    <!--                 ),                                                   -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('JOINED',),                         -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='average_booking_value',                           -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='listing__is_lux_latest',                         -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='listings_latest',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_lux_latest',                           -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='listing'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--               path_elements=(                                       -->
+                    <!--                 SemanticModelJoinPathElement(                       -->
+                    <!--                   semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='listings_latest',          -->
+                    <!--                   ),                                                -->
+                    <!--                   join_on_entity=EntityReference(                   -->
+                    <!--                     element_name='listing',                         -->
+                    <!--                   ),                                                -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('JOINED',),                        -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_lux_latest',                         -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='listing',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_0') -->
@@ -72,12 +78,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='listing__is_lux_latest',                          -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_lux_latest',                            -->
-                                <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -102,6 +102,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('JOINED',),                         -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_lux_latest',                          -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='listing',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->
@@ -177,50 +189,56 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings',                                         -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='listing__is_lux_latest',                          -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_lux_latest',                            -->
-                    <!--             entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='listings_latest',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_lux_latest',                            -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='listing'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--               path_elements=(                                        -->
-                    <!--                 SemanticModelJoinPathElement(                        -->
-                    <!--                   semantic_model_reference=SemanticModelReference(   -->
-                    <!--                     semantic_model_name='listings_latest',           -->
-                    <!--                   ),                                                 -->
-                    <!--                   join_on_entity=EntityReference(                    -->
-                    <!--                     element_name='listing',                          -->
-                    <!--                   ),                                                 -->
-                    <!--                 ),                                                   -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('JOINED',),                         -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings',                                        -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='listing__is_lux_latest',                         -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='listings_latest',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_lux_latest',                           -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='listing'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--               path_elements=(                                       -->
+                    <!--                 SemanticModelJoinPathElement(                       -->
+                    <!--                   semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='listings_latest',          -->
+                    <!--                   ),                                                -->
+                    <!--                   join_on_entity=EntityReference(                   -->
+                    <!--                     element_name='listing',                         -->
+                    <!--                   ),                                                -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('JOINED',),                        -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_lux_latest',                         -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='listing',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_1') -->
@@ -237,12 +255,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='listing__is_lux_latest',                          -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_lux_latest',                            -->
-                                <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -267,6 +279,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('JOINED',),                         -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_lux_latest',                          -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='listing',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -12,41 +12,47 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='booking_value',                                    -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--     alias='booking_value_with_is_instant_constraint',                -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='booking_value',                                   -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--     alias='booking_value_with_is_instant_constraint',               -->
+                    <!--   )                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_0') -->
@@ -63,12 +69,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -83,6 +83,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('LOCAL',),                          -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_instant',                             -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='booking',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
@@ -17,20 +17,28 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                                                -->
-                        <!--   WhereFilterSpec(                                               -->
-                        <!--     where_sql='listing__bookings > 2',                           -->
-                        <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       GroupByMetricSpec(                                         -->
-                        <!--         element_name='bookings',                                 -->
-                        <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                        <!--         metric_subquery_entity_links=(                           -->
-                        <!--           EntityReference(element_name='listing'),               -->
-                        <!--         ),                                                       -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--   )                                                              -->
+                        <!-- where_condition =                        -->
+                        <!--   WhereFilterSpec(                       -->
+                        <!--     where_sql='listing__bookings > 2',   -->
+                        <!--     bind_parameters=SqlBindParameters(), -->
+                        <!--     linkable_spec_set=LinkableSpecSet(   -->
+                        <!--       group_by_metric_specs=(            -->
+                        <!--         GroupByMetricSpec(               -->
+                        <!--           element_name='bookings',       -->
+                        <!--           entity_links=(                 -->
+                        <!--             EntityReference(             -->
+                        <!--               element_name='listing',    -->
+                        <!--             ),                           -->
+                        <!--           ),                             -->
+                        <!--           metric_subquery_entity_links=( -->
+                        <!--             EntityReference(             -->
+                        <!--               element_name='listing',    -->
+                        <!--             ),                           -->
+                        <!--           ),                             -->
+                        <!--         ),                               -->
+                        <!--       ),                                 -->
+                        <!--     ),                                   -->
+                        <!--   )                                      -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['listings', 'listing__bookings']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
@@ -5,27 +5,33 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_1') -->
-            <!-- metric_spec =                                                        -->
-            <!--   MetricSpec(                                                        -->
-            <!--     element_name='listings',                                         -->
-            <!--     filter_specs=(                                                   -->
-            <!--       WhereFilterSpec(                                               -->
-            <!--         where_sql='listing__bookings > 2',                           -->
-            <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           GroupByMetricSpec(                                         -->
-            <!--             element_name='bookings',                                 -->
-            <!--             entity_links=(EntityReference(element_name='listing'),), -->
-            <!--             metric_subquery_entity_links=(                           -->
-            <!--               EntityReference(                                       -->
-            <!--                 element_name='listing',                              -->
-            <!--               ),                                                     -->
-            <!--             ),                                                       -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
-            <!--       ),                                                             -->
-            <!--     ),                                                               -->
-            <!--   )                                                                  -->
+            <!-- metric_spec =                                -->
+            <!--   MetricSpec(                                -->
+            <!--     element_name='listings',                 -->
+            <!--     filter_specs=(                           -->
+            <!--       WhereFilterSpec(                       -->
+            <!--         where_sql='listing__bookings > 2',   -->
+            <!--         bind_parameters=SqlBindParameters(), -->
+            <!--         linkable_spec_set=LinkableSpecSet(   -->
+            <!--           group_by_metric_specs=(            -->
+            <!--             GroupByMetricSpec(               -->
+            <!--               element_name='bookings',       -->
+            <!--               entity_links=(                 -->
+            <!--                 EntityReference(             -->
+            <!--                   element_name='listing',    -->
+            <!--                 ),                           -->
+            <!--               ),                             -->
+            <!--               metric_subquery_entity_links=( -->
+            <!--                 EntityReference(             -->
+            <!--                   element_name='listing',    -->
+            <!--                 ),                           -->
+            <!--               ),                             -->
+            <!--             ),                               -->
+            <!--           ),                                 -->
+            <!--         ),                                   -->
+            <!--       ),                                     -->
+            <!--     ),                                       -->
+            <!--   )                                          -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_1') -->
@@ -37,20 +43,28 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                                                -->
-                        <!--   WhereFilterSpec(                                               -->
-                        <!--     where_sql='listing__bookings > 2',                           -->
-                        <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       GroupByMetricSpec(                                         -->
-                        <!--         element_name='bookings',                                 -->
-                        <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                        <!--         metric_subquery_entity_links=(                           -->
-                        <!--           EntityReference(element_name='listing'),               -->
-                        <!--         ),                                                       -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
-                        <!--   )                                                              -->
+                        <!-- where_condition =                        -->
+                        <!--   WhereFilterSpec(                       -->
+                        <!--     where_sql='listing__bookings > 2',   -->
+                        <!--     bind_parameters=SqlBindParameters(), -->
+                        <!--     linkable_spec_set=LinkableSpecSet(   -->
+                        <!--       group_by_metric_specs=(            -->
+                        <!--         GroupByMetricSpec(               -->
+                        <!--           element_name='bookings',       -->
+                        <!--           entity_links=(                 -->
+                        <!--             EntityReference(             -->
+                        <!--               element_name='listing',    -->
+                        <!--             ),                           -->
+                        <!--           ),                             -->
+                        <!--           metric_subquery_entity_links=( -->
+                        <!--             EntityReference(             -->
+                        <!--               element_name='listing',    -->
+                        <!--             ),                           -->
+                        <!--           ),                             -->
+                        <!--         ),                               -->
+                        <!--       ),                                 -->
+                        <!--     ),                                   -->
+                        <!--   )                                      -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['listings', 'listing__bookings']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_1') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='bookings_at_start_of_month',                                 -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day = '2020-01-01'",                           -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='bookings_at_start_of_month',                      -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day = '2020-01-01'",                -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
@@ -44,12 +49,6 @@
                 <!--       WhereFilterSpec(                                              -->
                 <!--         where_sql="metric_time__day = '2020-01-01'",                -->
                 <!--         bind_parameters=SqlBindParameters(),                        -->
-                <!--         linkable_specs=(                                            -->
-                <!--           TimeDimensionSpec(                                        -->
-                <!--             element_name='metric_time',                             -->
-                <!--             time_granularity=DAY,                                   -->
-                <!--           ),                                                        -->
-                <!--         ),                                                          -->
                 <!--         linkable_elements=(                                         -->
                 <!--           LinkableDimension(                                        -->
                 <!--             defined_in_semantic_model=SemanticModelReference(       -->
@@ -64,6 +63,14 @@
                 <!--             ),                                                      -->
                 <!--             properties=frozenset('METRIC_TIME',),                   -->
                 <!--             time_granularity=DAY,                                   -->
+                <!--           ),                                                        -->
+                <!--         ),                                                          -->
+                <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                <!--           time_dimension_specs=(                                    -->
+                <!--             TimeDimensionSpec(                                      -->
+                <!--               element_name='metric_time',                           -->
+                <!--               time_granularity=DAY,                                 -->
+                <!--             ),                                                      -->
                 <!--           ),                                                        -->
                 <!--         ),                                                          -->
                 <!--       ),                                                            -->
@@ -83,28 +90,35 @@
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
                             <!-- node_id = NodeId(id_str='wcc_0') -->
-                            <!-- where_condition =                                                                          -->
-                            <!--   WhereFilterSpec(                                                                         -->
-                            <!--     where_sql="metric_time__day = '2020-01-01'",                                           -->
-                            <!--     bind_parameters=SqlBindParameters(),                                                   -->
-                            <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
-                            <!--     linkable_elements=(                                                                    -->
-                            <!--       LinkableDimension(                                                                   -->
-                            <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
-                            <!--           semantic_model_name='bookings_source',                                           -->
-                            <!--         ),                                                                                 -->
-                            <!--         element_name='metric_time',                                                        -->
-                            <!--         dimension_type=TIME,                                                               -->
-                            <!--         join_path=SemanticModelJoinPath(                                                   -->
-                            <!--           left_semantic_model_reference=SemanticModelReference(                            -->
-                            <!--             semantic_model_name='bookings_source',                                         -->
-                            <!--           ),                                                                               -->
-                            <!--         ),                                                                                 -->
-                            <!--         properties=frozenset('METRIC_TIME',),                                              -->
-                            <!--         time_granularity=DAY,                                                              -->
-                            <!--       ),                                                                                   -->
-                            <!--     ),                                                                                     -->
-                            <!--   )                                                                                        -->
+                            <!-- where_condition =                                               -->
+                            <!--   WhereFilterSpec(                                              -->
+                            <!--     where_sql="metric_time__day = '2020-01-01'",                -->
+                            <!--     bind_parameters=SqlBindParameters(),                        -->
+                            <!--     linkable_elements=(                                         -->
+                            <!--       LinkableDimension(                                        -->
+                            <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                            <!--           semantic_model_name='bookings_source',                -->
+                            <!--         ),                                                      -->
+                            <!--         element_name='metric_time',                             -->
+                            <!--         dimension_type=TIME,                                    -->
+                            <!--         join_path=SemanticModelJoinPath(                        -->
+                            <!--           left_semantic_model_reference=SemanticModelReference( -->
+                            <!--             semantic_model_name='bookings_source',              -->
+                            <!--           ),                                                    -->
+                            <!--         ),                                                      -->
+                            <!--         properties=frozenset('METRIC_TIME',),                   -->
+                            <!--         time_granularity=DAY,                                   -->
+                            <!--       ),                                                        -->
+                            <!--     ),                                                          -->
+                            <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                            <!--       time_dimension_specs=(                                    -->
+                            <!--         TimeDimensionSpec(                                      -->
+                            <!--           element_name='metric_time',                           -->
+                            <!--           time_granularity=DAY,                                 -->
+                            <!--         ),                                                      -->
+                            <!--       ),                                                        -->
+                            <!--     ),                                                          -->
+                            <!--   )                                                             -->
                             <FilterElementsNode>
                                 <!-- description =                                                                  -->
                                 <!--   "Pass Only Elements: ['bookings', 'metric_time__month', 'metric_time__day']" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_2') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='booking_fees_last_week_per_booker_this_week',                -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day = '2020-01-01'",                           -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='booking_fees_last_week_per_booker_this_week',     -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day = '2020-01-01'",                -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <CombineAggregatedOutputsNode>
                 <!-- description = 'Combine Aggregated Outputs' -->
                 <!-- node_id = NodeId(id_str='cao_0') -->
@@ -47,12 +52,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql="metric_time__day = '2020-01-01'",                   -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           TimeDimensionSpec(                                           -->
-                    <!--             element_name='metric_time',                                -->
-                    <!--             time_granularity=DAY,                                      -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -67,6 +66,14 @@
                     <!--             ),                                                         -->
                     <!--             properties=frozenset('METRIC_TIME',),                      -->
                     <!--             time_granularity=DAY,                                      -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           time_dimension_specs=(                                       -->
+                    <!--             TimeDimensionSpec(                                         -->
+                    <!--               element_name='metric_time',                              -->
+                    <!--               time_granularity=DAY,                                    -->
+                    <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--       ),                                                               -->
@@ -89,12 +96,6 @@
                                 <!--   WhereFilterSpec(                                              -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                -->
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
-                                <!--     linkable_specs=(                                            -->
-                                <!--       TimeDimensionSpec(                                        -->
-                                <!--         element_name='metric_time',                             -->
-                                <!--         time_granularity=DAY,                                   -->
-                                <!--       ),                                                        -->
-                                <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -109,6 +110,14 @@
                                 <!--         ),                                                      -->
                                 <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
+                                <!--       ),                                                        -->
+                                <!--     ),                                                          -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                <!--       time_dimension_specs=(                                    -->
+                                <!--         TimeDimensionSpec(                                      -->
+                                <!--           element_name='metric_time',                           -->
+                                <!--           time_granularity=DAY,                                 -->
+                                <!--         ),                                                      -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->
                                 <!--   )                                                             -->
@@ -159,12 +168,6 @@
                     <!--       WhereFilterSpec(                                              -->
                     <!--         where_sql="metric_time__day = '2020-01-01'",                -->
                     <!--         bind_parameters=SqlBindParameters(),                        -->
-                    <!--         linkable_specs=(                                            -->
-                    <!--           TimeDimensionSpec(                                        -->
-                    <!--             element_name='metric_time',                             -->
-                    <!--             time_granularity=DAY,                                   -->
-                    <!--           ),                                                        -->
-                    <!--         ),                                                          -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
@@ -179,6 +182,14 @@
                     <!--             ),                                                      -->
                     <!--             properties=frozenset('METRIC_TIME',),                   -->
                     <!--             time_granularity=DAY,                                   -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           time_dimension_specs=(                                    -->
+                    <!--             TimeDimensionSpec(                                      -->
+                    <!--               element_name='metric_time',                           -->
+                    <!--               time_granularity=DAY,                                 -->
+                    <!--             ),                                                      -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--       ),                                                            -->
@@ -200,12 +211,6 @@
                                 <!--   WhereFilterSpec(                                              -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                -->
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
-                                <!--     linkable_specs=(                                            -->
-                                <!--       TimeDimensionSpec(                                        -->
-                                <!--         element_name='metric_time',                             -->
-                                <!--         time_granularity=DAY,                                   -->
-                                <!--       ),                                                        -->
-                                <!--     ),                                                          -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -220,6 +225,14 @@
                                 <!--         ),                                                      -->
                                 <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
+                                <!--       ),                                                        -->
+                                <!--     ),                                                          -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                <!--       time_dimension_specs=(                                    -->
+                                <!--         TimeDimensionSpec(                                      -->
+                                <!--           element_name='metric_time',                           -->
+                                <!--           time_granularity=DAY,                                 -->
+                                <!--         ),                                                      -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->
                                 <!--   )                                                             -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql="listing__country_latest = 'us'",                  -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='country_latest',                           -->
-            <!--             entity_links=(EntityReference(element_name='listing'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -44,6 +38,18 @@
             <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='country_latest',                         -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='listing',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -67,12 +73,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql="listing__country_latest = 'us'",                  -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='country_latest',                           -->
-                        <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -97,6 +97,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('JOINED',),                         -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='country_latest',                         -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='listing',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_0') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='bookings',                                                   -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day >= '2020-01-01'",                          -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='bookings',                                        -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day >= '2020-01-01'",               -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_0') -->
@@ -50,28 +55,35 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                                                                          -->
-                        <!--   WhereFilterSpec(                                                                         -->
-                        <!--     where_sql="metric_time__day >= '2020-01-01'",                                          -->
-                        <!--     bind_parameters=SqlBindParameters(),                                                   -->
-                        <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
-                        <!--     linkable_elements=(                                                                    -->
-                        <!--       LinkableDimension(                                                                   -->
-                        <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
-                        <!--           semantic_model_name='bookings_source',                                           -->
-                        <!--         ),                                                                                 -->
-                        <!--         element_name='metric_time',                                                        -->
-                        <!--         dimension_type=TIME,                                                               -->
-                        <!--         join_path=SemanticModelJoinPath(                                                   -->
-                        <!--           left_semantic_model_reference=SemanticModelReference(                            -->
-                        <!--             semantic_model_name='bookings_source',                                         -->
-                        <!--           ),                                                                               -->
-                        <!--         ),                                                                                 -->
-                        <!--         properties=frozenset('METRIC_TIME',),                                              -->
-                        <!--         time_granularity=DAY,                                                              -->
-                        <!--       ),                                                                                   -->
-                        <!--     ),                                                                                     -->
-                        <!--   )                                                                                        -->
+                        <!-- where_condition =                                               -->
+                        <!--   WhereFilterSpec(                                              -->
+                        <!--     where_sql="metric_time__day >= '2020-01-01'",               -->
+                        <!--     bind_parameters=SqlBindParameters(),                        -->
+                        <!--     linkable_elements=(                                         -->
+                        <!--       LinkableDimension(                                        -->
+                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                        <!--           semantic_model_name='bookings_source',                -->
+                        <!--         ),                                                      -->
+                        <!--         element_name='metric_time',                             -->
+                        <!--         dimension_type=TIME,                                    -->
+                        <!--         join_path=SemanticModelJoinPath(                        -->
+                        <!--           left_semantic_model_reference=SemanticModelReference( -->
+                        <!--             semantic_model_name='bookings_source',              -->
+                        <!--           ),                                                    -->
+                        <!--         ),                                                      -->
+                        <!--         properties=frozenset('METRIC_TIME',),                   -->
+                        <!--         time_granularity=DAY,                                   -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                        <!--       time_dimension_specs=(                                    -->
+                        <!--         TimeDimensionSpec(                                      -->
+                        <!--           element_name='metric_time',                           -->
+                        <!--           time_granularity=DAY,                                 -->
+                        <!--         ),                                                      -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--   )                                                             -->
                         <FilterElementsNode>
                             <!-- description =                                                                   -->
                             <!--   "Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql="listing__country_latest = 'us'",                  -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='country_latest',                           -->
-            <!--             entity_links=(EntityReference(element_name='listing'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -44,6 +38,18 @@
             <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='country_latest',                         -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='listing',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -57,12 +63,6 @@
                     <!--   WhereFilterSpec(                                               -->
                     <!--     where_sql="listing__country_latest = 'us'",                  -->
                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                    <!--     linkable_specs=(                                             -->
-                    <!--       DimensionSpec(                                             -->
-                    <!--         element_name='country_latest',                           -->
-                    <!--         entity_links=(EntityReference(element_name='listing'),), -->
-                    <!--       ),                                                         -->
-                    <!--     ),                                                           -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -87,6 +87,18 @@
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
                     <!--         properties=frozenset('JOINED',),                         -->
+                    <!--       ),                                                         -->
+                    <!--     ),                                                           -->
+                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                    <!--       dimension_specs=(                                          -->
+                    <!--         DimensionSpec(                                           -->
+                    <!--           element_name='country_latest',                         -->
+                    <!--           entity_links=(                                         -->
+                    <!--             EntityReference(                                     -->
+                    <!--               element_name='listing',                            -->
+                    <!--             ),                                                   -->
+                    <!--           ),                                                     -->
+                    <!--         ),                                                       -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                              -->
             <!--         where_sql="visit__referrer_id = '123456'",                  -->
             <!--         bind_parameters=SqlBindParameters(),                        -->
-            <!--         linkable_specs=(                                            -->
-            <!--           DimensionSpec(                                            -->
-            <!--             element_name='referrer_id',                             -->
-            <!--             entity_links=(EntityReference(element_name='visit'),),  -->
-            <!--           ),                                                        -->
-            <!--         ),                                                          -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
@@ -32,6 +26,18 @@
             <!--               ),                                                    -->
             <!--             ),                                                      -->
             <!--             properties=frozenset('LOCAL',),                         -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           dimension_specs=(                                         -->
+            <!--             DimensionSpec(                                          -->
+            <!--               element_name='referrer_id',                           -->
+            <!--               entity_links=(                                        -->
+            <!--                 EntityReference(                                    -->
+            <!--                   element_name='visit',                             -->
+            <!--                 ),                                                  -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
             <!--       ),                                                            -->
@@ -62,12 +68,6 @@
                             <!--   WhereFilterSpec(                                              -->
                             <!--     where_sql="visit__referrer_id = '123456'",                  -->
                             <!--     bind_parameters=SqlBindParameters(),                        -->
-                            <!--     linkable_specs=(                                            -->
-                            <!--       DimensionSpec(                                            -->
-                            <!--         element_name='referrer_id',                             -->
-                            <!--         entity_links=(EntityReference(element_name='visit'),),  -->
-                            <!--       ),                                                        -->
-                            <!--     ),                                                          -->
                             <!--     linkable_elements=(                                         -->
                             <!--       LinkableDimension(                                        -->
                             <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -82,6 +82,18 @@
                             <!--           ),                                                    -->
                             <!--         ),                                                      -->
                             <!--         properties=frozenset('LOCAL',),                         -->
+                            <!--       ),                                                        -->
+                            <!--     ),                                                          -->
+                            <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                            <!--       dimension_specs=(                                         -->
+                            <!--         DimensionSpec(                                          -->
+                            <!--           element_name='referrer_id',                           -->
+                            <!--           entity_links=(                                        -->
+                            <!--             EntityReference(                                    -->
+                            <!--               element_name='visit',                             -->
+                            <!--             ),                                                  -->
+                            <!--           ),                                                    -->
+                            <!--         ),                                                      -->
                             <!--       ),                                                        -->
                             <!--     ),                                                          -->
                             <!--   )                                                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                              -->
             <!--         where_sql="visit__referrer_id = '123456'",                  -->
             <!--         bind_parameters=SqlBindParameters(),                        -->
-            <!--         linkable_specs=(                                            -->
-            <!--           DimensionSpec(                                            -->
-            <!--             element_name='referrer_id',                             -->
-            <!--             entity_links=(EntityReference(element_name='visit'),),  -->
-            <!--           ),                                                        -->
-            <!--         ),                                                          -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
@@ -32,6 +26,18 @@
             <!--               ),                                                    -->
             <!--             ),                                                      -->
             <!--             properties=frozenset('LOCAL',),                         -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           dimension_specs=(                                         -->
+            <!--             DimensionSpec(                                          -->
+            <!--               element_name='referrer_id',                           -->
+            <!--               entity_links=(                                        -->
+            <!--                 EntityReference(                                    -->
+            <!--                   element_name='visit',                             -->
+            <!--                 ),                                                  -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
             <!--       ),                                                            -->
@@ -104,12 +110,6 @@
                                         <!--   WhereFilterSpec(                                              -->
                                         <!--     where_sql="visit__referrer_id = '123456'",                  -->
                                         <!--     bind_parameters=SqlBindParameters(),                        -->
-                                        <!--     linkable_specs=(                                            -->
-                                        <!--       DimensionSpec(                                            -->
-                                        <!--         element_name='referrer_id',                             -->
-                                        <!--         entity_links=(EntityReference(element_name='visit'),),  -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
                                         <!--     linkable_elements=(                                         -->
                                         <!--       LinkableDimension(                                        -->
                                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -128,6 +128,18 @@
                                         <!--           ),                                                    -->
                                         <!--         ),                                                      -->
                                         <!--         properties=frozenset('LOCAL',),                         -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                        <!--       dimension_specs=(                                         -->
+                                        <!--         DimensionSpec(                                          -->
+                                        <!--           element_name='referrer_id',                           -->
+                                        <!--           entity_links=(                                        -->
+                                        <!--             EntityReference(                                    -->
+                                        <!--               element_name='visit',                             -->
+                                        <!--             ),                                                  -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
                                         <!--       ),                                                        -->
                                         <!--     ),                                                          -->
                                         <!--   )                                                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -32,6 +26,18 @@
             <!--               ),                                                     -->
             <!--             ),                                                       -->
             <!--             properties=frozenset('LOCAL',),                          -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -58,12 +64,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -78,6 +78,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -32,6 +26,18 @@
             <!--               ),                                                     -->
             <!--             ),                                                       -->
             <!--             properties=frozenset('LOCAL',),                          -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -105,14 +111,6 @@
                                         <!--   WhereFilterSpec(                                              -->
                                         <!--     where_sql='booking__is_instant',                            -->
                                         <!--     bind_parameters=SqlBindParameters(),                        -->
-                                        <!--     linkable_specs=(                                            -->
-                                        <!--       DimensionSpec(                                            -->
-                                        <!--         element_name='is_instant',                              -->
-                                        <!--         entity_links=(                                          -->
-                                        <!--           EntityReference(element_name='booking'),              -->
-                                        <!--         ),                                                      -->
-                                        <!--       ),                                                        -->
-                                        <!--     ),                                                          -->
                                         <!--     linkable_elements=(                                         -->
                                         <!--       LinkableDimension(                                        -->
                                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -131,6 +129,18 @@
                                         <!--           ),                                                    -->
                                         <!--         ),                                                      -->
                                         <!--         properties=frozenset('LOCAL',),                         -->
+                                        <!--       ),                                                        -->
+                                        <!--     ),                                                          -->
+                                        <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                        <!--       dimension_specs=(                                         -->
+                                        <!--         DimensionSpec(                                          -->
+                                        <!--           element_name='is_instant',                            -->
+                                        <!--           entity_links=(                                        -->
+                                        <!--             EntityReference(                                    -->
+                                        <!--               element_name='booking',                           -->
+                                        <!--             ),                                                  -->
+                                        <!--           ),                                                    -->
+                                        <!--         ),                                                      -->
                                         <!--       ),                                                        -->
                                         <!--     ),                                                          -->
                                         <!--   )                                                             -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                       -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                      -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
@@ -109,12 +121,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -129,6 +135,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->
@@ -222,12 +240,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -244,6 +256,18 @@
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
                     <!--             properties=frozenset('LOCAL',),                            -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--       ),                                                               -->
@@ -283,12 +307,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -303,6 +321,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_3') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                       -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                      -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_3') -->
@@ -152,16 +164,6 @@
                                                 <!--   WhereFilterSpec(                                              -->
                                                 <!--     where_sql='booking__is_instant',                            -->
                                                 <!--     bind_parameters=SqlBindParameters(),                        -->
-                                                <!--     linkable_specs=(                                            -->
-                                                <!--       DimensionSpec(                                            -->
-                                                <!--         element_name='is_instant',                              -->
-                                                <!--         entity_links=(                                          -->
-                                                <!--           EntityReference(                                      -->
-                                                <!--             element_name='booking',                             -->
-                                                <!--           ),                                                    -->
-                                                <!--         ),                                                      -->
-                                                <!--       ),                                                        -->
-                                                <!--     ),                                                          -->
                                                 <!--     linkable_elements=(                                         -->
                                                 <!--       LinkableDimension(                                        -->
                                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -180,6 +182,18 @@
                                                 <!--           ),                                                    -->
                                                 <!--         ),                                                      -->
                                                 <!--         properties=frozenset('LOCAL',),                         -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                                <!--       dimension_specs=(                                         -->
+                                                <!--         DimensionSpec(                                          -->
+                                                <!--           element_name='is_instant',                            -->
+                                                <!--           entity_links=(                                        -->
+                                                <!--             EntityReference(                                    -->
+                                                <!--               element_name='booking',                           -->
+                                                <!--             ),                                                  -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
                                                 <!--       ),                                                        -->
                                                 <!--     ),                                                          -->
                                                 <!--   )                                                             -->
@@ -230,12 +244,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -252,6 +260,18 @@
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
                     <!--             properties=frozenset('LOCAL',),                            -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--       ),                                                               -->
@@ -291,12 +311,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -311,6 +325,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                       -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                      -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_1') -->
@@ -84,12 +96,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -104,6 +110,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
@@ -128,12 +146,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -148,6 +160,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->
@@ -241,12 +265,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -265,6 +283,18 @@
                     <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
                     <!--       ),                                                               -->
                     <!--     ),                                                                 -->
                     <!--     alias='bookings_2_weeks_ago',                                      -->
@@ -277,12 +307,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -297,6 +321,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
@@ -321,12 +357,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -341,6 +371,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_3') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                       -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                      -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_5') -->
@@ -84,12 +96,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -104,6 +110,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
@@ -171,16 +189,6 @@
                                                 <!--   WhereFilterSpec(                                              -->
                                                 <!--     where_sql='booking__is_instant',                            -->
                                                 <!--     bind_parameters=SqlBindParameters(),                        -->
-                                                <!--     linkable_specs=(                                            -->
-                                                <!--       DimensionSpec(                                            -->
-                                                <!--         element_name='is_instant',                              -->
-                                                <!--         entity_links=(                                          -->
-                                                <!--           EntityReference(                                      -->
-                                                <!--             element_name='booking',                             -->
-                                                <!--           ),                                                    -->
-                                                <!--         ),                                                      -->
-                                                <!--       ),                                                        -->
-                                                <!--     ),                                                          -->
                                                 <!--     linkable_elements=(                                         -->
                                                 <!--       LinkableDimension(                                        -->
                                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -199,6 +207,18 @@
                                                 <!--           ),                                                    -->
                                                 <!--         ),                                                      -->
                                                 <!--         properties=frozenset('LOCAL',),                         -->
+                                                <!--       ),                                                        -->
+                                                <!--     ),                                                          -->
+                                                <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                                <!--       dimension_specs=(                                         -->
+                                                <!--         DimensionSpec(                                          -->
+                                                <!--           element_name='is_instant',                            -->
+                                                <!--           entity_links=(                                        -->
+                                                <!--             EntityReference(                                    -->
+                                                <!--               element_name='booking',                           -->
+                                                <!--             ),                                                  -->
+                                                <!--           ),                                                    -->
+                                                <!--         ),                                                      -->
                                                 <!--       ),                                                        -->
                                                 <!--     ),                                                          -->
                                                 <!--   )                                                             -->
@@ -249,12 +269,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -273,6 +287,18 @@
                     <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
                     <!--       ),                                                               -->
                     <!--     ),                                                                 -->
                     <!--     alias='bookings_2_weeks_ago',                                      -->
@@ -285,12 +311,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -305,6 +325,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->
@@ -329,12 +361,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -349,6 +375,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings',                                         -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings',                                        -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_0') -->
@@ -99,12 +111,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -119,6 +125,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('LOCAL',),                          -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_instant',                             -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='booking',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->
@@ -211,12 +229,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -233,6 +245,18 @@
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
                     <!--             properties=frozenset('LOCAL',),                            -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--       ),                                                               -->
@@ -262,12 +286,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -282,6 +300,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('LOCAL',),                          -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_instant',                             -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='booking',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -34,6 +28,18 @@
             <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
             <!--       ),                                                             -->
             <!--     ),                                                               -->
             <!--   )                                                                  -->
@@ -43,40 +49,46 @@
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_3') -->
-                    <!-- metric_spec =                                                        -->
-                    <!--   MetricSpec(                                                        -->
-                    <!--     element_name='bookings',                                         -->
-                    <!--     filter_specs=(                                                   -->
-                    <!--       WhereFilterSpec(                                               -->
-                    <!--         where_sql='booking__is_instant',                             -->
-                    <!--         bind_parameters=SqlBindParameters(),                         -->
-                    <!--         linkable_specs=(                                             -->
-                    <!--           DimensionSpec(                                             -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--         linkable_elements=(                                          -->
-                    <!--           LinkableDimension(                                         -->
-                    <!--             defined_in_semantic_model=SemanticModelReference(        -->
-                    <!--               semantic_model_name='bookings_source',                 -->
-                    <!--             ),                                                       -->
-                    <!--             element_name='is_instant',                               -->
-                    <!--             dimension_type=CATEGORICAL,                              -->
-                    <!--             entity_links=(                                           -->
-                    <!--               EntityReference(element_name='booking'),               -->
-                    <!--             ),                                                       -->
-                    <!--             join_path=SemanticModelJoinPath(                         -->
-                    <!--               left_semantic_model_reference=SemanticModelReference(  -->
-                    <!--                 semantic_model_name='bookings_source',               -->
-                    <!--               ),                                                     -->
-                    <!--             ),                                                       -->
-                    <!--             properties=frozenset('LOCAL',),                          -->
-                    <!--           ),                                                         -->
-                    <!--         ),                                                           -->
-                    <!--       ),                                                             -->
-                    <!--     ),                                                               -->
-                    <!--   )                                                                  -->
+                    <!-- metric_spec =                                                       -->
+                    <!--   MetricSpec(                                                       -->
+                    <!--     element_name='bookings',                                        -->
+                    <!--     filter_specs=(                                                  -->
+                    <!--       WhereFilterSpec(                                              -->
+                    <!--         where_sql='booking__is_instant',                            -->
+                    <!--         bind_parameters=SqlBindParameters(),                        -->
+                    <!--         linkable_elements=(                                         -->
+                    <!--           LinkableDimension(                                        -->
+                    <!--             defined_in_semantic_model=SemanticModelReference(       -->
+                    <!--               semantic_model_name='bookings_source',                -->
+                    <!--             ),                                                      -->
+                    <!--             element_name='is_instant',                              -->
+                    <!--             dimension_type=CATEGORICAL,                             -->
+                    <!--             entity_links=(                                          -->
+                    <!--               EntityReference(element_name='booking'),              -->
+                    <!--             ),                                                      -->
+                    <!--             join_path=SemanticModelJoinPath(                        -->
+                    <!--               left_semantic_model_reference=SemanticModelReference( -->
+                    <!--                 semantic_model_name='bookings_source',              -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--             properties=frozenset('LOCAL',),                         -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                          -->
+                    <!--           dimension_specs=(                                         -->
+                    <!--             DimensionSpec(                                          -->
+                    <!--               element_name='is_instant',                            -->
+                    <!--               entity_links=(                                        -->
+                    <!--                 EntityReference(                                    -->
+                    <!--                   element_name='booking',                           -->
+                    <!--                 ),                                                  -->
+                    <!--               ),                                                    -->
+                    <!--             ),                                                      -->
+                    <!--           ),                                                        -->
+                    <!--         ),                                                          -->
+                    <!--       ),                                                            -->
+                    <!--     ),                                                              -->
+                    <!--   )                                                                 -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_2') -->
@@ -141,16 +153,6 @@
                                             <!--   WhereFilterSpec(                                              -->
                                             <!--     where_sql='booking__is_instant',                            -->
                                             <!--     bind_parameters=SqlBindParameters(),                        -->
-                                            <!--     linkable_specs=(                                            -->
-                                            <!--       DimensionSpec(                                            -->
-                                            <!--         element_name='is_instant',                              -->
-                                            <!--         entity_links=(                                          -->
-                                            <!--           EntityReference(                                      -->
-                                            <!--             element_name='booking',                             -->
-                                            <!--           ),                                                    -->
-                                            <!--         ),                                                      -->
-                                            <!--       ),                                                        -->
-                                            <!--     ),                                                          -->
                                             <!--     linkable_elements=(                                         -->
                                             <!--       LinkableDimension(                                        -->
                                             <!--         defined_in_semantic_model=SemanticModelReference(       -->
@@ -169,6 +171,18 @@
                                             <!--           ),                                                    -->
                                             <!--         ),                                                      -->
                                             <!--         properties=frozenset('LOCAL',),                         -->
+                                            <!--       ),                                                        -->
+                                            <!--     ),                                                          -->
+                                            <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                                            <!--       dimension_specs=(                                         -->
+                                            <!--         DimensionSpec(                                          -->
+                                            <!--           element_name='is_instant',                            -->
+                                            <!--           entity_links=(                                        -->
+                                            <!--             EntityReference(                                    -->
+                                            <!--               element_name='booking',                           -->
+                                            <!--             ),                                                  -->
+                                            <!--           ),                                                    -->
+                                            <!--         ),                                                      -->
                                             <!--       ),                                                        -->
                                             <!--     ),                                                          -->
                                             <!--   )                                                             -->
@@ -217,12 +231,6 @@
                     <!--       WhereFilterSpec(                                                 -->
                     <!--         where_sql='booking__is_instant',                               -->
                     <!--         bind_parameters=SqlBindParameters(),                           -->
-                    <!--         linkable_specs=(                                               -->
-                    <!--           DimensionSpec(                                               -->
-                    <!--             element_name='is_instant',                                 -->
-                    <!--             entity_links=(EntityReference(element_name='booking'),),   -->
-                    <!--           ),                                                           -->
-                    <!--         ),                                                             -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
@@ -239,6 +247,18 @@
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
                     <!--             properties=frozenset('LOCAL',),                            -->
+                    <!--           ),                                                           -->
+                    <!--         ),                                                             -->
+                    <!--         linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--           dimension_specs=(                                            -->
+                    <!--             DimensionSpec(                                             -->
+                    <!--               element_name='is_instant',                               -->
+                    <!--               entity_links=(                                           -->
+                    <!--                 EntityReference(                                       -->
+                    <!--                   element_name='booking',                              -->
+                    <!--                 ),                                                     -->
+                    <!--               ),                                                       -->
+                    <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--       ),                                                               -->
@@ -268,12 +288,6 @@
                                 <!--   WhereFilterSpec(                                               -->
                                 <!--     where_sql='booking__is_instant',                             -->
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
-                                <!--     linkable_specs=(                                             -->
-                                <!--       DimensionSpec(                                             -->
-                                <!--         element_name='is_instant',                               -->
-                                <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                <!--       ),                                                         -->
-                                <!--     ),                                                           -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -288,6 +302,18 @@
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
                                 <!--         properties=frozenset('LOCAL',),                          -->
+                                <!--       ),                                                         -->
+                                <!--     ),                                                           -->
+                                <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                <!--       dimension_specs=(                                          -->
+                                <!--         DimensionSpec(                                           -->
+                                <!--           element_name='is_instant',                             -->
+                                <!--           entity_links=(                                         -->
+                                <!--             EntityReference(                                     -->
+                                <!--               element_name='booking',                            -->
+                                <!--             ),                                                   -->
+                                <!--           ),                                                     -->
+                                <!--         ),                                                       -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -32,6 +26,18 @@
             <!--               ),                                                     -->
             <!--             ),                                                       -->
             <!--             properties=frozenset('LOCAL',),                          -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -57,12 +63,6 @@
                         <!--   WhereFilterSpec(                                               -->
                         <!--     where_sql='booking__is_instant',                             -->
                         <!--     bind_parameters=SqlBindParameters(),                         -->
-                        <!--     linkable_specs=(                                             -->
-                        <!--       DimensionSpec(                                             -->
-                        <!--         element_name='is_instant',                               -->
-                        <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                        <!--       ),                                                         -->
-                        <!--     ),                                                           -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -77,6 +77,18 @@
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
                         <!--         properties=frozenset('LOCAL',),                          -->
+                        <!--       ),                                                         -->
+                        <!--     ),                                                           -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                        <!--       dimension_specs=(                                          -->
+                        <!--         DimensionSpec(                                           -->
+                        <!--           element_name='is_instant',                             -->
+                        <!--           entity_links=(                                         -->
+                        <!--             EntityReference(                                     -->
+                        <!--               element_name='booking',                            -->
+                        <!--             ),                                                   -->
+                        <!--           ),                                                     -->
+                        <!--         ),                                                       -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
@@ -12,12 +12,6 @@
             <!--       WhereFilterSpec(                                               -->
             <!--         where_sql='booking__is_instant',                             -->
             <!--         bind_parameters=SqlBindParameters(),                         -->
-            <!--         linkable_specs=(                                             -->
-            <!--           DimensionSpec(                                             -->
-            <!--             element_name='is_instant',                               -->
-            <!--             entity_links=(EntityReference(element_name='booking'),), -->
-            <!--           ),                                                         -->
-            <!--         ),                                                           -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
@@ -32,6 +26,18 @@
             <!--               ),                                                     -->
             <!--             ),                                                       -->
             <!--             properties=frozenset('LOCAL',),                          -->
+            <!--           ),                                                         -->
+            <!--         ),                                                           -->
+            <!--         linkable_spec_set=LinkableSpecSet(                           -->
+            <!--           dimension_specs=(                                          -->
+            <!--             DimensionSpec(                                           -->
+            <!--               element_name='is_instant',                             -->
+            <!--               entity_links=(                                         -->
+            <!--                 EntityReference(                                     -->
+            <!--                   element_name='booking',                            -->
+            <!--                 ),                                                   -->
+            <!--               ),                                                     -->
+            <!--             ),                                                       -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--       ),                                                             -->
@@ -93,12 +99,6 @@
                                     <!--   WhereFilterSpec(                                               -->
                                     <!--     where_sql='booking__is_instant',                             -->
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
-                                    <!--     linkable_specs=(                                             -->
-                                    <!--       DimensionSpec(                                             -->
-                                    <!--         element_name='is_instant',                               -->
-                                    <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                                    <!--       ),                                                         -->
-                                    <!--     ),                                                           -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -113,6 +113,18 @@
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
                                     <!--         properties=frozenset('LOCAL',),                          -->
+                                    <!--       ),                                                         -->
+                                    <!--     ),                                                           -->
+                                    <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                                    <!--       dimension_specs=(                                          -->
+                                    <!--         DimensionSpec(                                           -->
+                                    <!--           element_name='is_instant',                             -->
+                                    <!--           entity_links=(                                         -->
+                                    <!--             EntityReference(                                     -->
+                                    <!--               element_name='booking',                            -->
+                                    <!--             ),                                                   -->
+                                    <!--           ),                                                     -->
+                                    <!--         ),                                                       -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_0') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='bookings',                                                   -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day = '2024-01-01'",                           -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='bookings',                                        -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day = '2024-01-01'",                -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_0') -->
@@ -50,28 +55,35 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                                                                          -->
-                        <!--   WhereFilterSpec(                                                                         -->
-                        <!--     where_sql="metric_time__day = '2024-01-01'",                                           -->
-                        <!--     bind_parameters=SqlBindParameters(),                                                   -->
-                        <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
-                        <!--     linkable_elements=(                                                                    -->
-                        <!--       LinkableDimension(                                                                   -->
-                        <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
-                        <!--           semantic_model_name='bookings_source',                                           -->
-                        <!--         ),                                                                                 -->
-                        <!--         element_name='metric_time',                                                        -->
-                        <!--         dimension_type=TIME,                                                               -->
-                        <!--         join_path=SemanticModelJoinPath(                                                   -->
-                        <!--           left_semantic_model_reference=SemanticModelReference(                            -->
-                        <!--             semantic_model_name='bookings_source',                                         -->
-                        <!--           ),                                                                               -->
-                        <!--         ),                                                                                 -->
-                        <!--         properties=frozenset('METRIC_TIME',),                                              -->
-                        <!--         time_granularity=DAY,                                                              -->
-                        <!--       ),                                                                                   -->
-                        <!--     ),                                                                                     -->
-                        <!--   )                                                                                        -->
+                        <!-- where_condition =                                               -->
+                        <!--   WhereFilterSpec(                                              -->
+                        <!--     where_sql="metric_time__day = '2024-01-01'",                -->
+                        <!--     bind_parameters=SqlBindParameters(),                        -->
+                        <!--     linkable_elements=(                                         -->
+                        <!--       LinkableDimension(                                        -->
+                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                        <!--           semantic_model_name='bookings_source',                -->
+                        <!--         ),                                                      -->
+                        <!--         element_name='metric_time',                             -->
+                        <!--         dimension_type=TIME,                                    -->
+                        <!--         join_path=SemanticModelJoinPath(                        -->
+                        <!--           left_semantic_model_reference=SemanticModelReference( -->
+                        <!--             semantic_model_name='bookings_source',              -->
+                        <!--           ),                                                    -->
+                        <!--         ),                                                      -->
+                        <!--         properties=frozenset('METRIC_TIME',),                   -->
+                        <!--         time_granularity=DAY,                                   -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                        <!--       time_dimension_specs=(                                    -->
+                        <!--         TimeDimensionSpec(                                      -->
+                        <!--           element_name='metric_time',                           -->
+                        <!--           time_granularity=DAY,                                 -->
+                        <!--         ),                                                      -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--   )                                                             -->
                         <FilterElementsNode>
                             <!-- description =                                                                       -->
                             <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']" -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
@@ -5,35 +5,40 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_1') -->
-            <!-- metric_spec =                                                                  -->
-            <!--   MetricSpec(                                                                  -->
-            <!--     element_name='bookings',                                                   -->
-            <!--     filter_specs=(                                                             -->
-            <!--       WhereFilterSpec(                                                         -->
-            <!--         where_sql="metric_time__day = '2024-01-01'",                           -->
-            <!--         bind_parameters=SqlBindParameters(),                                   -->
-            <!--         linkable_specs=(                                                       -->
-            <!--           TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--         ),                                                                     -->
-            <!--         linkable_elements=(                                                    -->
-            <!--           LinkableDimension(                                                   -->
-            <!--             defined_in_semantic_model=SemanticModelReference(                  -->
-            <!--               semantic_model_name='bookings_source',                           -->
-            <!--             ),                                                                 -->
-            <!--             element_name='metric_time',                                        -->
-            <!--             dimension_type=TIME,                                               -->
-            <!--             join_path=SemanticModelJoinPath(                                   -->
-            <!--               left_semantic_model_reference=SemanticModelReference(            -->
-            <!--                 semantic_model_name='bookings_source',                         -->
-            <!--               ),                                                               -->
-            <!--             ),                                                                 -->
-            <!--             properties=frozenset('METRIC_TIME',),                              -->
-            <!--             time_granularity=DAY,                                              -->
-            <!--           ),                                                                   -->
-            <!--         ),                                                                     -->
-            <!--       ),                                                                       -->
-            <!--     ),                                                                         -->
-            <!--   )                                                                            -->
+            <!-- metric_spec =                                                       -->
+            <!--   MetricSpec(                                                       -->
+            <!--     element_name='bookings',                                        -->
+            <!--     filter_specs=(                                                  -->
+            <!--       WhereFilterSpec(                                              -->
+            <!--         where_sql="metric_time__day = '2024-01-01'",                -->
+            <!--         bind_parameters=SqlBindParameters(),                        -->
+            <!--         linkable_elements=(                                         -->
+            <!--           LinkableDimension(                                        -->
+            <!--             defined_in_semantic_model=SemanticModelReference(       -->
+            <!--               semantic_model_name='bookings_source',                -->
+            <!--             ),                                                      -->
+            <!--             element_name='metric_time',                             -->
+            <!--             dimension_type=TIME,                                    -->
+            <!--             join_path=SemanticModelJoinPath(                        -->
+            <!--               left_semantic_model_reference=SemanticModelReference( -->
+            <!--                 semantic_model_name='bookings_source',              -->
+            <!--               ),                                                    -->
+            <!--             ),                                                      -->
+            <!--             properties=frozenset('METRIC_TIME',),                   -->
+            <!--             time_granularity=DAY,                                   -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--         linkable_spec_set=LinkableSpecSet(                          -->
+            <!--           time_dimension_specs=(                                    -->
+            <!--             TimeDimensionSpec(                                      -->
+            <!--               element_name='metric_time',                           -->
+            <!--               time_granularity=DAY,                                 -->
+            <!--             ),                                                      -->
+            <!--           ),                                                        -->
+            <!--         ),                                                          -->
+            <!--       ),                                                            -->
+            <!--     ),                                                              -->
+            <!--   )                                                                 -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_1') -->
@@ -50,28 +55,35 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_1') -->
-                        <!-- where_condition =                                                                          -->
-                        <!--   WhereFilterSpec(                                                                         -->
-                        <!--     where_sql="metric_time__day = '2024-01-01'",                                           -->
-                        <!--     bind_parameters=SqlBindParameters(),                                                   -->
-                        <!--     linkable_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),), -->
-                        <!--     linkable_elements=(                                                                    -->
-                        <!--       LinkableDimension(                                                                   -->
-                        <!--         defined_in_semantic_model=SemanticModelReference(                                  -->
-                        <!--           semantic_model_name='bookings_source',                                           -->
-                        <!--         ),                                                                                 -->
-                        <!--         element_name='metric_time',                                                        -->
-                        <!--         dimension_type=TIME,                                                               -->
-                        <!--         join_path=SemanticModelJoinPath(                                                   -->
-                        <!--           left_semantic_model_reference=SemanticModelReference(                            -->
-                        <!--             semantic_model_name='bookings_source',                                         -->
-                        <!--           ),                                                                               -->
-                        <!--         ),                                                                                 -->
-                        <!--         properties=frozenset('METRIC_TIME',),                                              -->
-                        <!--         time_granularity=DAY,                                                              -->
-                        <!--       ),                                                                                   -->
-                        <!--     ),                                                                                     -->
-                        <!--   )                                                                                        -->
+                        <!-- where_condition =                                               -->
+                        <!--   WhereFilterSpec(                                              -->
+                        <!--     where_sql="metric_time__day = '2024-01-01'",                -->
+                        <!--     bind_parameters=SqlBindParameters(),                        -->
+                        <!--     linkable_elements=(                                         -->
+                        <!--       LinkableDimension(                                        -->
+                        <!--         defined_in_semantic_model=SemanticModelReference(       -->
+                        <!--           semantic_model_name='bookings_source',                -->
+                        <!--         ),                                                      -->
+                        <!--         element_name='metric_time',                             -->
+                        <!--         dimension_type=TIME,                                    -->
+                        <!--         join_path=SemanticModelJoinPath(                        -->
+                        <!--           left_semantic_model_reference=SemanticModelReference( -->
+                        <!--             semantic_model_name='bookings_source',              -->
+                        <!--           ),                                                    -->
+                        <!--         ),                                                      -->
+                        <!--         properties=frozenset('METRIC_TIME',),                   -->
+                        <!--         time_granularity=DAY,                                   -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--     linkable_spec_set=LinkableSpecSet(                          -->
+                        <!--       time_dimension_specs=(                                    -->
+                        <!--         TimeDimensionSpec(                                      -->
+                        <!--           element_name='metric_time',                           -->
+                        <!--           time_granularity=DAY,                                 -->
+                        <!--         ),                                                      -->
+                        <!--       ),                                                        -->
+                        <!--     ),                                                          -->
+                        <!--   )                                                             -->
                         <FilterElementsNode>
                             <!-- description =                                                                       -->
                             <!--   "Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -51,12 +51,6 @@
                             <!--   WhereFilterSpec(                                               -->
                             <!--     where_sql='booking__is_instant',                             -->
                             <!--     bind_parameters=SqlBindParameters(),                         -->
-                            <!--     linkable_specs=(                                             -->
-                            <!--       DimensionSpec(                                             -->
-                            <!--         element_name='is_instant',                               -->
-                            <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--       ),                                                         -->
-                            <!--     ),                                                           -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
                             <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -71,6 +65,18 @@
                             <!--           ),                                                     -->
                             <!--         ),                                                       -->
                             <!--         properties=frozenset('LOCAL',),                          -->
+                            <!--       ),                                                         -->
+                            <!--     ),                                                           -->
+                            <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                            <!--       dimension_specs=(                                          -->
+                            <!--         DimensionSpec(                                           -->
+                            <!--           element_name='is_instant',                             -->
+                            <!--           entity_links=(                                         -->
+                            <!--             EntityReference(                                     -->
+                            <!--               element_name='booking',                            -->
+                            <!--             ),                                                   -->
+                            <!--           ),                                                     -->
+                            <!--         ),                                                       -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--   )                                                              -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -51,12 +51,6 @@
                             <!--   WhereFilterSpec(                                               -->
                             <!--     where_sql='booking__is_instant',                             -->
                             <!--     bind_parameters=SqlBindParameters(),                         -->
-                            <!--     linkable_specs=(                                             -->
-                            <!--       DimensionSpec(                                             -->
-                            <!--         element_name='is_instant',                               -->
-                            <!--         entity_links=(EntityReference(element_name='booking'),), -->
-                            <!--       ),                                                         -->
-                            <!--     ),                                                           -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
                             <!--         defined_in_semantic_model=SemanticModelReference(        -->
@@ -71,6 +65,18 @@
                             <!--           ),                                                     -->
                             <!--         ),                                                       -->
                             <!--         properties=frozenset('LOCAL',),                          -->
+                            <!--       ),                                                         -->
+                            <!--     ),                                                           -->
+                            <!--     linkable_spec_set=LinkableSpecSet(                           -->
+                            <!--       dimension_specs=(                                          -->
+                            <!--         DimensionSpec(                                           -->
+                            <!--           element_name='is_instant',                             -->
+                            <!--           entity_links=(                                         -->
+                            <!--             EntityReference(                                     -->
+                            <!--               element_name='booking',                            -->
+                            <!--             ),                                                   -->
+                            <!--           ),                                                     -->
+                            <!--         ),                                                       -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--   )                                                              -->


### PR DESCRIPTION
In `WhereFilterSpec`, the field `linkable_specs` can't be used with `SerializableDataclass` since it's an interface. This PR changes that field to a `LinkableSpecSet`.