### PR TITLE
Improve branch combining logic for `AggregateMeasuresNode`

### DIFF
--- a/.changes/unreleased/Features-20240821-112601.yaml
+++ b/.changes/unreleased/Features-20240821-112601.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Support combining AggregateMeasuresNodes where metric input measures have aliases,
+  so long as there are no duplicates.
+time: 2024-08-21T11:26:01.714888-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1375"


### PR DESCRIPTION
There was a TODO in here to improve this logic, and it seemed pretty simple so I snagged it.
Previously, if there were aliases in any metric input measures, we would avoid trying to combine the `AggregateMeasuresNodes`. The comment clarified that the scenario we were trying to avoid was a case where different measures used the same alias. To make this more specific, I updated the logic to only skip combining nodes if duplicate aliases were found in the input measures.