### PR TITLE
Update fields in `LinkableElement`-related classes to use tuples

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/linkable_element_property.py
+++ b/metricflow-semantics/metricflow_semantics/model/linkable_element_property.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import FrozenSet
+from typing import Any, FrozenSet
 
 
 class LinkableElementProperty(Enum):
@@ -31,3 +31,10 @@ class LinkableElementProperty(Enum):
     @staticmethod
     def all_properties() -> FrozenSet[LinkableElementProperty]:  # noqa: D102
         return frozenset({linkable_element_property for linkable_element_property in LinkableElementProperty})
+
+    def __lt__(self, other: Any) -> bool:  # type: ignore[misc]
+        """When ordering, order by the enum name."""
+        if not isinstance(other, LinkableElementProperty):
+            return NotImplemented
+
+        return self.name < other.name

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import collections
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -102,8 +103,11 @@ class LinkableElement(SemanticModelDerivation, SerializableDataclass, ABC):
     properties: Tuple[LinkableElementProperty, ...]
 
     def __post_init__(self) -> None:  # noqa: D105
-        assert len(self.property_set) == len(self.properties)
-        assert self.properties == tuple(sorted(self.properties))
+        if len(self.property_set) != len(self.properties):
+            duplicate_properties = [item for item, count in collections.Counter(self.properties).items() if count > 1]
+            assert False, f"Found duplicate properties {duplicate_properties} in {self.properties}"
+
+        assert self.properties == tuple(sorted(self.properties)), f"Properties are not sorted: {self.properties}"
 
     @cached_property
     def property_set(self) -> FrozenSet[LinkableElementProperty]:  # noqa: D102

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element.py
@@ -4,7 +4,8 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import FrozenSet, Optional, Sequence, Tuple
+from functools import cached_property
+from typing import FrozenSet, Iterable, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
@@ -98,6 +99,16 @@ class SemanticModelJoinPathElement(SerializableDataclass):
 class LinkableElement(SemanticModelDerivation, SerializableDataclass, ABC):
     """An entity / dimension that may have been joined by entities."""
 
+    properties: Tuple[LinkableElementProperty, ...]
+
+    def __post_init__(self) -> None:  # noqa: D105
+        assert len(self.property_set) == len(self.properties)
+        assert self.properties == tuple(sorted(self.properties))
+
+    @cached_property
+    def property_set(self) -> FrozenSet[LinkableElementProperty]:  # noqa: D102
+        return frozenset(self.properties)
+
     @property
     @abstractmethod
     def element_type(self) -> LinkableElementType:
@@ -126,9 +137,30 @@ class LinkableDimension(LinkableElement, SerializableDataclass):
     dimension_type: DimensionType
     entity_links: Tuple[EntityReference, ...]
     join_path: SemanticModelJoinPath
-    properties: FrozenSet[LinkableElementProperty]
     time_granularity: Optional[TimeGranularity]
     date_part: Optional[DatePart]
+
+    @staticmethod
+    def create(  # noqa: D102
+        properties: Iterable[LinkableElementProperty],
+        defined_in_semantic_model: Optional[SemanticModelReference],
+        element_name: str,
+        dimension_type: DimensionType,
+        entity_links: Tuple[EntityReference, ...],
+        join_path: SemanticModelJoinPath,
+        time_granularity: Optional[TimeGranularity],
+        date_part: Optional[DatePart],
+    ) -> LinkableDimension:
+        return LinkableDimension(
+            properties=tuple(sorted(set(properties))),
+            defined_in_semantic_model=defined_in_semantic_model,
+            element_name=element_name,
+            dimension_type=dimension_type,
+            entity_links=entity_links,
+            join_path=join_path,
+            time_granularity=time_granularity,
+            date_part=date_part,
+        )
 
     @property
     @override
@@ -185,9 +217,24 @@ class LinkableEntity(LinkableElement, SerializableDataclass):
     # The semantic model where this entity was defined.
     defined_in_semantic_model: SemanticModelReference
     element_name: str
-    properties: FrozenSet[LinkableElementProperty]
     entity_links: Tuple[EntityReference, ...]
     join_path: SemanticModelJoinPath
+
+    @staticmethod
+    def create(  # noqa: D102
+        properties: Iterable[LinkableElementProperty],
+        defined_in_semantic_model: SemanticModelReference,
+        element_name: str,
+        entity_links: Tuple[EntityReference, ...],
+        join_path: SemanticModelJoinPath,
+    ) -> LinkableEntity:
+        return LinkableEntity(
+            properties=tuple(sorted(set(properties))),
+            defined_in_semantic_model=defined_in_semantic_model,
+            element_name=element_name,
+            entity_links=entity_links,
+            join_path=join_path,
+        )
 
     @property
     @override
@@ -221,15 +268,24 @@ class LinkableEntity(LinkableElement, SerializableDataclass):
 class LinkableMetric(LinkableElement, SerializableDataclass):
     """Describes how a metric can be realized by joining based on entity links."""
 
-    properties: FrozenSet[LinkableElementProperty]
     join_path: SemanticModelToMetricSubqueryJoinPath
+
+    @staticmethod
+    def create(  # noqa: D102
+        properties: Iterable[LinkableElementProperty], join_path: SemanticModelToMetricSubqueryJoinPath
+    ) -> LinkableMetric:
+        return LinkableMetric(
+            properties=tuple(sorted(set(properties))),
+            join_path=join_path,
+        )
 
     def __post_init__(self) -> None:
         """Ensure expected LinkableElementProperties have been set.
 
         LinkableMetrics always require a join to a metric subquery.
         """
-        assert {LinkableElementProperty.METRIC, LinkableElementProperty.JOINED}.issubset(self.properties)
+        super().__post_init__()
+        assert {LinkableElementProperty.METRIC, LinkableElementProperty.JOINED}.issubset(self.property_set)
 
     @property
     @override

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -237,11 +237,11 @@ class LinkableElementSet(SemanticModelDerivation):
             filtered_linkable_dimensions = tuple(
                 linkable_dimension
                 for linkable_dimension in linkable_dimensions
-                if len(linkable_dimension.properties.intersection(with_any_of)) > 0
-                and len(linkable_dimension.properties.intersection(without_any_of)) == 0
+                if len(linkable_dimension.property_set.intersection(with_any_of)) > 0
+                and len(linkable_dimension.property_set.intersection(without_any_of)) == 0
                 and (
                     len(without_all_of) == 0
-                    or linkable_dimension.properties.intersection(without_all_of) != without_all_of
+                    or linkable_dimension.property_set.intersection(without_all_of) != without_all_of
                 )
             )
             if len(filtered_linkable_dimensions) > 0:
