### PR TITLE
Enable tag-based deployment for dbt-metricflow

### DIFF
--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -1,9 +1,10 @@
-name: Publish Metricflow Release
+name: Publish dbt-metricflow Release
 on:
   workflow_dispatch:
   push:
+    # Tag format is <package>/v<pep440_semantic_version>
     tags:
-      - "*"
+      - "dbt-metricflow/v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   PYTHON_VERSION: "3.8"
@@ -21,8 +22,6 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `metricflow`
+      - name: Hatch Publish `dbt-metricflow`
+        working-directory: ./dbt-metricflow
         run: hatch build && hatch publish
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -1,0 +1,30 @@
+name: Publish Metricflow Release
+on:
+  workflow_dispatch:
+  push:
+    # MetricFlow historically tagged releases with v<pep440_semantic_version>
+    # We restrict to this for now and assume any tag without a package identifier is MetricFlow itself
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+env:
+  PYTHON_VERSION: "3.8"
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment: Pypi Publish
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Hatch Publish `metricflow`
+        run: hatch build && hatch publish
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
We need to be able to start deploying dbt-metricflow via tags that
trigger a deployment action instead of relying on manual deployment.

This is necessary for two reasons:

1. The MetricFlow repository is evolving to allow for multiple
package deployments in distinctive ways, and each package would benefit
from a set of pre-deployment steps.
2. With the CLI now bundled with dbt-metricflow we  need a structured way
of adding and deploying patch fixes for versions that are too far
behind the current repo main branch to deploy off of main.

Therefore, this PR splits our PyPI deployment action into two separate
versions with different tag-format triggers, one for MetricFlow and
the other for dbt-metricflow. Authentication for dbt-metricflow will
be managed via PyPI's Trusted Publisher mechanism. MetricFlow will
follow suit once the relevant PyPI enrollments are ready.

Note these are separate files with some duplication here, but it's minimal,
and we expect further divergence over time as we develop package-specific
pre-deployment tests for these packages.
