### PR TITLE
Enable Trusted Publishing for PyPI actions

### DIFF
--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -32,3 +32,5 @@ jobs:
 
       - name: Publish `dbt-metricflow` package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dbt-metricflow/dist/

--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -12,7 +12,11 @@ env:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
-    environment: Pypi Publish
+    environment:
+      name: Pypi Publish
+      url: https://pypi.org/p/dbt-metricflow
+    permissions:
+      id-token: write
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -22,6 +26,9 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `dbt-metricflow`
+      - name: Build `dbt-metricflow` package
         working-directory: ./dbt-metricflow
-        run: hatch build && hatch publish
+        run: hatch build
+
+      - name: Publish `dbt-metricflow` package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -13,7 +13,11 @@ env:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
-    environment: Pypi Publish
+    environment:
+      name: Pypi Publish
+      url: https://pypi.org/p/metricflow
+    permissions:
+      id-token: write
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -23,5 +27,8 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `metricflow`
-        run: hatch build && hatch publish
+      - name: Build `metricflow` package
+        run: hatch build
+
+      - name: Publish `metricflow` package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
In order to use Trusted Publishing we have to do some special things.

Most of these things have been abstracted away through the official
action plugin provided by the Python Packaging Authority.

This change simply conforms our actions configs with the requirements
for the plugin. Specifically, providing the `id-token: write` permission
and the target URL for publication in the relevant environment config.
