### PR TITLE
Updated error message for validation tasks

### DIFF
--- a/metricflow/validation/data_warehouse_model_validator.py
+++ b/metricflow/validation/data_warehouse_model_validator.py
@@ -238,7 +238,7 @@ class DataWarehouseTaskBuilder:
                             ),
                             element_type=SemanticModelElementType.DIMENSION,
                         ),
-                        error_message=f"Unable to query dimension `{spec.element_name}` on semantic model `{semantic_model.name}` in data warehouse",
+                        error_message=f"Unable to query dimension `{spec.qualified_name}` on semantic model `{semantic_model.name}` in data warehouse",
                     )
                 )
 


### PR DESCRIPTION
## Context
Currently, in dwh validations for dimensions, we query all the dimensions in 1 query and if that fails we attempt to query each dimension one by one. However, with time dimension, we end up querying multiple variants of a singular dimension (ie., `ordered_at` expands to querying `ordered_at__week`, `ordered_at__month`, etc...), but the error message only used the element_ment. This meant in the error, we ended up seeing "duplicates", but it was actually just querying each one of those variants. With this, we should use the qualfiied name to see what we're actually querying for

#### Example:
<img width="801" alt="Screenshot 2024-07-15 at 10 33 32 PM" src="https://github.com/user-attachments/assets/3bce8e55-49f9-43b7-9910-8076249b0eda">
