### PR TITLE
Backport publishing actions enabling tag deployment for dbt-metricflow

### DIFF
--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -12,7 +12,11 @@ env:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
-    environment: Pypi Publish
+    environment:
+      name: Pypi Publish
+      url: https://pypi.org/p/dbt-metricflow
+    permissions:
+      id-token: write
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -22,6 +26,11 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `dbt-metricflow`
+      - name: Build `dbt-metricflow` package
         working-directory: ./dbt-metricflow
-        run: hatch build && hatch publish
+        run: hatch build
+
+      - name: Publish `dbt-metricflow` package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./dbt-metricflow/dist/

--- a/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-dbt-metricflow-to-pypi.yaml
@@ -1,9 +1,10 @@
-name: Publish Metricflow Release
+name: Publish dbt-metricflow Release
 on:
   workflow_dispatch:
   push:
+    # Tag format is <package>/v<pep440_semantic_version>
     tags:
-      - "*"
+      - "dbt-metricflow/v[0-9]+.[0-9]+.[0-9]+*"
 
 env:
   PYTHON_VERSION: "3.8"
@@ -21,8 +22,6 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `metricflow`
+      - name: Hatch Publish `dbt-metricflow`
+        working-directory: ./dbt-metricflow
         run: hatch build && hatch publish
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -13,7 +13,11 @@ env:
 jobs:
   pypi-publish:
     runs-on: ubuntu-latest
-    environment: Pypi Publish
+    environment:
+      name: Pypi Publish
+      url: https://pypi.org/p/metricflow
+    permissions:
+      id-token: write
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
@@ -23,5 +27,8 @@ jobs:
         with:
           python-version: "${{ env.PYTHON_VERSION }}"
 
-      - name: Hatch Publish `metricflow`
-        run: hatch build && hatch publish
+      - name: Build `metricflow` package
+        run: hatch build
+
+      - name: Publish `metricflow` package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -1,0 +1,30 @@
+name: Publish Metricflow Release
+on:
+  workflow_dispatch:
+  push:
+    # MetricFlow historically tagged releases with v<pep440_semantic_version>
+    # We restrict to this for now and assume any tag without a package identifier is MetricFlow itself
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+env:
+  PYTHON_VERSION: "3.8"
+
+jobs:
+  pypi-publish:
+    runs-on: ubuntu-latest
+    environment: Pypi Publish
+    steps:
+      - name: Check-out the repo
+        uses: actions/checkout@v3
+
+      - name: Setup Python ${{ env.PYTHON_VERSION }} Environment
+        uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "${{ env.PYTHON_VERSION }}"
+
+      - name: Hatch Publish `metricflow`
+        run: hatch build && hatch publish
+        env:
+          HATCH_INDEX_USER: __token__
+          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/cd-push-metricflow-to-pypi.yaml
+++ b/.github/workflows/cd-push-metricflow-to-pypi.yaml
@@ -25,6 +25,3 @@ jobs:
 
       - name: Hatch Publish `metricflow`
         run: hatch build && hatch publish
-        env:
-          HATCH_INDEX_USER: __token__
-          HATCH_INDEX_AUTH: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Backport of three PRs required to enable tag-based deployment from the 
`support/dbt-metricflow-0.7.x` branch. Specifically:

- **Enable tag-based deployment for dbt-metricflow (#1349)**
- **Remove access token reference for PyPI (#1350)**
- **Enable Trusted Publishing for PyPI actions (#1356)**
