### PR TITLE
Backport: Add Column Header to the exported CSV from query command

### DIFF
--- a/.changes/unreleased/Fixes-20240716-090114.yaml
+++ b/.changes/unreleased/Fixes-20240716-090114.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Add Column header to the exported CSV from query command
+time: 2024-07-16T09:01:14.102978+05:30
+custom:
+    Author: saurabh0402
+    Issue: 1285,1313

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -340,6 +340,7 @@ def query(
         elif csv is not None:
             # csv is a LazyFile that is file-like that works in this case.
             csv_writer = csv_module.writer(csv)
+            csv_writer.writerow(df.column_names)
             for row in df.rows:
                 csv_writer.writerow(row)
             click.echo(f"🖨 Successfully written query output to {csv.name}")


### PR DESCRIPTION
This PR is a backport of #1313 to dbt-metricflow 0.7.x

This will allow us to deploy @saurabh0402's fix for the following issue:

https://github.com/dbt-labs/metricflow/issues/1285

Note - efficacy was tested via the CLI by running hatch build and doing a pip install
of the build package into a clean VM, and running `mf query` with the `--csv` flag
enabled.