### PR TITLE
Remove access token reference for PyPI

### DIFF
--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -25,6 +25,3 @@ jobs:
 
       - name: Hatch Publish `metricflow`
         run: hatch build && hatch publish
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
We have changed authentication methods for PyPI to a more secure
approach, so we no longer have to store an access token in GitHub
secrets. This removes the in-code references so we can delete
the secrets themselves.
