### PR TITLE
Remove `from_name` methods on spec classes

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -242,10 +242,12 @@ class SemanticModelLookup:
             semantic_models_for_dimension = self._dimension_index.get(dim.reference, []) + [semantic_model]
             self._dimension_index[dim.reference] = semantic_models_for_dimension
 
-            assert StructuredLinkableSpecName.from_name(dim.name).is_element_name, (
-                f"Dimension name `{dim.name}` contains annotations, but this name should be the plain element name "
-                "from the original model. This should have been blocked by validation!"
-            )
+            if not StructuredLinkableSpecName.from_name(dim.name).is_element_name:
+                # TODO: [custom granularity] change this to an assertion once we're sure there aren't exceptions
+                logger.warning(
+                    f"Dimension name `{dim.name}` contains annotations, but this name should be the plain element name "
+                    "from the original model. This should have been blocked by validation!"
+                )
 
             # TODO: Construct these specs correctly. All of the time dimension specs have the default granularity
             self._dimension_ref_to_spec[dim.time_dimension_reference or dim.reference] = (

--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -104,3 +104,8 @@ class StructuredLinkableSpecName:
         return StructuredLinkableSpecName(
             entity_link_names=self.entity_link_names, element_name=self.element_name
         ).qualified_name
+
+    @property
+    def is_element_name(self) -> bool:
+        """Indicates whether or not this is an unadorned element name, i.e., one without links or time annotations."""
+        return self.qualified_name == self.element_name

--- a/metricflow-semantics/metricflow_semantics/specs/dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/dimension_spec.py
@@ -8,7 +8,6 @@ from dbt_semantic_interfaces.references import DimensionReference, EntityReferen
 from typing_extensions import override
 
 from metricflow_semantics.model.semantics.linkable_element import ElementPathKey, LinkableElementType
-from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.specs.instance_spec import InstanceSpecVisitor, LinkableInstanceSpec
 from metricflow_semantics.visitor import VisitorOutputT
 
@@ -30,15 +29,6 @@ class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
     @staticmethod
     def from_linkable(spec: LinkableInstanceSpec) -> DimensionSpec:  # noqa: D102
         return DimensionSpec(element_name=spec.element_name, entity_links=spec.entity_links)
-
-    @staticmethod
-    def from_name(name: str) -> DimensionSpec:
-        """Construct from a name e.g. listing__ds__month."""
-        parsed_name = StructuredLinkableSpecName.from_name(name)
-        return DimensionSpec(
-            entity_links=tuple([EntityReference(idl) for idl in parsed_name.entity_link_names]),
-            element_name=parsed_name.element_name,
-        )
 
     @property
     def reference(self) -> DimensionReference:  # noqa: D102

--- a/metricflow-semantics/metricflow_semantics/specs/entity_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/entity_spec.py
@@ -8,7 +8,6 @@ from dbt_semantic_interfaces.references import EntityReference
 from typing_extensions import override
 
 from metricflow_semantics.model.semantics.linkable_element import ElementPathKey, LinkableElementType
-from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.specs.instance_spec import InstanceSpecVisitor, LinkableInstanceSpec
 from metricflow_semantics.visitor import VisitorOutputT
 
@@ -31,14 +30,6 @@ class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
         eg as a prefix to a DimensionSpec's entity links to when a join is occurring via this entity
         """
         return (EntityReference(element_name=self.element_name),) + self.entity_links
-
-    @staticmethod
-    def from_name(name: str) -> EntitySpec:  # noqa: D102
-        structured_name = StructuredLinkableSpecName.from_name(name)
-        return EntitySpec(
-            entity_links=tuple(EntityReference(idl) for idl in structured_name.entity_link_names),
-            element_name=structured_name.element_name,
-        )
 
     def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         if not isinstance(other, EntitySpec):

--- a/metricflow-semantics/metricflow_semantics/specs/measure_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/measure_spec.py
@@ -22,11 +22,6 @@ class MeasureSpec(InstanceSpec):  # noqa: D101
     fill_nulls_with: Optional[int] = None
 
     @staticmethod
-    def from_name(name: str) -> MeasureSpec:
-        """Construct from a name e.g. listing__ds__month."""
-        return MeasureSpec(element_name=name)
-
-    @staticmethod
     def from_reference(reference: MeasureReference) -> MeasureSpec:
         """Initialize from a measure reference instance."""
         return MeasureSpec(element_name=reference.element_name)

--- a/metricflow-semantics/metricflow_semantics/specs/metadata_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/metadata_spec.py
@@ -21,9 +21,5 @@ class MetadataSpec(InstanceSpec):
     def qualified_name(self) -> str:  # noqa: D102
         return f"{self.element_name}{DUNDER}{self.agg_type.value}" if self.agg_type else self.element_name
 
-    @staticmethod
-    def from_name(name: str, agg_type: Optional[AggregationType] = None) -> MetadataSpec:  # noqa: D102
-        return MetadataSpec(element_name=name, agg_type=agg_type)
-
     def accept(self, visitor: InstanceSpecVisitor[VisitorOutputT]) -> VisitorOutputT:  # noqa: D102
         return visitor.visit_metadata_spec(self)

--- a/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
@@ -7,6 +7,7 @@ from typing import Any, Sequence, Tuple
 from dbt_semantic_interfaces.dataclass_serialization import SerializableDataclass
 from dbt_semantic_interfaces.type_enums import AggregationType, TimeGranularity
 
+from metricflow_semantics.naming.linkable_spec_name import DUNDER
 from metricflow_semantics.specs.entity_spec import LinklessEntitySpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
@@ -33,6 +34,13 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
     window_choice: AggregationType
     window_groupings: Tuple[str, ...] = ()
 
+    def __post_init__(self) -> None:
+        """Post init validator to ensure names with double-underscores are not allowed."""
+        assert self.name.find(DUNDER) == -1, (
+            f"Non-additive dimension spec references a dimension name `{self.name}`, with added annotations, but it "
+            "should be a simple element name reference. This should have been blocked by model validation!"
+        )
+
     @property
     def bucket_hash(self) -> str:
         """Returns the hash value used for grouping equivalent params."""
@@ -43,9 +51,9 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
     def linkable_specs(  # noqa: D102
         self, non_additive_dimension_grain: TimeGranularity
     ) -> Sequence[LinkableInstanceSpec]:
-        return (TimeDimensionSpec.from_name(self.name).with_grain(non_additive_dimension_grain),) + tuple(
-            LinklessEntitySpec.from_element_name(entity_name) for entity_name in self.window_groupings
-        )
+        return (
+            TimeDimensionSpec(element_name=self.name, entity_links=(), time_granularity=non_additive_dimension_grain),
+        ) + tuple(LinklessEntitySpec.from_element_name(entity_name) for entity_name in self.window_groupings)
 
     def __eq__(self, other: Any) -> bool:  # type: ignore[misc]  # noqa: D105
         if not isinstance(other, NonAdditiveDimensionSpec):

--- a/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/non_additive_dimension_spec.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from hashlib import sha1
 from typing import Any, Sequence, Tuple
@@ -12,6 +13,8 @@ from metricflow_semantics.specs.entity_spec import LinklessEntitySpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.sql.sql_column_type import SqlColumnType
+
+logger = logging.getLogger(__file__)
 
 
 def hash_items(items: Sequence[SqlColumnType]) -> str:
@@ -36,10 +39,12 @@ class NonAdditiveDimensionSpec(SerializableDataclass):
 
     def __post_init__(self) -> None:
         """Post init validator to ensure names with double-underscores are not allowed."""
-        assert self.name.find(DUNDER) == -1, (
-            f"Non-additive dimension spec references a dimension name `{self.name}`, with added annotations, but it "
-            "should be a simple element name reference. This should have been blocked by model validation!"
-        )
+        # TODO: [custom granularity] change this to an assertion once we're sure there aren't exceptions
+        if not self.name.find(DUNDER) == -1:
+            logger.warning(
+                f"Non-additive dimension spec references a dimension name `{self.name}`, with added annotations, but it "
+                "should be a simple element name reference. This should have been blocked by model validation!"
+            )
 
     @property
     def bucket_hash(self) -> str:

--- a/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
@@ -109,15 +109,6 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D101
             entity_links=(),
         )
 
-    @staticmethod
-    def from_name(name: str) -> TimeDimensionSpec:  # noqa: D102
-        structured_name = StructuredLinkableSpecName.from_name(name)
-        return TimeDimensionSpec(
-            entity_links=tuple(EntityReference(idl) for idl in structured_name.entity_link_names),
-            element_name=structured_name.element_name,
-            time_granularity=structured_name.time_granularity or DEFAULT_TIME_GRANULARITY,
-        )
-
     @property
     def reference(self) -> TimeDimensionReference:  # noqa: D102
         return TimeDimensionReference(element_name=self.element_name)

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -401,10 +401,12 @@ class DataflowPlanBuilder:
             descendent_filter_specs=metric_spec.filter_specs,
             queried_linkable_specs=queried_linkable_specs,
         )
-        assert StructuredLinkableSpecName.from_name(conversion_type_params.entity).is_element_name, (
-            f"Found additional annotations in type param entity name `{conversion_type_params.entity}`, which should "
-            "be a simple element name reference. This should have been blocked by model validation!"
-        )
+        # TODO: [custom granularity] change this to an assertion once we're sure there aren't exceptions
+        if not StructuredLinkableSpecName.from_name(conversion_type_params.entity).is_element_name:
+            logger.warning(
+                f"Found additional annotations in type param entity name `{conversion_type_params.entity}`, which "
+                "should be a simple element name reference. This should have been blocked by model validation!"
+            )
         entity_spec = EntitySpec(element_name=conversion_type_params.entity, entity_links=())
         logger.info(
             f"For conversion metric {metric_spec},\n"

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -26,6 +26,7 @@ from metricflow_semantics.mf_logging.formatting import indent
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.mf_logging.runtime import log_runtime
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
     FilterSpecResolutionLookUp,
@@ -352,7 +353,7 @@ class DataflowPlanBuilder:
             conversion_node=unaggregated_conversion_measure_node,
             conversion_measure_spec=conversion_measure_spec.measure_spec,
             conversion_time_dimension_spec=conversion_time_dimension_spec,
-            unique_identifier_keys=(MetadataSpec.from_name(MetricFlowReservedKeywords.MF_INTERNAL_UUID.value),),
+            unique_identifier_keys=(MetadataSpec(MetricFlowReservedKeywords.MF_INTERNAL_UUID.value),),
             entity_spec=entity_spec,
             window=window,
             constant_properties=constant_property_specs,
@@ -400,7 +401,11 @@ class DataflowPlanBuilder:
             descendent_filter_specs=metric_spec.filter_specs,
             queried_linkable_specs=queried_linkable_specs,
         )
-        entity_spec = EntitySpec.from_name(conversion_type_params.entity)
+        assert StructuredLinkableSpecName.from_name(conversion_type_params.entity).is_element_name, (
+            f"Found additional annotations in type param entity name `{conversion_type_params.entity}`, which should "
+            "be a simple element name reference. This should have been blocked by model validation!"
+        )
+        entity_spec = EntitySpec(element_name=conversion_type_params.entity, entity_links=())
         logger.info(
             f"For conversion metric {metric_spec},\n"
             f"base_measure is:\n{mf_pformat(base_measure)}\n"
@@ -1558,8 +1563,11 @@ class DataflowPlanBuilder:
                 linkable_specs=queried_linkable_specs.as_tuple,
                 non_additive_dimension_spec=non_additive_dimension_spec,
             )
-            time_dimension_spec = TimeDimensionSpec.from_name(non_additive_dimension_spec.name).with_grain(
-                time_granularity=non_additive_dimension_grain
+            time_dimension_spec = TimeDimensionSpec(
+                # The NonAdditiveDimensionSpec name property is a plain element name
+                element_name=non_additive_dimension_spec.name,
+                entity_links=(),
+                time_granularity=non_additive_dimension_grain,
             )
             window_groupings = tuple(
                 LinklessEntitySpec.from_element_name(name) for name in non_additive_dimension_spec.window_groupings

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1425,7 +1425,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         select_columns: List[SqlSelectColumn] = []
         metadata_instances: List[MetadataInstance] = []
         for agg_type in (AggregationType.MIN, AggregationType.MAX):
-            metadata_spec = MetadataSpec.from_name(name=parent_column_alias, agg_type=agg_type)
+            metadata_spec = MetadataSpec(element_name=parent_column_alias, agg_type=agg_type)
             output_column_association = self._column_association_resolver.resolve_spec(metadata_spec)
             select_columns.append(
                 SqlSelectColumn(
@@ -1461,7 +1461,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         input_data_set: SqlDataSet = node.parent_node.accept(self)
         input_data_set_alias = self._next_unique_table_alias()
 
-        gen_uuid_spec = MetadataSpec.from_name(MetricFlowReservedKeywords.MF_INTERNAL_UUID.value)
+        gen_uuid_spec = MetadataSpec(MetricFlowReservedKeywords.MF_INTERNAL_UUID.value)
         output_column_association = self._column_association_resolver.resolve_spec(gen_uuid_spec)
         output_instance_set = input_data_set.instance_set.transform(
             AddMetadata(

--- a/tests_metricflow/dataflow/builder/test_node_evaluator.py
+++ b/tests_metricflow/dataflow/builder/test_node_evaluator.py
@@ -576,7 +576,11 @@ def test_node_evaluator_with_multi_hop_scd_target(
     The validity window should have an entity link, the validity window join is mediated by an intervening
     node, and so we need to refer to that column via the link prefix.
     """
-    linkable_specs = [DimensionSpec.from_name("listing__lux_listing__is_confirmed_lux")]
+    linkable_specs = [
+        DimensionSpec(
+            element_name="is_confirmed_lux", entity_links=(EntityReference("listing"), EntityReference("lux_listing"))
+        )
+    ]
     node_evaluator = make_multihop_node_evaluator(
         source_node_set=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].source_node_set,
         semantic_manifest_lookup_with_multihop_links=scd_semantic_manifest_lookup,
@@ -641,7 +645,11 @@ def test_node_evaluator_with_multi_hop_through_scd(
     The validity window should NOT have any entity links, as the validity window join is not mediated by an
     intervening node and therefore the column name does not use the link prefix.
     """
-    linkable_specs = [DimensionSpec.from_name("listing__user__home_state_latest")]
+    linkable_specs = [
+        DimensionSpec(
+            element_name="home_state_latest", entity_links=(EntityReference("listing"), EntityReference("user"))
+        )
+    ]
     node_evaluator = make_multihop_node_evaluator(
         source_node_set=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].source_node_set,
         semantic_manifest_lookup_with_multihop_links=scd_semantic_manifest_lookup,
@@ -701,7 +709,9 @@ def test_node_evaluator_with_invalid_multi_hop_scd(
 
     This will return an empty result because the linkable spec is not joinable in this model.
     """
-    linkable_specs = [DimensionSpec.from_name("listing__user__account_type")]
+    linkable_specs = [
+        DimensionSpec(element_name="account_type", entity_links=(EntityReference("listing"), EntityReference("user")))
+    ]
     node_evaluator = make_multihop_node_evaluator(
         source_node_set=mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].source_node_set,
         semantic_manifest_lookup_with_multihop_links=scd_semantic_manifest_lookup,

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -322,7 +322,11 @@ def test_multi_hop_through_scd_dimension(
     query_spec = MetricFlowQuerySpec(
         metric_specs=(MetricSpec(element_name="bookings"),),
         time_dimension_specs=(MTD_SPEC_DAY,),
-        dimension_specs=(DimensionSpec.from_name(name="listing__user__home_state_latest"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="home_state_latest", entity_links=(EntityReference("listing"), EntityReference("user"))
+            ),
+        ),
     )
 
     render_and_check(
@@ -347,7 +351,12 @@ def test_multi_hop_to_scd_dimension(
     query_spec = MetricFlowQuerySpec(
         metric_specs=(MetricSpec(element_name="bookings"),),
         time_dimension_specs=(MTD_SPEC_DAY,),
-        dimension_specs=(DimensionSpec.from_name(name="listing__lux_listing__is_confirmed_lux"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="is_confirmed_lux",
+                entity_links=(EntityReference("listing"), EntityReference("lux_listing")),
+            ),
+        ),
     )
 
     render_and_check(


### PR DESCRIPTION
A number of our spec classes have a `from_name` method which
wraps the StructuredLinkableSpecName.from_name method.

In the dominant majority of cases these calls are unnecessary,
and the behavior of our code would be far more clear with a targeted
set of assertions and standard dataclass initialization.

We also have a looming issue with custom granularities affecting
the way we manage granularity configurations, which will typically
require us to initialize spec classes in a context where we have
access to the properties of any custom granularity. This can't be
readily handled from within the spec classes themselves.

This change rmeoves the `from_name` methods to avoid proliferation of
unnecessary uses, and to streamline the process of moving to direct
initialization when custom granularities are involved.