@@ -251,11 +251,11 @@ class LinkableElementSet(SemanticModelDerivation):
             filtered_linkable_entities = tuple(
                 linkable_entity
                 for linkable_entity in linkable_entities
-                if len(linkable_entity.properties.intersection(with_any_of)) > 0
-                and len(linkable_entity.properties.intersection(without_any_of)) == 0
+                if len(linkable_entity.property_set.intersection(with_any_of)) > 0
+                and len(linkable_entity.property_set.intersection(without_any_of)) == 0
                 and (
                     len(without_all_of) == 0
-                    or linkable_entity.properties.intersection(without_all_of) != without_all_of
+                    or linkable_entity.property_set.intersection(without_all_of) != without_all_of
                 )
             )
             if len(filtered_linkable_entities) > 0:
@@ -265,11 +265,11 @@ class LinkableElementSet(SemanticModelDerivation):
             filtered_linkable_metrics = tuple(
                 linkable_metric
                 for linkable_metric in linkable_metrics
-                if len(linkable_metric.properties.intersection(with_any_of)) > 0
-                and len(linkable_metric.properties.intersection(without_any_of)) == 0
+                if len(linkable_metric.property_set.intersection(with_any_of)) > 0
+                and len(linkable_metric.property_set.intersection(without_any_of)) == 0
                 and (
                     len(without_all_of) == 0
-                    or linkable_metric.properties.intersection(without_all_of) != without_all_of
+                    or linkable_metric.property_set.intersection(without_all_of) != without_all_of
                 )
             )
             if len(filtered_linkable_metrics) > 0:

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -69,7 +69,7 @@ def _generate_linkable_time_dimensions(
             properties.add(LinkableElementProperty.DERIVED_TIME_GRANULARITY)
 
         linkable_dimensions.append(
-            LinkableDimension(
+            LinkableDimension.create(
                 defined_in_semantic_model=semantic_model_origin,
                 element_name=dimension.reference.element_name,
                 dimension_type=DimensionType.TIME,
@@ -77,7 +77,7 @@ def _generate_linkable_time_dimensions(
                 join_path=join_path,
                 time_granularity=time_granularity,
                 date_part=None,
-                properties=frozenset(properties),
+                properties=tuple(sorted(properties)),
             )
         )
 
@@ -85,7 +85,7 @@ def _generate_linkable_time_dimensions(
         for date_part in DatePart:
             if time_granularity.to_int() <= date_part.to_int():
                 linkable_dimensions.append(
-                    LinkableDimension(
+                    LinkableDimension.create(
                         defined_in_semantic_model=semantic_model_origin,
                         element_name=dimension.reference.element_name,
                         dimension_type=DimensionType.TIME,
@@ -305,7 +305,7 @@ class ValidLinkableSpecResolver:
             if join_path_has_path_links and entity_reference in using_join_path.entity_links:
                 continue
             for metric_subquery_join_path_element in self._joinable_metrics_for_entities[entity_reference]:
-                linkable_metric = LinkableMetric(
+                linkable_metric = LinkableMetric.create(
                     properties=properties,
                     join_path=SemanticModelToMetricSubqueryJoinPath(
                         metric_subquery_join_path_element=metric_subquery_join_path_element,
@@ -328,7 +328,7 @@ class ValidLinkableSpecResolver:
         linkable_entities = []
         for entity in semantic_model.entities:
             linkable_entities.append(
-                LinkableEntity(
+                LinkableEntity.create(
                     defined_in_semantic_model=semantic_model.reference,
                     element_name=entity.reference.element_name,
                     entity_links=(),
@@ -343,7 +343,7 @@ class ValidLinkableSpecResolver:
                 if entity_link == entity.reference:
                     continue
                 linkable_entities.append(
-                    LinkableEntity(
+                    LinkableEntity.create(
                         defined_in_semantic_model=semantic_model.reference,
                         element_name=entity.reference.element_name,
                         entity_links=(entity_link,),
@@ -360,7 +360,7 @@ class ValidLinkableSpecResolver:
                 dimension_type = dimension.type
                 if dimension_type is DimensionType.CATEGORICAL:
                     linkable_dimensions.append(
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=semantic_model.reference,
                             element_name=dimension.reference.element_name,
                             dimension_type=DimensionType.CATEGORICAL,
@@ -492,7 +492,7 @@ class ValidLinkableSpecResolver:
                     date_part=date_part,
                 )
                 path_key_to_linkable_dimensions[path_key].append(
-                    LinkableDimension(
+                    LinkableDimension.create(
                         defined_in_semantic_model=measure_semantic_model.reference if measure_semantic_model else None,
                         element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
                         dimension_type=DimensionType.TIME,
@@ -719,7 +719,7 @@ class ValidLinkableSpecResolver:
             dimension_type = dimension.type
             if dimension_type == DimensionType.CATEGORICAL:
                 linkable_dimensions.append(
-                    LinkableDimension(
+                    LinkableDimension.create(
                         defined_in_semantic_model=semantic_model.reference,
                         element_name=dimension.reference.element_name,
                         dimension_type=DimensionType.CATEGORICAL,
@@ -747,7 +747,7 @@ class ValidLinkableSpecResolver:
             # Avoid creating "booking_id__booking_id"
             if entity.reference != join_path.last_entity_link:
                 linkable_entities.append(
-                    LinkableEntity(
+                    LinkableEntity.create(
                         defined_in_semantic_model=semantic_model.reference,
                         element_name=entity.reference.element_name,
                         entity_links=join_path.entity_links,

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
@@ -56,14 +56,14 @@ _base_metric_reference = MetricReference(element_name="base_metric")
 
 
 # Entities
-_base_entity = LinkableEntity(
+_base_entity = LinkableEntity.create(
     element_name=_base_entity_reference.element_name,
     defined_in_semantic_model=_base_semantic_model,
     entity_links=(),
     join_path=SemanticModelJoinPath(left_semantic_model_reference=_measure_semantic_model),
     properties=frozenset([LinkableElementProperty.ENTITY]),
 )
-_ambiguous_entity = LinkableEntity(
+_ambiguous_entity = LinkableEntity.create(
     element_name=AMBIGUOUS_NAME,
     defined_in_semantic_model=_base_semantic_model,
     entity_links=(_base_entity_reference,),
@@ -71,7 +71,7 @@ _ambiguous_entity = LinkableEntity(
     properties=frozenset([LinkableElementProperty.ENTITY, LinkableElementProperty.LOCAL_LINKED]),
 )
 # For testing deduplication on entities
-_ambiguous_entity_with_join_path = LinkableEntity(
+_ambiguous_entity_with_join_path = LinkableEntity.create(
     element_name=AMBIGUOUS_NAME,
     defined_in_semantic_model=_base_semantic_model,
     entity_links=(_base_entity_reference,),
@@ -88,7 +88,7 @@ _ambiguous_entity_with_join_path = LinkableEntity(
 )
 
 # Dimensions
-_categorical_dimension = LinkableDimension(
+_categorical_dimension = LinkableDimension.create(
     element_name=_base_dimension_reference.element_name,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
@@ -98,7 +98,7 @@ _categorical_dimension = LinkableDimension(
     time_granularity=None,
     date_part=None,
 )
-_time_dimension = LinkableDimension(
+_time_dimension = LinkableDimension.create(
     element_name=_time_dimension_reference.element_name,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.TIME,
@@ -109,7 +109,7 @@ _time_dimension = LinkableDimension(
     date_part=None,
 )
 # Resolves to the same local linked name name as _ambiguous_entity
-_ambiguous_categorical_dimension = LinkableDimension(
+_ambiguous_categorical_dimension = LinkableDimension.create(
     element_name=AMBIGUOUS_NAME,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
@@ -121,7 +121,7 @@ _ambiguous_categorical_dimension = LinkableDimension(
 )
 # The opposite direction of the join for ambiguous_entity_with_join_path
 # For testing deduplication on dimensions
-_ambiguous_categorical_dimension_with_join_path = LinkableDimension(
+_ambiguous_categorical_dimension_with_join_path = LinkableDimension.create(
     element_name=AMBIGUOUS_NAME,
     entity_links=(_base_entity_reference,),
     dimension_type=DimensionType.CATEGORICAL,
@@ -140,7 +140,7 @@ _ambiguous_categorical_dimension_with_join_path = LinkableDimension(
 )
 
 # Metrics
-_base_metric = LinkableMetric(
+_base_metric = LinkableMetric.create(
     properties=frozenset([LinkableElementProperty.METRIC, LinkableElementProperty.JOINED]),
     join_path=SemanticModelToMetricSubqueryJoinPath(
         metric_subquery_join_path_element=MetricSubqueryJoinPathElement(
@@ -152,7 +152,7 @@ _base_metric = LinkableMetric(
         semantic_model_join_path=SemanticModelJoinPath(left_semantic_model_reference=_base_semantic_model),
     ),
 )
-_ambiguous_metric = LinkableMetric(
+_ambiguous_metric = LinkableMetric.create(
     properties=frozenset([LinkableElementProperty.METRIC, LinkableElementProperty.JOINED]),
     join_path=SemanticModelToMetricSubqueryJoinPath(
         metric_subquery_join_path_element=MetricSubqueryJoinPathElement(
@@ -165,7 +165,7 @@ _ambiguous_metric = LinkableMetric(
     ),
 )
 # For testing deduplication on metrics
-_ambiguous_metric_with_join_path = LinkableMetric(
+_ambiguous_metric_with_join_path = LinkableMetric.create(
     properties=frozenset([LinkableElementProperty.METRIC, LinkableElementProperty.JOINED]),
     join_path=SemanticModelToMetricSubqueryJoinPath(
         metric_subquery_join_path_element=MetricSubqueryJoinPathElement(
@@ -575,7 +575,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 entity_links=(entity_0,),
                 element_type=LinkableElementType.DIMENSION,
             ): (
-                LinkableDimension(
+                LinkableDimension.create(
                     defined_in_semantic_model=SemanticModelReference("dimension_source"),
                     element_name="dimension_element",
                     dimension_type=DimensionType.CATEGORICAL,
@@ -600,7 +600,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 element_type=LinkableElementType.TIME_DIMENSION,
                 time_granularity=TimeGranularity.DAY,
             ): (
-                LinkableDimension(
+                LinkableDimension.create(
                     defined_in_semantic_model=SemanticModelReference("time_dimension_source"),
                     element_name="time_dimension_element",
                     dimension_type=DimensionType.TIME,
@@ -626,7 +626,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 entity_links=(entity_2,),
                 element_type=LinkableElementType.ENTITY,
             ): (
-                LinkableEntity(
+                LinkableEntity.create(
                     defined_in_semantic_model=SemanticModelReference("entity_source"),
                     element_name="entity_element",
                     entity_links=(entity_2,),
@@ -650,7 +650,7 @@ def linkable_set() -> LinkableElementSet:  # noqa: D103
                 element_type=LinkableElementType.METRIC,
                 metric_subquery_entity_links=(entity_2,),
             ): (
-                LinkableMetric(
+                LinkableMetric.create(
                     properties=frozenset([LinkableElementProperty.METRIC, LinkableElementProperty.JOINED]),
                     join_path=SemanticModelToMetricSubqueryJoinPath(
                         metric_subquery_join_path_element=MetricSubqueryJoinPathElement(

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
@@ -112,7 +112,7 @@ def test_dimension_in_filter(  # noqa: D103
                         time_granularity=None,
                         date_part=None,
                     ): (
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=SemanticModelReference("bookings"),
                             dimension_type=DimensionType.CATEGORICAL,
                             element_name="country_latest",
@@ -170,7 +170,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D103
                         time_granularity=TimeGranularity.WEEK,
                         date_part=None,
                     ): (
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=SemanticModelReference("listings_source"),
                             dimension_type=DimensionType.TIME,
                             element_name="created_at",
@@ -234,7 +234,7 @@ def test_time_dimension_in_filter(  # noqa: D103
                         time_granularity=TimeGranularity.MONTH,
                         date_part=None,
                     ): (
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=SemanticModelReference("listings_source"),
                             dimension_type=DimensionType.CATEGORICAL,
                             element_name="created_at",
@@ -298,7 +298,7 @@ def test_time_dimension_with_grain_in_name(  # noqa: D103
                         time_granularity=TimeGranularity.MONTH,
                         date_part=None,
                     ): (
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=SemanticModelReference("listings_source"),
                             dimension_type=DimensionType.CATEGORICAL,
                             element_name="created_at",
@@ -363,7 +363,7 @@ def test_date_part_in_filter(  # noqa: D103
                         time_granularity=TimeGranularity.DAY,
                         date_part=DatePart.YEAR,
                     ): (
-                        LinkableDimension(
+                        LinkableDimension.create(
                             defined_in_semantic_model=SemanticModelReference("bookings"),
                             dimension_type=DimensionType.TIME,
                             element_name="metric_time",
@@ -431,7 +431,7 @@ def resolved_spec_lookup() -> FilterSpecResolutionLookUp:
                             time_granularity=TimeGranularity.WEEK,
                             date_part=DatePart.YEAR,
                         ): (
-                            LinkableDimension(
+                            LinkableDimension.create(
                                 defined_in_semantic_model=SemanticModelReference("bookings"),
                                 dimension_type=DimensionType.TIME,
                                 element_name="metric_time",
@@ -553,7 +553,7 @@ def test_entity_in_filter(  # noqa: D103
                         time_granularity=TimeGranularity.DAY,
                         date_part=DatePart.YEAR,
                     ): (
-                        LinkableEntity(
+                        LinkableEntity.create(
                             defined_in_semantic_model=SemanticModelReference("bookings"),
                             element_name="user",
                             entity_links=(EntityReference("listing"),),
@@ -606,7 +606,7 @@ def test_metric_in_filter(  # noqa: D103
                         date_part=None,
                         metric_subquery_entity_links=(EntityReference("listing"),),
                     ): (
-                        LinkableMetric(
+                        LinkableMetric.create(
                             properties=frozenset({LinkableElementProperty.METRIC, LinkableElementProperty.JOINED}),
                             join_path=SemanticModelToMetricSubqueryJoinPath(
                                 metric_subquery_join_path_element=MetricSubqueryJoinPathElement(
@@ -664,7 +664,7 @@ def test_dimension_time_dimension_parity(column_association_resolver: ColumnAsso
                                     time_granularity=TimeGranularity.DAY,
                                     date_part=DatePart.YEAR,
                                 ): (
-                                    LinkableDimension(
+                                    LinkableDimension.create(
                                         defined_in_semantic_model=SemanticModelReference("bookings"),
                                         dimension_type=DimensionType.TIME,
                                         element_name=METRIC_TIME_ELEMENT_NAME,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,7 +19,6 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=YEAR,
       ): (
         LinkableDimension(
+          properties=(DERIVED_TIME_GRANULARITY, METRIC_TIME),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,13 +19,10 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset(
-            'DERIVED_TIME_GRANULARITY',
-            'METRIC_TIME',
-          ),
           time_granularity=YEAR,
         ),
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='yearly_measure_source',
           ),
@@ -35,7 +33,6 @@ GroupByItemResolution(
               semantic_model_name='yearly_measure_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=YEAR,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,7 +19,6 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=YEAR,
       ): (
         LinkableDimension(
+          properties=(DERIVED_TIME_GRANULARITY, METRIC_TIME),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,13 +19,10 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset(
-            'DERIVED_TIME_GRANULARITY',
-            'METRIC_TIME',
-          ),
           time_granularity=YEAR,
         ),
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='yearly_measure_source',
           ),
@@ -35,7 +33,6 @@ GroupByItemResolution(
               semantic_model_name='yearly_measure_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=YEAR,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,7 +19,6 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=DAY,
       ): (
         LinkableDimension(
+          properties=(METRIC_TIME,),
           element_name='metric_time',
           dimension_type=TIME,
           join_path=SemanticModelJoinPath(
@@ -15,7 +16,6 @@ GroupByItemResolution(
               semantic_model_name='__VIRTUAL__',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=DAY,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
@@ -8,6 +8,7 @@ GroupByItemResolution(
         time_granularity=MONTH,
       ): (
         LinkableDimension(
+          properties=(METRIC_TIME,),
           defined_in_semantic_model=SemanticModelReference(
             semantic_model_name='monthly_measures_source',
           ),
@@ -18,7 +19,6 @@ GroupByItemResolution(
               semantic_model_name='monthly_measures_source',
             ),
           ),
-          properties=frozenset('METRIC_TIME',),
           time_granularity=MONTH,
         ),
       ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -54,6 +54,9 @@ ParseQueryResult(
                 ),
               ): (
                 LinkableDimension(
+                  properties=(
+                    LOCAL,
+                  ),
                   defined_in_semantic_model=SemanticModelReference(
                     semantic_model_name='bookings_source',
                   ),
@@ -68,9 +71,6 @@ ParseQueryResult(
                     left_semantic_model_reference=SemanticModelReference(
                       semantic_model_name='bookings_source',
                     ),
-                  ),
-                  properties=frozenset(
-                    'LOCAL',
                   ),
                 ),
               ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_derived_metrics_with_common_filtered_metric__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),
@@ -93,6 +93,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -102,9 +105,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_filter__result.txt
@@ -30,6 +30,10 @@ FilterSpecResolutionLookUp(
             time_granularity=YEAR,
           ): (
             LinkableDimension(
+              properties=(
+                DERIVED_TIME_GRANULARITY,
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -40,13 +44,12 @@ FilterSpecResolutionLookUp(
                   semantic_model_name='monthly_measures_source',
                 ),
               ),
-              properties=frozenset(
-                'DERIVED_TIME_GRANULARITY',
-                'METRIC_TIME',
-              ),
               time_granularity=YEAR,
             ),
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='yearly_measure_source',
               ),
@@ -56,9 +59,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='yearly_measure_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=YEAR,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_invalid_metric_input_filter__result.txt
@@ -30,6 +30,10 @@ FilterSpecResolutionLookUp(
             time_granularity=YEAR,
           ): (
             LinkableDimension(
+              properties=(
+                DERIVED_TIME_GRANULARITY,
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -40,13 +44,12 @@ FilterSpecResolutionLookUp(
                   semantic_model_name='monthly_measures_source',
                 ),
               ),
-              properties=frozenset(
-                'DERIVED_TIME_GRANULARITY',
-                'METRIC_TIME',
-              ),
               time_granularity=YEAR,
             ),
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='yearly_measure_source',
               ),
@@ -56,9 +59,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='yearly_measure_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=YEAR,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_filter__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_resolution_for_valid_metric_input_filter__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__accumulate_last_2_months_metric__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_different_parent_time_grains__result.txt
@@ -30,6 +30,10 @@ FilterSpecResolutionLookUp(
             time_granularity=YEAR,
           ): (
             LinkableDimension(
+              properties=(
+                DERIVED_TIME_GRANULARITY,
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -40,13 +44,12 @@ FilterSpecResolutionLookUp(
                   semantic_model_name='monthly_measures_source',
                 ),
               ),
-              properties=frozenset(
-                'DERIVED_TIME_GRANULARITY',
-                'METRIC_TIME',
-              ),
               time_granularity=YEAR,
             ),
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='yearly_measure_source',
               ),
@@ -56,9 +59,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='yearly_measure_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=YEAR,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__derived_metric_with_same_parent_time_grains__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_different_time_grains__result.txt
@@ -33,6 +33,10 @@ FilterSpecResolutionLookUp(
             time_granularity=YEAR,
           ): (
             LinkableDimension(
+              properties=(
+                DERIVED_TIME_GRANULARITY,
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -43,13 +47,12 @@ FilterSpecResolutionLookUp(
                   semantic_model_name='monthly_measures_source',
                 ),
               ),
-              properties=frozenset(
-                'DERIVED_TIME_GRANULARITY',
-                'METRIC_TIME',
-              ),
               time_granularity=YEAR,
             ),
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='yearly_measure_source',
               ),
@@ -59,9 +62,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='yearly_measure_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=YEAR,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__metrics_with_same_time_grains__result.txt
@@ -33,6 +33,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -42,9 +45,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_spec_lookup.py/str/test_filter_spec_resolution__simple_metric__result.txt
@@ -30,6 +30,9 @@ FilterSpecResolutionLookUp(
             time_granularity=MONTH,
           ): (
             LinkableDimension(
+              properties=(
+                METRIC_TIME,
+              ),
               defined_in_semantic_model=SemanticModelReference(
                 semantic_model_name='monthly_measures_source',
               ),
@@ -39,9 +42,6 @@ FilterSpecResolutionLookUp(
                 left_semantic_model_reference=SemanticModelReference(
                   semantic_model_name='monthly_measures_source',
                 ),
-              ),
-              properties=frozenset(
-                'METRIC_TIME',
               ),
               time_granularity=MONTH,
             ),

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -202,7 +202,7 @@ def test_filter_with_where_constraint_node(
                     ),
                 ),
                 linkable_elements=(
-                    LinkableDimension(
+                    LinkableDimension.create(
                         defined_in_semantic_model=SemanticModelReference("bookings_source"),
                         element_name="ds",
                         dimension_type=DimensionType.TIME,

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -32,6 +32,7 @@
                     <!--     bind_parameters=SqlBindParameters(),                         -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
+                    <!--         properties=(LOCAL,),                                     -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
@@ -43,7 +44,6 @@
                     <!--             semantic_model_name='listings_latest',               -->
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
-                    <!--         properties=frozenset('LOCAL',),                          -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -37,6 +37,7 @@
                     <!--     bind_parameters=SqlBindParameters(),                         -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
+                    <!--         properties=(LOCAL,),                                     -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
@@ -48,7 +49,6 @@
                     <!--             semantic_model_name='listings_latest',               -->
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
-                    <!--         properties=frozenset('LOCAL',),                          -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -53,6 +53,7 @@
                     <!--     bind_parameters=SqlBindParameters(),                        -->
                     <!--     linkable_elements=(                                         -->
                     <!--       LinkableDimension(                                        -->
+                    <!--         properties=(METRIC_TIME,),                              -->
                     <!--         defined_in_semantic_model=SemanticModelReference(       -->
                     <!--           semantic_model_name='bookings_source',                -->
                     <!--         ),                                                      -->
@@ -63,7 +64,6 @@
                     <!--             semantic_model_name='bookings_source',              -->
                     <!--           ),                                                    -->
                     <!--         ),                                                      -->
-                    <!--         properties=frozenset('METRIC_TIME',),                   -->
                     <!--         time_granularity=DAY,                                   -->
                     <!--       ),                                                        -->
                     <!--     ),                                                          -->
@@ -103,6 +103,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
+                                <!--         properties=(METRIC_TIME,),                              -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
@@ -113,7 +114,6 @@
                                 <!--             semantic_model_name='bookings_source',              -->
                                 <!--           ),                                                    -->
                                 <!--         ),                                                      -->
-                                <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -21,6 +21,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(JOINED,),                                   -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='listings_latest',                -->
                     <!--             ),                                                      -->
@@ -44,7 +45,6 @@
                     <!--                 ),                                                  -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('JOINED',),                        -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -80,6 +80,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(JOINED,),                                    -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='listings_latest',                 -->
                                 <!--         ),                                                       -->
@@ -101,7 +102,6 @@
                                 <!--             ),                                                   -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('JOINED',),                         -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -198,6 +198,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(JOINED,),                                   -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='listings_latest',                -->
                     <!--             ),                                                      -->
@@ -221,7 +222,6 @@
                     <!--                 ),                                                  -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('JOINED',),                        -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -257,6 +257,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(JOINED,),                                    -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='listings_latest',                 -->
                                 <!--         ),                                                       -->
@@ -278,7 +279,6 @@
                                 <!--             ),                                                   -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('JOINED',),                         -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -21,6 +21,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -34,7 +35,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -71,6 +71,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(LOCAL,),                                     -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='bookings_source',                 -->
                                 <!--         ),                                                       -->
@@ -82,7 +83,6 @@
                                 <!--             semantic_model_name='bookings_source',               -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('LOCAL',),                          -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -51,6 +51,7 @@
                 <!--         bind_parameters=SqlBindParameters(),                        -->
                 <!--         linkable_elements=(                                         -->
                 <!--           LinkableDimension(                                        -->
+                <!--             properties=(METRIC_TIME,),                              -->
                 <!--             defined_in_semantic_model=SemanticModelReference(       -->
                 <!--               semantic_model_name='bookings_source',                -->
                 <!--             ),                                                      -->
@@ -61,7 +62,6 @@
                 <!--                 semantic_model_name='bookings_source',              -->
                 <!--               ),                                                    -->
                 <!--             ),                                                      -->
-                <!--             properties=frozenset('METRIC_TIME',),                   -->
                 <!--             time_granularity=DAY,                                   -->
                 <!--           ),                                                        -->
                 <!--         ),                                                          -->
@@ -96,6 +96,7 @@
                             <!--     bind_parameters=SqlBindParameters(),                        -->
                             <!--     linkable_elements=(                                         -->
                             <!--       LinkableDimension(                                        -->
+                            <!--         properties=(METRIC_TIME,),                              -->
                             <!--         defined_in_semantic_model=SemanticModelReference(       -->
                             <!--           semantic_model_name='bookings_source',                -->
                             <!--         ),                                                      -->
@@ -106,7 +107,6 @@
                             <!--             semantic_model_name='bookings_source',              -->
                             <!--           ),                                                    -->
                             <!--         ),                                                      -->
-                            <!--         properties=frozenset('METRIC_TIME',),                   -->
                             <!--         time_granularity=DAY,                                   -->
                             <!--       ),                                                        -->
                             <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -54,6 +54,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(METRIC_TIME,),                                 -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -64,7 +65,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('METRIC_TIME',),                      -->
                     <!--             time_granularity=DAY,                                      -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
@@ -98,6 +98,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
+                                <!--         properties=(METRIC_TIME,),                              -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
@@ -108,7 +109,6 @@
                                 <!--             semantic_model_name='bookings_source',              -->
                                 <!--           ),                                                    -->
                                 <!--         ),                                                      -->
-                                <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->
@@ -170,6 +170,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(METRIC_TIME,),                              -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -180,7 +181,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('METRIC_TIME',),                   -->
                     <!--             time_granularity=DAY,                                   -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
@@ -213,6 +213,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                        -->
                                 <!--     linkable_elements=(                                         -->
                                 <!--       LinkableDimension(                                        -->
+                                <!--         properties=(METRIC_TIME,),                              -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                 <!--           semantic_model_name='bookings_source',                -->
                                 <!--         ),                                                      -->
@@ -223,7 +224,6 @@
                                 <!--             semantic_model_name='bookings_source',              -->
                                 <!--           ),                                                    -->
                                 <!--         ),                                                      -->
-                                <!--         properties=frozenset('METRIC_TIME',),                   -->
                                 <!--         time_granularity=DAY,                                   -->
                                 <!--       ),                                                        -->
                                 <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(JOINED,),                                    -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='listings_latest',                 -->
             <!--             ),                                                       -->
@@ -35,7 +36,6 @@
             <!--                 ),                                                   -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -75,6 +75,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(JOINED,),                                    -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='listings_latest',                 -->
                         <!--         ),                                                       -->
@@ -96,7 +97,6 @@
                         <!--             ),                                                   -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('JOINED',),                         -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -61,6 +61,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                        -->
                         <!--     linkable_elements=(                                         -->
                         <!--       LinkableDimension(                                        -->
+                        <!--         properties=(METRIC_TIME,),                              -->
                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
                         <!--           semantic_model_name='bookings_source',                -->
                         <!--         ),                                                      -->
@@ -71,7 +72,6 @@
                         <!--             semantic_model_name='bookings_source',              -->
                         <!--           ),                                                    -->
                         <!--         ),                                                      -->
-                        <!--         properties=frozenset('METRIC_TIME',),                   -->
                         <!--         time_granularity=DAY,                                   -->
                         <!--       ),                                                        -->
                         <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(JOINED,),                                    -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='listings_latest',                 -->
             <!--             ),                                                       -->
@@ -35,7 +36,6 @@
             <!--                 ),                                                   -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('JOINED',),                         -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -65,6 +65,7 @@
                     <!--     bind_parameters=SqlBindParameters(),                         -->
                     <!--     linkable_elements=(                                          -->
                     <!--       LinkableDimension(                                         -->
+                    <!--         properties=(JOINED,),                                    -->
                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                     <!--           semantic_model_name='listings_latest',                 -->
                     <!--         ),                                                       -->
@@ -86,7 +87,6 @@
                     <!--             ),                                                   -->
                     <!--           ),                                                     -->
                     <!--         ),                                                       -->
-                    <!--         properties=frozenset('JOINED',),                         -->
                     <!--       ),                                                         -->
                     <!--     ),                                                           -->
                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(LOCAL,),                                    -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='visits_source',                  -->
             <!--             ),                                                      -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='visits_source',                -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('LOCAL',),                         -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
             <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -70,6 +70,7 @@
                             <!--     bind_parameters=SqlBindParameters(),                        -->
                             <!--     linkable_elements=(                                         -->
                             <!--       LinkableDimension(                                        -->
+                            <!--         properties=(LOCAL,),                                    -->
                             <!--         defined_in_semantic_model=SemanticModelReference(       -->
                             <!--           semantic_model_name='visits_source',                  -->
                             <!--         ),                                                      -->
@@ -81,7 +82,6 @@
                             <!--             semantic_model_name='visits_source',                -->
                             <!--           ),                                                    -->
                             <!--         ),                                                      -->
-                            <!--         properties=frozenset('LOCAL',),                         -->
                             <!--       ),                                                        -->
                             <!--     ),                                                          -->
                             <!--     linkable_spec_set=LinkableSpecSet(                          -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(LOCAL,),                                    -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='visits_source',                  -->
             <!--             ),                                                      -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='visits_source',                -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('LOCAL',),                         -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
             <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -112,6 +112,7 @@
                                         <!--     bind_parameters=SqlBindParameters(),                        -->
                                         <!--     linkable_elements=(                                         -->
                                         <!--       LinkableDimension(                                        -->
+                                        <!--         properties=(LOCAL,),                                    -->
                                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                         <!--           semantic_model_name='visits_source',                  -->
                                         <!--         ),                                                      -->
@@ -127,7 +128,6 @@
                                         <!--             semantic_model_name='visits_source',                -->
                                         <!--           ),                                                    -->
                                         <!--         ),                                                      -->
-                                        <!--         properties=frozenset('LOCAL',),                         -->
                                         <!--       ),                                                        -->
                                         <!--     ),                                                          -->
                                         <!--     linkable_spec_set=LinkableSpecSet(                          -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -66,6 +66,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -77,7 +78,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -113,6 +113,7 @@
                                         <!--     bind_parameters=SqlBindParameters(),                        -->
                                         <!--     linkable_elements=(                                         -->
                                         <!--       LinkableDimension(                                        -->
+                                        <!--         properties=(LOCAL,),                                    -->
                                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                         <!--           semantic_model_name='bookings_source',                -->
                                         <!--         ),                                                      -->
@@ -128,7 +129,6 @@
                                         <!--             semantic_model_name='bookings_source',              -->
                                         <!--           ),                                                    -->
                                         <!--         ),                                                      -->
-                                        <!--         properties=frozenset('LOCAL',),                         -->
                                         <!--       ),                                                        -->
                                         <!--     ),                                                          -->
                                         <!--     linkable_spec_set=LinkableSpecSet(                          -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -123,6 +123,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -134,7 +135,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -242,6 +242,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -255,7 +256,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -309,6 +309,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -320,7 +321,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -166,6 +166,7 @@
                                                 <!--     bind_parameters=SqlBindParameters(),                        -->
                                                 <!--     linkable_elements=(                                         -->
                                                 <!--       LinkableDimension(                                        -->
+                                                <!--         properties=(LOCAL,),                                    -->
                                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                                 <!--           semantic_model_name='bookings_source',                -->
                                                 <!--         ),                                                      -->
@@ -181,7 +182,6 @@
                                                 <!--             semantic_model_name='bookings_source',              -->
                                                 <!--           ),                                                    -->
                                                 <!--         ),                                                      -->
-                                                <!--         properties=frozenset('LOCAL',),                         -->
                                                 <!--       ),                                                        -->
                                                 <!--     ),                                                          -->
                                                 <!--     linkable_spec_set=LinkableSpecSet(                          -->
@@ -246,6 +246,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -259,7 +260,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -313,6 +313,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -324,7 +325,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -98,6 +98,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -109,7 +110,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -148,6 +148,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -159,7 +160,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -267,6 +267,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -280,7 +281,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -309,6 +309,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -320,7 +321,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -359,6 +359,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -370,7 +371,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -98,6 +98,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -109,7 +110,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -191,6 +191,7 @@
                                                 <!--     bind_parameters=SqlBindParameters(),                        -->
                                                 <!--     linkable_elements=(                                         -->
                                                 <!--       LinkableDimension(                                        -->
+                                                <!--         properties=(LOCAL,),                                    -->
                                                 <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                                 <!--           semantic_model_name='bookings_source',                -->
                                                 <!--         ),                                                      -->
@@ -206,7 +207,6 @@
                                                 <!--             semantic_model_name='bookings_source',              -->
                                                 <!--           ),                                                    -->
                                                 <!--         ),                                                      -->
-                                                <!--         properties=frozenset('LOCAL',),                         -->
                                                 <!--       ),                                                        -->
                                                 <!--     ),                                                          -->
                                                 <!--     linkable_spec_set=LinkableSpecSet(                          -->
@@ -271,6 +271,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -284,7 +285,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -313,6 +313,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -324,7 +325,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -363,6 +363,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -374,7 +375,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -113,6 +113,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(LOCAL,),                                     -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='bookings_source',                 -->
                                 <!--         ),                                                       -->
@@ -124,7 +125,6 @@
                                 <!--             semantic_model_name='bookings_source',               -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('LOCAL',),                          -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->
@@ -231,6 +231,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -244,7 +245,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -288,6 +288,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(LOCAL,),                                     -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='bookings_source',                 -->
                                 <!--         ),                                                       -->
@@ -299,7 +300,6 @@
                                 <!--             semantic_model_name='bookings_source',               -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('LOCAL',),                          -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -58,6 +58,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                        -->
                     <!--         linkable_elements=(                                         -->
                     <!--           LinkableDimension(                                        -->
+                    <!--             properties=(LOCAL,),                                    -->
                     <!--             defined_in_semantic_model=SemanticModelReference(       -->
                     <!--               semantic_model_name='bookings_source',                -->
                     <!--             ),                                                      -->
@@ -71,7 +72,6 @@
                     <!--                 semantic_model_name='bookings_source',              -->
                     <!--               ),                                                    -->
                     <!--             ),                                                      -->
-                    <!--             properties=frozenset('LOCAL',),                         -->
                     <!--           ),                                                        -->
                     <!--         ),                                                          -->
                     <!--         linkable_spec_set=LinkableSpecSet(                          -->
@@ -155,6 +155,7 @@
                                             <!--     bind_parameters=SqlBindParameters(),                        -->
                                             <!--     linkable_elements=(                                         -->
                                             <!--       LinkableDimension(                                        -->
+                                            <!--         properties=(LOCAL,),                                    -->
                                             <!--         defined_in_semantic_model=SemanticModelReference(       -->
                                             <!--           semantic_model_name='bookings_source',                -->
                                             <!--         ),                                                      -->
@@ -170,7 +171,6 @@
                                             <!--             semantic_model_name='bookings_source',              -->
                                             <!--           ),                                                    -->
                                             <!--         ),                                                      -->
-                                            <!--         properties=frozenset('LOCAL',),                         -->
                                             <!--       ),                                                        -->
                                             <!--     ),                                                          -->
                                             <!--     linkable_spec_set=LinkableSpecSet(                          -->
@@ -233,6 +233,7 @@
                     <!--         bind_parameters=SqlBindParameters(),                           -->
                     <!--         linkable_elements=(                                            -->
                     <!--           LinkableDimension(                                           -->
+                    <!--             properties=(LOCAL,),                                       -->
                     <!--             defined_in_semantic_model=SemanticModelReference(          -->
                     <!--               semantic_model_name='bookings_source',                   -->
                     <!--             ),                                                         -->
@@ -246,7 +247,6 @@
                     <!--                 semantic_model_name='bookings_source',                 -->
                     <!--               ),                                                       -->
                     <!--             ),                                                         -->
-                    <!--             properties=frozenset('LOCAL',),                            -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
                     <!--         linkable_spec_set=LinkableSpecSet(                             -->
@@ -290,6 +290,7 @@
                                 <!--     bind_parameters=SqlBindParameters(),                         -->
                                 <!--     linkable_elements=(                                          -->
                                 <!--       LinkableDimension(                                         -->
+                                <!--         properties=(LOCAL,),                                     -->
                                 <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                 <!--           semantic_model_name='bookings_source',                 -->
                                 <!--         ),                                                       -->
@@ -301,7 +302,6 @@
                                 <!--             semantic_model_name='bookings_source',               -->
                                 <!--           ),                                                     -->
                                 <!--         ),                                                       -->
-                                <!--         properties=frozenset('LOCAL',),                          -->
                                 <!--       ),                                                         -->
                                 <!--     ),                                                           -->
                                 <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -65,6 +65,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                         -->
                         <!--     linkable_elements=(                                          -->
                         <!--       LinkableDimension(                                         -->
+                        <!--         properties=(LOCAL,),                                     -->
                         <!--         defined_in_semantic_model=SemanticModelReference(        -->
                         <!--           semantic_model_name='bookings_source',                 -->
                         <!--         ),                                                       -->
@@ -76,7 +77,6 @@
                         <!--             semantic_model_name='bookings_source',               -->
                         <!--           ),                                                     -->
                         <!--         ),                                                       -->
-                        <!--         properties=frozenset('LOCAL',),                          -->
                         <!--       ),                                                         -->
                         <!--     ),                                                           -->
                         <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                         -->
             <!--         linkable_elements=(                                          -->
             <!--           LinkableDimension(                                         -->
+            <!--             properties=(LOCAL,),                                     -->
             <!--             defined_in_semantic_model=SemanticModelReference(        -->
             <!--               semantic_model_name='bookings_source',                 -->
             <!--             ),                                                       -->
@@ -25,7 +26,6 @@
             <!--                 semantic_model_name='bookings_source',               -->
             <!--               ),                                                     -->
             <!--             ),                                                       -->
-            <!--             properties=frozenset('LOCAL',),                          -->
             <!--           ),                                                         -->
             <!--         ),                                                           -->
             <!--         linkable_spec_set=LinkableSpecSet(                           -->
@@ -101,6 +101,7 @@
                                     <!--     bind_parameters=SqlBindParameters(),                         -->
                                     <!--     linkable_elements=(                                          -->
                                     <!--       LinkableDimension(                                         -->
+                                    <!--         properties=(LOCAL,),                                     -->
                                     <!--         defined_in_semantic_model=SemanticModelReference(        -->
                                     <!--           semantic_model_name='bookings_source',                 -->
                                     <!--         ),                                                       -->
@@ -112,7 +113,6 @@
                                     <!--             semantic_model_name='bookings_source',               -->
                                     <!--           ),                                                     -->
                                     <!--         ),                                                       -->
-                                    <!--         properties=frozenset('LOCAL',),                          -->
                                     <!--       ),                                                         -->
                                     <!--     ),                                                           -->
                                     <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -61,6 +61,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                        -->
                         <!--     linkable_elements=(                                         -->
                         <!--       LinkableDimension(                                        -->
+                        <!--         properties=(METRIC_TIME,),                              -->
                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
                         <!--           semantic_model_name='bookings_source',                -->
                         <!--         ),                                                      -->
@@ -71,7 +72,6 @@
                         <!--             semantic_model_name='bookings_source',              -->
                         <!--           ),                                                    -->
                         <!--         ),                                                      -->
-                        <!--         properties=frozenset('METRIC_TIME',),                   -->
                         <!--         time_granularity=DAY,                                   -->
                         <!--       ),                                                        -->
                         <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
@@ -14,6 +14,7 @@
             <!--         bind_parameters=SqlBindParameters(),                        -->
             <!--         linkable_elements=(                                         -->
             <!--           LinkableDimension(                                        -->
+            <!--             properties=(METRIC_TIME,),                              -->
             <!--             defined_in_semantic_model=SemanticModelReference(       -->
             <!--               semantic_model_name='bookings_source',                -->
             <!--             ),                                                      -->
@@ -24,7 +25,6 @@
             <!--                 semantic_model_name='bookings_source',              -->
             <!--               ),                                                    -->
             <!--             ),                                                      -->
-            <!--             properties=frozenset('METRIC_TIME',),                   -->
             <!--             time_granularity=DAY,                                   -->
             <!--           ),                                                        -->
             <!--         ),                                                          -->
@@ -61,6 +61,7 @@
                         <!--     bind_parameters=SqlBindParameters(),                        -->
                         <!--     linkable_elements=(                                         -->
                         <!--       LinkableDimension(                                        -->
+                        <!--         properties=(METRIC_TIME,),                              -->
                         <!--         defined_in_semantic_model=SemanticModelReference(       -->
                         <!--           semantic_model_name='bookings_source',                -->
                         <!--         ),                                                      -->
@@ -71,7 +72,6 @@
                         <!--             semantic_model_name='bookings_source',              -->
                         <!--           ),                                                    -->
                         <!--         ),                                                      -->
-                        <!--         properties=frozenset('METRIC_TIME',),                   -->
                         <!--         time_granularity=DAY,                                   -->
                         <!--       ),                                                        -->
                         <!--     ),                                                          -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -53,6 +53,7 @@
                             <!--     bind_parameters=SqlBindParameters(),                         -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
+                            <!--         properties=(LOCAL,),                                     -->
                             <!--         defined_in_semantic_model=SemanticModelReference(        -->
                             <!--           semantic_model_name='bookings_source',                 -->
                             <!--         ),                                                       -->
@@ -64,7 +65,6 @@
                             <!--             semantic_model_name='bookings_source',               -->
                             <!--           ),                                                     -->
                             <!--         ),                                                       -->
-                            <!--         properties=frozenset('LOCAL',),                          -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--     linkable_spec_set=LinkableSpecSet(                           -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -53,6 +53,7 @@
                             <!--     bind_parameters=SqlBindParameters(),                         -->
                             <!--     linkable_elements=(                                          -->
                             <!--       LinkableDimension(                                         -->
+                            <!--         properties=(LOCAL,),                                     -->
                             <!--         defined_in_semantic_model=SemanticModelReference(        -->
                             <!--           semantic_model_name='bookings_source',                 -->
                             <!--         ),                                                       -->
@@ -64,7 +65,6 @@
                             <!--             semantic_model_name='bookings_source',               -->
                             <!--           ),                                                     -->
                             <!--         ),                                                       -->
-                            <!--         properties=frozenset('LOCAL',),                          -->
                             <!--       ),                                                         -->
                             <!--     ),                                                           -->
                             <!--     linkable_spec_set=LinkableSpecSet(                           -->


### PR DESCRIPTION
Currently, serialization of sets is not supported so this PR changes the `properties` field of a few `LinkableElement` related classes to a tuple-based implementation.