### PR TITLE
Update dbt-metricflow version to 0.7.1

### DIFF
--- a/dbt-metricflow/pyproject.toml
+++ b/dbt-metricflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dbt-metricflow"
-version = "0.7.0"
+version = "0.7.1"
 description = "Execute commands against the MetricFlow semantic layer with dbt."
 readme = "README.md"
 requires-python = ">=3.8,<3.13"


### PR DESCRIPTION
This update will be deployed as a patch release on the 0.7.0 minor
version.

This was tested by building locally and installing the build
to run a sequence of CLI commands.