### PR TITLE
Bug fix: allow multiple metric input measures with the same spec

### DIFF
--- a/.changes/unreleased/Fixes-20240821-111857.yaml
+++ b/.changes/unreleased/Fixes-20240821-111857.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Allow metrics with matching input measures where one is cumulative and one is
+  not.
+time: 2024-08-21T11:18:57.795215-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1374"

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -640,12 +640,15 @@ class UpdateMeasureFillNullsWith(InstanceSetTransform[InstanceSet]):
         """Update all measure instances with the corresponding fill_nulls_with value."""
         updated_instances: List[MeasureInstance] = []
         for instance in measure_instances:
-            matches = [spec for spec in self.metric_input_measure_specs if spec.measure_spec == instance.spec]
-            assert len(matches) == 1, f"Matched with {matches} for measure instance {instance}. "
-            "We should always have 1 direct match for each measure instance and input measure."
+            # There might be multiple matching specs, but they'll all have the same fill_nulls_with value so we can use any of them.
+            matching_specs = [spec for spec in self.metric_input_measure_specs if spec.measure_spec == instance.spec]
+            assert (
+                len(matching_specs) >= 1
+            ), f"Found no matching input measure spec for measure instance {instance}. Something has been misconfigured."
+
             measure_spec = MeasureSpec(
                 element_name=instance.spec.element_name,
-                fill_nulls_with=matches[0].fill_nulls_with,
+                fill_nulls_with=matching_specs[0].fill_nulls_with,
                 non_additive_dimension_spec=instance.spec.non_additive_dimension_spec,
             )
             updated_instances.append(


### PR DESCRIPTION
Fixes a bug that a user encountered yesterday, which triggered our alerts. This query was for a ratio metric `users_created / users_created_cumulative`, a perfectly valid metric. The input measure specs were the same, but the input measure INSTANCES had different `cumulative_descriptions` (one is cumulative and one is not).

If interested, see the alert and DD links here: https://dbt-labs.slack.com/archives/C05D1MF1N4Q/p1724196314740709