### PR TITLE
Update `mf_pformat_many()` to return a more compact representation

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -466,5 +466,5 @@ def mf_pformat_many(  # type: ignore
             ),
         )
         item_block = "\n".join(item_block_lines)
-        lines.append(item_block)
-    return "\n\n".join(lines)
+        lines.append(indent(item_block))
+    return "\n".join(lines)

--- a/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
@@ -141,12 +141,10 @@ def test_pformat_many() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              (1, 2, 3)
-
-            object_1:
-              {4: 5}
+              object_0:
+                (1, 2, 3)
+              object_1:
+                {4: 5}
             """
         ).rstrip()
         == result
@@ -160,10 +158,9 @@ def test_pformat_many_with_raw_strings() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              foo
-              bar
+              object_0:
+                foo
+                bar
             """
         ).rstrip()
         == result
@@ -176,9 +173,8 @@ def test_pformat_many_with_strings() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              'foo\\nbar'
+              object_0:
+                'foo\\nbar'
             """
         ).rstrip()
         == result


### PR DESCRIPTION
As per title.