### PR TITLE
Use ExpandedTimeGranularity in TimeDimensionSpec

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -360,7 +360,7 @@ class LinkableElementSet(SemanticModelDerivation):
             return TimeDimensionSpec(
                 element_name=path_key.element_name,
                 entity_links=path_key.entity_links,
-                time_granularity=path_key.time_granularity.base_granularity,
+                time_granularity=path_key.time_granularity,
                 date_part=path_key.date_part,
             )
         elif path_key.element_type is LinkableElementType.ENTITY:

--- a/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
@@ -154,7 +154,7 @@ class _DunderNameTransform(InstanceSpecSetTransform[Sequence[str]]):
             if time_dimension_spec.date_part is not None:
                 items.append(DunderNamingScheme.date_part_suffix(date_part=time_dimension_spec.date_part))
             else:
-                items.append(time_dimension_spec.time_granularity.value)
+                items.append(time_dimension_spec.time_granularity.name)
             names_to_return.append(DUNDER.join(items))
 
         for other_group_by_item_specs in (

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_str.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_str.py
@@ -10,7 +10,6 @@ from dbt_semantic_interfaces.call_parameter_sets import (
 )
 from dbt_semantic_interfaces.naming.keywords import DUNDER
 from dbt_semantic_interfaces.references import EntityReference
-from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from typing_extensions import override
 
@@ -32,7 +31,7 @@ class ObjectBuilderNameConverter:
             element_name=parameter_set.entity_reference.element_name,
             entity_links=parameter_set.entity_path,
             group_by=(),
-            time_granularity=None,
+            time_granularity_name=None,
             date_part=None,
         )
         return f"Entity({initializer_parameter_str})"
@@ -45,7 +44,7 @@ class ObjectBuilderNameConverter:
             group_by=tuple(
                 EntityReference(element_name=group_by_ref.element_name) for group_by_ref in parameter_set.group_by
             ),
-            time_granularity=None,
+            time_granularity_name=None,
             date_part=None,
         )
         return f"Metric({initializer_parameter_str})"
@@ -55,7 +54,7 @@ class ObjectBuilderNameConverter:
         element_name: str,
         entity_links: Sequence[EntityReference],
         group_by: Sequence[EntityReference],
-        time_granularity: Optional[TimeGranularity],
+        time_granularity_name: Optional[str],
         date_part: Optional[DatePart],
     ) -> str:
         """Return the parameters that should go in the initializer.
@@ -68,9 +67,9 @@ class ObjectBuilderNameConverter:
             initializer_parameters.append(repr(entity_link_names[-1] + DUNDER + element_name))
         else:
             initializer_parameters.append(repr(element_name))
-        if time_granularity is not None:
+        if time_granularity_name is not None:
             initializer_parameters.append(
-                f"'{time_granularity.value}'",
+                f"'{time_granularity_name}'",
             )
         if date_part is not None:
             initializer_parameters.append(f"date_part_name={repr(date_part.value)}")
@@ -101,7 +100,7 @@ class ObjectBuilderNameConverter:
                     element_name=entity_spec.element_name,
                     entity_links=entity_spec.entity_links,
                     group_by=(),
-                    time_granularity=None,
+                    time_granularity_name=None,
                     date_part=None,
                 )
                 names_to_return.append(f"Entity({initializer_parameter_str})")
@@ -111,7 +110,7 @@ class ObjectBuilderNameConverter:
                     element_name=dimension_spec.element_name,
                     entity_links=dimension_spec.entity_links,
                     group_by=(),
-                    time_granularity=None,
+                    time_granularity_name=None,
                     date_part=None,
                 )
                 names_to_return.append(f"Dimension({initializer_parameter_str})")
@@ -121,7 +120,7 @@ class ObjectBuilderNameConverter:
                     element_name=time_dimension_spec.element_name,
                     entity_links=time_dimension_spec.entity_links,
                     group_by=(),
-                    time_granularity=time_dimension_spec.time_granularity,
+                    time_granularity_name=time_dimension_spec.time_granularity.name,
                     date_part=time_dimension_spec.date_part,
                 )
                 names_to_return.append(f"TimeDimension({initializer_parameter_str})")
@@ -131,7 +130,7 @@ class ObjectBuilderNameConverter:
                     element_name=group_by_metric_spec.element_name,
                     entity_links=(),
                     group_by=group_by_metric_spec.entity_links,
-                    time_granularity=None,
+                    time_granularity_name=None,
                     date_part=None,
                 )
                 names_to_return.append(f"Metric({initializer_parameter_str})")
@@ -153,7 +152,7 @@ class ObjectBuilderNameConverter:
             element_name=parameter_set.dimension_reference.element_name,
             entity_links=parameter_set.entity_path,
             group_by=(),
-            time_granularity=None,
+            time_granularity_name=None,
             date_part=None,
         )
         return f"Dimension({initializer_parameter_str})"
@@ -166,7 +165,7 @@ class ObjectBuilderNameConverter:
             element_name=parameter_set.time_dimension_reference.element_name,
             entity_links=parameter_set.entity_path,
             group_by=(),
-            time_granularity=None,
+            time_granularity_name=None,
             date_part=None,
         )
         return f"TimeDimension({initializer_parameter_str})"

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -67,6 +67,8 @@ class PushDownResult:
     # The issues seen so far while pushing down the result / resolving the ambiguity.
     issue_set: MetricFlowQueryResolutionIssueSet
     # The largest default time granularity of the metrics seen in the DAG so far. Used to resolve metric_time.
+    # TODO: [custom granularity] decide whether or not to support custom granularities as metric_time defaults and
+    # update accordingly
     max_metric_default_time_granularity: Optional[TimeGranularity] = None
 
     def __post_init__(self) -> None:  # noqa: D105

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
@@ -226,7 +226,7 @@ class GroupByItemResolver:
         )
 
     def resolve_min_metric_time_grain(self) -> TimeGranularity:
-        """Returns the finest time grain of metric_time for querying."""
+        """Returns the finest base time grain of metric_time for querying."""
         metric_time_grain_resolution = self.resolve_matching_item_for_querying(
             spec_pattern=TimeDimensionPattern.from_call_parameter_set(
                 TimeDimensionCallParameterSet(
@@ -247,4 +247,4 @@ class GroupByItemResolver:
                 f"{metric_time_grain_resolution.spec} and issues:\n\n"
                 f"{indent(mf_pformat(metric_time_grain_resolution.issue_set))}"
             )
-        return metric_time_spec_set.time_dimension_specs[0].time_granularity
+        return metric_time_spec_set.time_dimension_specs[0].time_granularity.base_granularity

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -166,7 +166,7 @@ class MetricFlowQueryParser:
             len(time_dimension_specs) == 1
         ), f"Bug with MinimumTimeGrainPattern - should have returned exactly 1 spec but got {time_dimension_specs}"
 
-        return time_dimension_specs[0].time_granularity
+        return time_dimension_specs[0].time_granularity.base_granularity
 
     def _adjust_time_constraint(
         self,

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/metric_time_default_granularity.py
@@ -15,6 +15,7 @@ from metricflow_semantics.specs.time_dimension_spec import (
     TimeDimensionSpecComparisonKey,
     TimeDimensionSpecField,
 )
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 class MetricTimeDefaultGranularityPattern(SpecPattern):
@@ -53,9 +54,12 @@ class MetricTimeDefaultGranularityPattern(SpecPattern):
             return candidate_specs
 
         # If there are metrics in the query, use max metric default. For no-metric queries, use standard default.
-        default_granularity = self._max_metric_default_time_granularity or DEFAULT_TIME_GRANULARITY
+        # TODO: [custom granularity] allow custom granularities to be used as defaults if appropriate
+        default_granularity = ExpandedTimeGranularity.from_time_granularity(
+            self._max_metric_default_time_granularity or DEFAULT_TIME_GRANULARITY
+        )
 
-        spec_key_to_grains: Dict[TimeDimensionSpecComparisonKey, Set[TimeGranularity]] = defaultdict(set)
+        spec_key_to_grains: Dict[TimeDimensionSpecComparisonKey, Set[ExpandedTimeGranularity]] = defaultdict(set)
         spec_key_to_specs: Dict[TimeDimensionSpecComparisonKey, Tuple[TimeDimensionSpec, ...]] = defaultdict(tuple)
         for metric_time_spec in spec_set.metric_time_specs:
             spec_key = metric_time_spec.comparison_key(exclude_fields=(TimeDimensionSpecField.TIME_GRANULARITY,))

--- a/metricflow-semantics/metricflow_semantics/test_helpers/metric_time_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/metric_time_dimension.py
@@ -5,22 +5,33 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.unique_valid_name import MetricFlowReservedKeywords
 
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 # Shortcuts for referring to the metric time dimension.
 MTD = MetricFlowReservedKeywords.METRIC_TIME.value
 MTD_REFERENCE = TimeDimensionReference(element_name=MetricFlowReservedKeywords.METRIC_TIME.value)
 MTD_SPEC_DAY = TimeDimensionSpec(
-    element_name=MetricFlowReservedKeywords.METRIC_TIME.value, entity_links=(), time_granularity=TimeGranularity.DAY
+    element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
+    entity_links=(),
+    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
 )
 MTD_SPEC_WEEK = TimeDimensionSpec(
-    element_name=MetricFlowReservedKeywords.METRIC_TIME.value, entity_links=(), time_granularity=TimeGranularity.WEEK
+    element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
+    entity_links=(),
+    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
 )
 MTD_SPEC_MONTH = TimeDimensionSpec(
-    element_name=MetricFlowReservedKeywords.METRIC_TIME.value, entity_links=(), time_granularity=TimeGranularity.MONTH
+    element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
+    entity_links=(),
+    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
 )
 MTD_SPEC_QUARTER = TimeDimensionSpec(
-    element_name=MetricFlowReservedKeywords.METRIC_TIME.value, entity_links=(), time_granularity=TimeGranularity.QUARTER
+    element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
+    entity_links=(),
+    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.QUARTER),
 )
 MTD_SPEC_YEAR = TimeDimensionSpec(
-    element_name=MetricFlowReservedKeywords.METRIC_TIME.value, entity_links=(), time_granularity=TimeGranularity.YEAR
+    element_name=MetricFlowReservedKeywords.METRIC_TIME.value,
+    entity_links=(),
+    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.YEAR),
 )

--- a/metricflow-semantics/metricflow_semantics/time/granularity.py
+++ b/metricflow-semantics/metricflow_semantics/time/granularity.py
@@ -11,16 +11,26 @@ class ExpandedTimeGranularity(SerializableDataclass):
     """Dataclass container for custom granularity extensions to the base TimeGranularity enumeration.
 
     This includes the granularity name, which is either the custom granularity or the TimeGranularity string value,
-    and an associated base time granularity value which we use as a pointer to the base grain used to look up the
-    time spine. This will allow for some level of comparison between custom granularities.
+    and an associated base time granularity value.
 
-    Note: this assumes that any base TimeGranularity value will derive the name from the TimeGranularity. It might be
-    worth adding validation to ensure that is always the case, meaning that no `name` value can be a value in the
-    TimeGranularity enumeration.
+    For custom granularities, we use the base time granularity as a pointer to the base standard grain used to look
+    up the time spine. For standard TimeGranularities the base_granularity is always the same as the TimeGranularity.
+
+    This will allow us to continue to do comparisons for standard TimeGranularity values, and also to do some level of
+    comparison between custom granularities.
     """
 
     name: str
     base_granularity: TimeGranularity
+
+    def __post_init__(self) -> None:
+        """Post init validation to ensure this class is configured correctly for standard time granularity values."""
+        if ExpandedTimeGranularity.is_standard_granularity_name(self.name):
+            assert TimeGranularity(self.name) == self.base_granularity, (
+                f"Invalid configuration of ExpandedTimeGranularity for standard TimeGranularity with name {self.name}."
+                f"This should correspond to a base_granularity of {TimeGranularity(self.name)}, but it has "
+                f"{self.base_granularity}."
+            )
 
     @property
     def is_custom_granularity(self) -> bool:  # noqa: D102

--- a/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
@@ -30,7 +30,7 @@ def test_containers() -> None:  # noqa: D103
 
 
 def test_classes() -> None:  # noqa: D103
-    assert "TimeDimensionSpec('metric_time', DAY)" == mf_pformat(
+    assert "TimeDimensionSpec('metric_time', ExpandedTimeGranularity('day', DAY))" == mf_pformat(
         MTD_SPEC_DAY,
         include_object_field_names=False,
         include_none_object_fields=False,
@@ -43,7 +43,7 @@ def test_classes() -> None:  # noqa: D103
             TimeDimensionSpec(
               element_name='metric_time',
               entity_links=(),
-              time_granularity=DAY,
+              time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
               date_part=None,
               aggregation_state=None,
             )
@@ -57,7 +57,17 @@ def test_classes() -> None:  # noqa: D103
         )
     )
 
-    assert "TimeDimensionSpec(element_name='metric_time', time_granularity=DAY)" == mf_pformat(MTD_SPEC_DAY)
+    assert (
+        textwrap.dedent(
+            """\
+            TimeDimensionSpec(
+              element_name='metric_time',
+              time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+            )
+            """
+        ).rstrip()
+        == mf_pformat(MTD_SPEC_DAY)
+    )
 
 
 def test_multi_line_key_value_dict() -> None:

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
@@ -713,7 +713,7 @@ def test_filter_by_pattern(linkable_set: LinkableElementSet) -> None:
         TimeDimensionSpec(
             element_name="time_dimension_element",
             entity_links=(EntityReference("entity_1"),),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=None,
         ),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
@@ -160,7 +160,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D103
             resolved_spec=TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference("listing"),),
-                time_granularity=TimeGranularity.WEEK,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
             ),
             resolved_linkable_element_set=LinkableElementSet(
                 path_key_to_linkable_dimensions={
@@ -202,7 +202,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D103
             TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference(element_name="listing"),),
-                time_granularity=TimeGranularity.WEEK,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
             ),
         ),
         entity_specs=(),
@@ -224,7 +224,7 @@ def test_time_dimension_in_filter(  # noqa: D103
             resolved_spec=TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference("listing"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
             resolved_linkable_element_set=LinkableElementSet(
                 path_key_to_linkable_dimensions={
@@ -266,7 +266,7 @@ def test_time_dimension_in_filter(  # noqa: D103
             TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference(element_name="listing"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
         entity_specs=(),
@@ -288,7 +288,7 @@ def test_time_dimension_with_grain_in_name(  # noqa: D103
             resolved_spec=TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference("listing"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
             resolved_linkable_element_set=LinkableElementSet(
                 path_key_to_linkable_dimensions={
@@ -330,7 +330,7 @@ def test_time_dimension_with_grain_in_name(  # noqa: D103
             TimeDimensionSpec(
                 element_name="created_at",
                 entity_links=(EntityReference(element_name="listing"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
         entity_specs=(),
@@ -352,7 +352,7 @@ def test_date_part_in_filter(  # noqa: D103
             resolved_spec=TimeDimensionSpec(
                 element_name="metric_time",
                 entity_links=(),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
                 date_part=DatePart.YEAR,
             ),
             resolved_linkable_element_set=LinkableElementSet(
@@ -395,7 +395,7 @@ def test_date_part_in_filter(  # noqa: D103
             TimeDimensionSpec(
                 element_name="metric_time",
                 entity_links=(),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
                 date_part=DatePart.YEAR,
             ),
         ),
@@ -483,7 +483,7 @@ def test_date_part_and_grain_in_filter(  # noqa: D103
             TimeDimensionSpec(
                 element_name="metric_time",
                 entity_links=(),
-                time_granularity=TimeGranularity.WEEK,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
                 date_part=DatePart.YEAR,
             ),
         ),
@@ -520,7 +520,7 @@ def test_date_part_less_than_grain_in_filter(  # noqa: D103
             TimeDimensionSpec(
                 element_name="metric_time",
                 entity_links=(),
-                time_granularity=TimeGranularity.WEEK,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
                 date_part=DatePart.DAY,
             ),
         ),

--- a/metricflow-semantics/tests_metricflow_semantics/naming/conftest.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/conftest.py
@@ -12,6 +12,7 @@ from metricflow_semantics.specs.group_by_metric_spec import GroupByMetricSpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 @pytest.fixture(scope="session")
@@ -24,7 +25,7 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
         TimeDimensionSpec(
             element_name="creation_time",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.MONTH,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             date_part=DatePart.DAY,
         ),
         # Dimensions

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
@@ -12,6 +12,7 @@ from metricflow_semantics.specs.entity_spec import EntitySpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 @pytest.fixture(scope="session")
@@ -38,7 +39,7 @@ def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
             TimeDimensionSpec(
                 element_name="creation_time",
                 entity_links=(EntityReference(element_name="booking"), EntityReference(element_name="listing")),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
                 date_part=DatePart.DAY,
             )
         )
@@ -53,7 +54,7 @@ def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
                     EntityReference(element_name="booking"),
                     EntityReference(element_name="listing"),
                 ),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             )
         )
         == "booking__listing__creation_time__month"

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_object_builder_naming_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_object_builder_naming_scheme.py
@@ -13,6 +13,7 @@ from metricflow_semantics.specs.group_by_metric_spec import GroupByMetricSpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 @pytest.fixture(scope="session")
@@ -35,7 +36,7 @@ def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> N
         TimeDimensionSpec(
             element_name="creation_time",
             entity_links=(EntityReference(element_name="booking"), EntityReference(element_name="listing")),
-            time_granularity=TimeGranularity.MONTH,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             date_part=DatePart.DAY,
         )
     ) == ("TimeDimension('listing__creation_time', 'month', date_part_name='day', entity_path=['booking'])")
@@ -102,7 +103,7 @@ def test_spec_pattern(  # noqa: D103
         TimeDimensionSpec(
             element_name="creation_time",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.MONTH,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             date_part=DatePart.DAY,
         ),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
@@ -11,7 +11,12 @@ ParseQueryResult(
         entity_links=(EntityReference(element_name='user'),),
       ),
     ),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__accumulate_last_2_months_metric__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_different_parent_time_grains__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__derived_metric_with_same_parent_time_grains__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_different_time_grains__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__metrics_with_same_time_grains__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__no_metrics__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_matching_item_for_filters.py/GroupByItemResolution/test_ambiguous_metric_time_in_query_filter__simple_metric__result.txt
@@ -1,5 +1,8 @@
 GroupByItemResolution(
-  spec=TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),
+  spec=TimeDimensionSpec(
+    element_name='metric_time',
+    time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+  ),
   linkable_element_set=LinkableElementSet(
     path_key_to_linkable_dimensions={
       ElementPathKey(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
@@ -1,6 +1,11 @@
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity'),),
-  time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR),),
+  time_dimension_specs=(
+    TimeDimensionSpec(
+      element_name='metric_time',
+      time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
@@ -1,6 +1,11 @@
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='derived_metric_without_time_granularity'),),
-  time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+  time_dimension_specs=(
+    TimeDimensionSpec(
+      element_name='metric_time',
+      time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
@@ -4,7 +4,7 @@ MetricFlowQuerySpec(
     TimeDimensionSpec(
       element_name='ds',
       entity_links=(EntityReference(element_name='listing'),),
-      time_granularity=DAY,
+      time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
     ),
   ),
   filter_intersection=PydanticWhereFilterIntersection(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
@@ -1,6 +1,11 @@
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='largest_listing'),),
-  time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+  time_dimension_specs=(
+    TimeDimensionSpec(
+      element_name='metric_time',
+      time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
@@ -1,6 +1,11 @@
 MetricFlowQuerySpec(
   metric_specs=(MetricSpec(element_name='monthly_metric_0'),),
-  time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+  time_dimension_specs=(
+    TimeDimensionSpec(
+      element_name='metric_time',
+      time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
   min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
@@ -5,7 +5,7 @@ ParseQueryResult(
       TimeDimensionSpec(
         element_name='ds',
         entity_links=(EntityReference(element_name='revenue_instance'),),
-        time_granularity=MONTH,
+        time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
       ),
     ),
     filter_intersection=PydanticWhereFilterIntersection(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
@@ -1,7 +1,12 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
     metric_specs=(MetricSpec(element_name='revenue_growth_2_weeks'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+      ),
+    ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),
     min_max_only=False,

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
@@ -1,10 +1,21 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
     metric_specs=(MetricSpec(element_name='bookings'), MetricSpec(element_name='revenue')),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='month',
+            base_granularity=MONTH,
+          ),
+        ),
         descending=True,
       ),
     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
@@ -1,10 +1,21 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
     metric_specs=(MetricSpec(element_name='bookings'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='day',
+            base_granularity=DAY,
+          ),
+        ),
         descending=False,
       ),
     ),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -1,7 +1,12 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
     metric_specs=(MetricSpec(element_name='bookings'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     time_range_constraint=TimeRangeConstraint(
       start_time=datetime.datetime(2020, 1, 15, 0, 0),
       end_time=datetime.datetime(2020, 2, 15, 0, 0),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
@@ -8,10 +8,21 @@ ParseQueryResult(
       ),
     ),
     entity_specs=(EntitySpec(element_name='listing'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='day',
+            base_granularity=DAY,
+          ),
+        ),
         descending=False,
       ),
       OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
@@ -8,10 +8,21 @@ ParseQueryResult(
       ),
     ),
     entity_specs=(EntitySpec(element_name='listing'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='day',
+            base_granularity=DAY,
+          ),
+        ),
         descending=False,
       ),
       OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
@@ -8,10 +8,21 @@ ParseQueryResult(
       ),
     ),
     entity_specs=(EntitySpec(element_name='listing'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='day',
+            base_granularity=DAY,
+          ),
+        ),
         descending=False,
       ),
       OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
@@ -8,10 +8,21 @@ ParseQueryResult(
       ),
     ),
     entity_specs=(EntitySpec(element_name='listing'),),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),
+      ),
+    ),
     order_by_specs=(
       OrderBySpec(
-        instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),
+        instance_spec=TimeDimensionSpec(
+          element_name='metric_time',
+          time_granularity=ExpandedTimeGranularity(
+            name='day',
+            base_granularity=DAY,
+          ),
+        ),
         descending=False,
       ),
       OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
@@ -1,7 +1,12 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
     metric_specs=(MetricSpec(element_name='bookings'), MetricSpec(element_name='revenue')),
-    time_dimension_specs=(TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),),
+    time_dimension_specs=(
+      TimeDimensionSpec(
+        element_name='metric_time',
+        time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH),
+      ),
+    ),
     time_range_constraint=TimeRangeConstraint(
       start_time=datetime.datetime(2020, 1, 1, 0, 0),
       end_time=datetime.datetime(2020, 2, 29, 0, 0),

--- a/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_entity_link_pattern.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_entity_link_pattern.py
@@ -20,6 +20,7 @@ from metricflow_semantics.specs.patterns.entity_link_pattern import (
 )
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_MONTH, MTD_SPEC_WEEK, MTD_SPEC_YEAR
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
         TimeDimensionSpec(
             element_name="creation_time",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.MONTH,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             date_part=DatePart.YEAR,
         ),
         # Dimensions
@@ -215,7 +216,7 @@ def test_time_dimension_date_part_match(specs: Sequence[LinkableInstanceSpec]) -
         TimeDimensionSpec(
             element_name="creation_time",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.MONTH,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             date_part=DatePart.YEAR,
         ),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_typed_patterns.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_typed_patterns.py
@@ -29,6 +29,7 @@ from metricflow_semantics.specs.patterns.typed_patterns import (
     TimeDimensionPattern,
 )
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +41,13 @@ def specs() -> Sequence[LinkableInstanceSpec]:  # noqa: D103
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=None,
         ),
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=DatePart.MONTH,
         ),
         # Dimensions
@@ -84,13 +85,13 @@ def test_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None:  # no
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=None,
         ),
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=DatePart.MONTH,
         ),
     )
@@ -108,7 +109,7 @@ def test_time_dimension_pattern(specs: Sequence[LinkableInstanceSpec]) -> None: 
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=None,
         ),
     )
@@ -127,7 +128,7 @@ def test_time_dimension_pattern_with_date_part(specs: Sequence[LinkableInstanceS
         TimeDimensionSpec(
             element_name="common_name",
             entity_links=(EntityReference("booking"), EntityReference("listing")),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             date_part=DatePart.MONTH,
         ),
     )

--- a/metricflow-semantics/tests_metricflow_semantics/specs/test_spec_serialization.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/test_spec_serialization.py
@@ -61,7 +61,7 @@ def test_where_filter_spec_serialization() -> None:  # noqa: D103
                 TimeDimensionSpec(
                     element_name="element_name",
                     entity_links=(EntityReference(element_name="element_name"),),
-                    time_granularity=TimeGranularity.YEAR,
+                    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.YEAR),
                 ),
             ),
             entity_specs=(

--- a/metricflow-semantics/tests_metricflow_semantics/specs/test_time_dimension_spec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/test_time_dimension_spec.py
@@ -5,6 +5,7 @@ import logging
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec, TimeDimensionSpecField
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -13,13 +14,13 @@ def test_comparison_key_excluding_time_grain() -> None:  # noqa: D103
     spec0 = TimeDimensionSpec(
         element_name="element0",
         entity_links=(EntityReference("entity0"),),
-        time_granularity=TimeGranularity.DAY,
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
 
     spec1 = TimeDimensionSpec(
         element_name="element0",
         entity_links=(EntityReference("entity0"),),
-        time_granularity=TimeGranularity.MONTH,
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
     )
     assert spec0.comparison_key(exclude_fields=[]) != spec1.comparison_key(exclude_fields=[])
     assert spec0.comparison_key(exclude_fields=[]) != spec1.comparison_key((TimeDimensionSpecField.TIME_GRANULARITY,))
@@ -30,4 +31,7 @@ def test_comparison_key_excluding_time_grain() -> None:  # noqa: D103
         spec1.comparison_key(exclude_fields=[TimeDimensionSpecField.TIME_GRANULARITY])
     )
 
-    assert spec0.with_grain(TimeGranularity.MONTH).comparison_key() == spec1.comparison_key()
+    assert (
+        spec0.with_grain(ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH)).comparison_key()
+        == spec1.comparison_key()
+    )

--- a/metricflow-semantics/tests_metricflow_semantics/test_specs.py
+++ b/metricflow-semantics/tests_metricflow_semantics/test_specs.py
@@ -13,6 +13,7 @@ from metricflow_semantics.specs.measure_spec import MeasureSpec
 from metricflow_semantics.specs.metric_spec import MetricSpec
 from metricflow_semantics.specs.spec_set import InstanceSpecSet
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 @pytest.fixture
@@ -31,7 +32,7 @@ def time_dimension_spec() -> TimeDimensionSpec:  # noqa: D103
     return TimeDimensionSpec(
         element_name="signup_ts",
         entity_links=(EntityReference(element_name="user_id"),),
-        time_granularity=TimeGranularity.DAY,
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
 
 
@@ -62,7 +63,7 @@ def test_time_dimension_without_first_entity_link(time_dimension_spec: TimeDimen
     assert time_dimension_spec.without_first_entity_link == TimeDimensionSpec(
         element_name="signup_ts",
         entity_links=(),
-        time_granularity=TimeGranularity.DAY,
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
 
 
@@ -127,7 +128,7 @@ def spec_set() -> InstanceSpecSet:  # noqa: D103
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             ),
         ),
         entity_specs=(
@@ -152,7 +153,7 @@ def test_spec_set_linkable_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D1
         TimeDimensionSpec(
             element_name="ds",
             entity_links=(),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
         ),
         EntitySpec(
             element_name="user_id",
@@ -176,7 +177,7 @@ def test_spec_set_all_specs(spec_set: InstanceSpecSet) -> None:  # noqa: D103
         TimeDimensionSpec(
             element_name="ds",
             entity_links=(),
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
         ),
         EntitySpec(
             element_name="user_id",

--- a/metricflow/dataflow/builder/partitions.py
+++ b/metricflow/dataflow/builder/partitions.py
@@ -98,7 +98,16 @@ class PartitionJoinResolver:
     def _get_simplest_time_dimension_spec(time_dimension_specs: Sequence[TimeDimensionSpec]) -> TimeDimensionSpec:
         """Return the time dimension spec with the smallest granularity, then fewest entity links."""
         assert len(time_dimension_specs) > 0
-        sorted_specs = sorted(time_dimension_specs, key=lambda x: (x.time_granularity, len(x.entity_links)))
+        # TODO: [custom granularity] restructure this method to operate on partition collections instead, and
+        # move this enforcement to the PartitionSpecSet
+        assert all(not x.time_granularity.is_custom_granularity for x in time_dimension_specs), (
+            f"Found custom granularity in partition time dimension specs {time_dimension_specs}, but time partitions "
+            "can only use standard granularities as they are based on engine date/time types!"
+        )
+
+        sorted_specs = sorted(
+            time_dimension_specs, key=lambda x: (x.time_granularity.base_granularity, len(x.entity_links))
+        )
         return sorted_specs[0]
 
     def resolve_partition_time_dimension_joins(

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -33,6 +33,7 @@ from metricflow_semantics.specs.dimension_spec import DimensionSpec
 from metricflow_semantics.specs.entity_spec import EntitySpec
 from metricflow_semantics.specs.time_dimension_spec import DEFAULT_TIME_GRANULARITY, TimeDimensionSpec
 from metricflow_semantics.sql.sql_table import SqlTable
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 from metricflow_semantics.time.time_spine_source import TIME_SPINE_DATA_SET_DESCRIPTION, TimeSpineSource
 
 from metricflow.dataset.semantic_model_adapter import SemanticModelDataSet
@@ -112,7 +113,7 @@ class SemanticModelToDataSetConverter:
         time_dimension_spec = TimeDimensionSpec(
             element_name=element_name,
             entity_links=entity_links,
-            time_granularity=time_granularity,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(time_granularity),
             date_part=date_part,
         )
 

--- a/metricflow/dataset/dataset_classes.py
+++ b/metricflow/dataset/dataset_classes.py
@@ -10,6 +10,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.unique_valid_name import MetricFlowReservedKeywords
 from metricflow_semantics.instances import InstanceSet, TimeDimensionInstance
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -52,11 +53,15 @@ class DataSet(ABC):
     def metric_time_dimension_spec(
         time_granularity: TimeGranularity, date_part: Optional[DatePart] = None
     ) -> TimeDimensionSpec:
-        """Spec that corresponds to DataSet.metric_time_dimension_reference."""
+        """Spec that corresponds to DataSet.metric_time_dimension_reference.
+
+        This is currently used for source time dimension specs derived directly from a semantic model, so
+        custom granularities are not available at the points where this method is invoked.
+        """
         return TimeDimensionSpec(
             element_name=DataSet.metric_time_dimension_reference().element_name,
             entity_links=(),
-            time_granularity=time_granularity,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(time_granularity),
             date_part=date_part,
         )
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -339,14 +339,22 @@ class CreateValidityWindowJoinDescription(InstanceSetTransform[Optional[Validity
                 spec
                 for spec in specs
                 if spec.element_name == start_dim.dimension_name
-                and spec.time_granularity == start_dim.time_granularity
+                # TODO: [custom_granularity] - support custom granularities for SCDs. Note this requires
+                # addition of SCD support for window sub-selection, similar to what we do for cumulative metrics
+                # when we group by a different time grain (e.g., select last_value from window, etc.)
+                and not spec.time_granularity.is_custom_granularity
+                and spec.time_granularity.base_granularity == start_dim.time_granularity
                 and spec.date_part == start_dim.date_part
             ]
             end_specs = [
                 spec
                 for spec in specs
                 if spec.element_name == end_dim.dimension_name
-                and spec.time_granularity == end_dim.time_granularity
+                # TODO: [custom_granularity] - support custom granularities for SCDs. Note this requires
+                # addition of SCD support for window sub-selection, similar to what we do for cumulative metrics
+                # when we group by a different time grain (e.g., select last_value from window, etc.)
+                and not spec.time_granularity.is_custom_granularity
+                and spec.time_granularity.base_granularity == end_dim.time_granularity
                 and spec.date_part == end_dim.date_part
             ]
             linkless_start_specs = {spec.without_entity_links for spec in start_specs}

--- a/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
+++ b/tests_metricflow/dataflow/builder/test_dataflow_plan_builder.py
@@ -29,6 +29,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import (
     MTD_SPEC_WEEK,
 )
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_plan_snapshot_text_equal
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataset.dataset_classes import DataSet
@@ -1103,7 +1104,7 @@ def test_min_max_only_time_year(
                 TimeDimensionSpec(
                     element_name="paid_at",
                     entity_links=(EntityReference("booking"),),
-                    time_granularity=TimeGranularity.YEAR,
+                    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.YEAR),
                 ),
             ),
             min_max_only=True,

--- a/tests_metricflow/dataflow/builder/test_node_evaluator.py
+++ b/tests_metricflow/dataflow/builder/test_node_evaluator.py
@@ -13,6 +13,7 @@ from metricflow_semantics.specs.entity_spec import EntitySpec, LinklessEntitySpe
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.builder.node_evaluator import (
@@ -427,12 +428,14 @@ def test_node_evaluator_with_multihop_joined_spec(
                 join_on_partition_time_dimensions=(
                     PartitionTimeDimensionJoinDescription(
                         start_node_time_dimension_spec=TimeDimensionSpec(
-                            element_name="ds_partitioned", entity_links=(), time_granularity=TimeGranularity.DAY
+                            element_name="ds_partitioned",
+                            entity_links=(),
+                            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
                         ),
                         node_to_join_time_dimension_spec=TimeDimensionSpec(
                             element_name="ds_partitioned",
                             entity_links=(),
-                            time_granularity=TimeGranularity.DAY,
+                            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
                         ),
                     ),
                 ),

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -10,6 +10,7 @@ from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifest
 from metricflow_semantics.specs.dunder_column_association_resolver import DunderColumnAssociationResolver
 from metricflow_semantics.specs.spec_set import InstanceSpecSet
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
 from metricflow.dataflow.nodes.filter_elements import FilterElementsNode
@@ -73,7 +74,11 @@ def test_view_sql_generated_at_a_node(
         parent_node=metric_time_node,
         include_specs=InstanceSpecSet(
             time_dimension_specs=(
-                TimeDimensionSpec(element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY),
+                TimeDimensionSpec(
+                    element_name="metric_time",
+                    entity_links=(),
+                    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
+                ),
             ),
         ),
     )

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_conversion_metrics_to_sql.py
@@ -9,6 +9,7 @@ from metricflow_semantics.specs.metric_spec import MetricSpec
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -61,7 +62,9 @@ def test_conversion_rate_with_window(
         entity_links=(EntityReference(element_name="visit"),),
     )
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     metric_spec = MetricSpec(element_name="visit_buy_conversion_rate_7days")
 
@@ -149,7 +152,9 @@ def test_conversion_rate_with_constant_properties(
         entity_links=(EntityReference(element_name="visit"),),
     )
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     dataflow_plan = dataflow_plan_builder.build_plan(
         query_spec=MetricFlowQuerySpec(
@@ -179,7 +184,9 @@ def test_conversion_metric_join_to_timespine_and_fill_nulls_with_0(
     """Test conversion metric that joins to time spine and fills nulls with 0."""
     metric_spec = MetricSpec(element_name="visit_buy_conversion_rate_7days_fill_nulls_with_0")
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     dataflow_plan = dataflow_plan_builder.build_plan(
         query_spec=MetricFlowQuerySpec(

--- a/tests_metricflow/plan_conversion/instance_converters/test_create_validity_window_join_description.py
+++ b/tests_metricflow/plan_conversion/instance_converters/test_create_validity_window_join_description.py
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.instances import InstanceSet
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.nodes.join_to_base import ValidityWindowJoinDescription
 from metricflow.plan_conversion.instance_converters import CreateValidityWindowJoinDescription
@@ -36,16 +37,18 @@ def test_validity_window_conversion(
     scd_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:
     """Tests converting an instance set with a single validity window into a ValidityWindowJoinDescription."""
-    # The listings semantic model uses a 2-column SCD Type III layout
+    # The listings semantic model uses a 2-column SCD Type II layout
     dataset = mf_engine_test_fixture_mapping[SemanticManifestSetup.SCD_MANIFEST].data_set_mapping["listings"]
     expected_join_description = ValidityWindowJoinDescription(
         window_start_dimension=TimeDimensionSpec(
             element_name="window_start",
-            time_granularity=TimeGranularity.DAY,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             entity_links=(),
         ),
         window_end_dimension=TimeDimensionSpec(
-            element_name="window_end", time_granularity=TimeGranularity.DAY, entity_links=()
+            element_name="window_end",
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
+            entity_links=(),
         ),
     )
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -182,7 +182,11 @@ def test_filter_with_where_constraint_node(
         "bookings_source"
     ]
 
-    ds_spec = TimeDimensionSpec(element_name="ds", entity_links=(), time_granularity=TimeGranularity.DAY)
+    ds_spec = TimeDimensionSpec(
+        element_name="ds",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
+    )
     filter_node = FilterElementsNode.create(
         parent_node=source_node,
         include_specs=InstanceSpecSet(measure_specs=(measure_spec,), time_dimension_specs=(ds_spec,)),
@@ -198,7 +202,7 @@ def test_filter_with_where_constraint_node(
                         TimeDimensionSpec(
                             element_name="ds",
                             entity_links=(EntityReference(element_name="booking"),),
-                            time_granularity=TimeGranularity.DAY,
+                            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
                         ),
                     ),
                 ),
@@ -574,7 +578,9 @@ def test_join_to_time_spine_node_without_offset(
     entity_spec = LinklessEntitySpec.from_element_name(element_name="listing")
     metric_input_measure_specs = (MetricInputMeasureSpec(measure_spec=measure_spec),)
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
@@ -647,7 +653,9 @@ def test_join_to_time_spine_node_with_offset_window(
     entity_spec = LinklessEntitySpec.from_element_name(element_name="listing")
     metric_input_measure_specs = (MetricInputMeasureSpec(measure_spec=measure_spec),)
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
@@ -720,7 +728,9 @@ def test_join_to_time_spine_node_with_offset_to_grain(
     entity_spec = LinklessEntitySpec.from_element_name(element_name="listing")
     metric_input_measure_specs = (MetricInputMeasureSpec(measure_spec=measure_spec),)
     metric_time_spec = TimeDimensionSpec(
-        element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.DAY
+        element_name="metric_time",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
     )
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
         "bookings_source"
@@ -969,7 +979,9 @@ def test_semi_additive_join_node_with_queried_group_by(
     non_additive_dimension_spec = NonAdditiveDimensionSpec(name="ds", window_choice=AggregationType.MIN)
     time_dimension_spec = TimeDimensionSpec(element_name="ds", entity_links=())
     queried_time_dimension_spec = TimeDimensionSpec(
-        element_name="ds", entity_links=(), time_granularity=TimeGranularity.WEEK
+        element_name="ds",
+        entity_links=(),
+        time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
     )
 
     measure_source_node = mf_engine_test_fixture_mapping[SemanticManifestSetup.SIMPLE_MANIFEST].read_node_mapping[
@@ -1047,7 +1059,11 @@ def test_constrain_time_range_node(
                 ),
             ),
             time_dimension_specs=(
-                TimeDimensionSpec(element_name="ds", entity_links=(), time_granularity=TimeGranularity.DAY),
+                TimeDimensionSpec(
+                    element_name="ds",
+                    entity_links=(),
+                    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
+                ),
             ),
         ),
     )

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -25,6 +25,7 @@ from metricflow_semantics.test_helpers.metric_time_dimension import (
     MTD_SPEC_WEEK,
     MTD_SPEC_YEAR,
 )
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -49,7 +50,7 @@ def test_cumulative_metric(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             ),
         ),
     )
@@ -86,7 +87,7 @@ def test_cumulative_metric_with_time_constraint(
             TimeDimensionSpec(
                 element_name="metric_time",
                 entity_links=(),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             ),
         ),
         time_range_constraint=TimeRangeConstraint(
@@ -183,7 +184,7 @@ def test_cumulative_metric_no_window(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
     )
@@ -242,7 +243,7 @@ def test_cumulative_metric_grain_to_date(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
     )
@@ -328,12 +329,12 @@ def test_cumulative_metric_with_multiple_agg_time_dimensions(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("revenue_instance"),),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             ),
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("revenue_instance"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
     )
@@ -390,7 +391,7 @@ def test_cumulative_metric_with_agg_time_and_metric_time(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("revenue_instance"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
     )
@@ -500,7 +501,7 @@ def test_window_metric_with_non_default_grains(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("booking"),),
-                time_granularity=TimeGranularity.MONTH,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MONTH),
             ),
         ),
     )
@@ -534,12 +535,12 @@ def test_grain_to_date_metric_with_non_default_grains(
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("revenue_instance"),),
-                time_granularity=TimeGranularity.QUARTER,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.QUARTER),
             ),
             TimeDimensionSpec(
                 element_name="ds",
                 entity_links=(EntityReference("revenue_instance"),),
-                time_granularity=TimeGranularity.YEAR,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.YEAR),
             ),
         ),
     )

--- a/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
+++ b/tests_metricflow/query_rendering/test_granularity_date_part_rendering.py
@@ -18,6 +18,7 @@ from metricflow_semantics.specs.metric_spec import MetricSpec
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataset.dataset_classes import DataSet
@@ -140,7 +141,7 @@ def test_sub_daily_dimension(  # noqa: D103
         time_dimension_specs=(
             TimeDimensionSpec(
                 element_name="bio_added_ts",
-                time_granularity=TimeGranularity.SECOND,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.SECOND),
                 entity_links=(EntityReference("user"),),
             ),
         ),
@@ -169,7 +170,7 @@ def test_simple_metric_with_sub_daily_dimension(  # noqa: D103
         time_dimension_specs=(
             TimeDimensionSpec(
                 element_name="archived_at",
-                time_granularity=TimeGranularity.HOUR,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.HOUR),
                 entity_links=(EntityReference("user"),),
             ),
         ),
@@ -198,7 +199,7 @@ def test_simple_metric_with_joined_sub_daily_dimension(  # noqa: D103
         time_dimension_specs=(
             TimeDimensionSpec(
                 element_name="bio_added_ts",
-                time_granularity=TimeGranularity.MINUTE,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.MINUTE),
                 entity_links=(
                     EntityReference("listing"),
                     EntityReference("user"),

--- a/tests_metricflow/query_rendering/test_metric_time_without_metrics.py
+++ b/tests_metricflow/query_rendering/test_metric_time_without_metrics.py
@@ -12,6 +12,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
@@ -55,7 +56,9 @@ def test_metric_time_quarter_alone(  # noqa: D103
         query_spec=MetricFlowQuerySpec(
             time_dimension_specs=(
                 TimeDimensionSpec(
-                    element_name="metric_time", entity_links=(), time_granularity=TimeGranularity.QUARTER
+                    element_name="metric_time",
+                    entity_links=(),
+                    time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.QUARTER),
                 ),
             ),
         ),

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -24,6 +24,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY, MTD_SPEC_WEEK
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
 from metricflow.dataset.dataset_classes import DataSet
@@ -482,7 +483,7 @@ def test_min_max_only_time(
             TimeDimensionSpec(
                 element_name="paid_at",
                 entity_links=(EntityReference("booking"),),
-                time_granularity=TimeGranularity.DAY,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.DAY),
             ),
         ),
         min_max_only=True,
@@ -512,7 +513,7 @@ def test_min_max_only_time_quarter(
             TimeDimensionSpec(
                 element_name="paid_at",
                 entity_links=(EntityReference("booking"),),
-                time_granularity=TimeGranularity.QUARTER,
+                time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.QUARTER),
             ),
         ),
         min_max_only=True,

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_common_semantic_model__dfp_0.xml
@@ -22,7 +22,11 @@
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -37,7 +41,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
@@ -89,7 +97,11 @@
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -105,7 +117,11 @@
                                 <!--   "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
                                 <!-- node_id = NodeId(id_str='pfe_3') -->
                                 <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_no_window_or_grain_with_metric_time__dfp_0.xml
@@ -13,13 +13,22 @@
                     <!-- description = "Pass Only Elements: ['txn_revenue', 'metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec = MeasureSpec(element_name='txn_revenue') -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <JoinOverTimeRangeNode>
                         <!-- description = 'Join Self Over Time Range' -->
                         <!-- node_id = NodeId(id_str='jotr_0') -->
-                        <!-- queried_agg_time_dimension_specs =                                       -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- queried_agg_time_dimension_specs =                                                -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
                             <!-- node_id = NodeId(id_str='sma_28014') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_non_default_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_non_default_grain__dfp_0.xml
@@ -6,8 +6,18 @@
             <!-- description = 'Re-aggregate Metrics via Window Functions' -->
             <!-- node_id = NodeId(id_str='wr_0') -->
             <!-- metric_spec = MetricSpec(element_name='trailing_2_months_revenue') -->
-            <!-- order_by_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-            <!-- partition_by_specs = (TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR),) -->
+            <!-- order_by_spec =                                                                 -->
+            <!--   TimeDimensionSpec(                                                            -->
+            <!--     element_name='metric_time',                                                 -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--   )                                                                             -->
+            <!-- partition_by_specs =                                                                -->
+            <!--   (                                                                                 -->
+            <!--     TimeDimensionSpec(                                                              -->
+            <!--       element_name='metric_time',                                                   -->
+            <!--       time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+            <!--     ),                                                                              -->
+            <!--   )                                                                                 -->
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
@@ -20,17 +30,31 @@
                         <!--   "Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='txn_revenue') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR) -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                    -->
+                        <!--   TimeDimensionSpec(                                                              -->
+                        <!--     element_name='metric_time',                                                   -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                        <!--   )                                                                               -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOverTimeRangeNode>
                             <!-- description = 'Join Self Over Time Range' -->
                             <!-- node_id = NodeId(id_str='jotr_0') -->
-                            <!-- queried_agg_time_dimension_specs =                                        -->
-                            <!--   (                                                                       -->
-                            <!--     TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR), -->
-                            <!--     TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),  -->
-                            <!--   )                                                                       -->
+                            <!-- queried_agg_time_dimension_specs =                                                  -->
+                            <!--   (                                                                                 -->
+                            <!--     TimeDimensionSpec(                                                              -->
+                            <!--       element_name='metric_time',                                                   -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                            <!--     ),                                                                              -->
+                            <!--     TimeDimensionSpec(                                                              -->
+                            <!--       element_name='metric_time',                                                   -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),   -->
+                            <!--     ),                                                                              -->
+                            <!--   )                                                                                 -->
                             <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
@@ -13,13 +13,22 @@
                     <!-- description = "Pass Only Elements: ['txn_revenue', 'metric_time__day']" -->
                     <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec = MeasureSpec(element_name='txn_revenue') -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <JoinOverTimeRangeNode>
                         <!-- description = 'Join Self Over Time Range' -->
                         <!-- node_id = NodeId(id_str='jotr_0') -->
-                        <!-- queried_agg_time_dimension_specs =                                       -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- queried_agg_time_dimension_specs =                                                -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_cumulative_metric_with_non_default_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_cumulative_metric_with_non_default_grain__dfp_0.xml
@@ -10,8 +10,18 @@
                 <!-- description = 'Re-aggregate Metrics via Window Functions' -->
                 <!-- node_id = NodeId(id_str='wr_0') -->
                 <!-- metric_spec = MetricSpec(element_name='trailing_2_months_revenue', alias='t2mr') -->
-                <!-- order_by_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                <!-- partition_by_specs = (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
+                <!-- order_by_spec =                                                                 -->
+                <!--   TimeDimensionSpec(                                                            -->
+                <!--     element_name='metric_time',                                                 -->
+                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                <!--   )                                                                             -->
+                <!-- partition_by_specs =                                                                  -->
+                <!--   (                                                                                   -->
+                <!--     TimeDimensionSpec(                                                                -->
+                <!--       element_name='metric_time',                                                     -->
+                <!--       time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                <!--     ),                                                                                -->
+                <!--   )                                                                                   -->
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
@@ -24,17 +34,31 @@
                             <!--   "Pass Only Elements: ['txn_revenue', 'metric_time__month', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = MeasureSpec(element_name='txn_revenue') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                      -->
+                            <!--   TimeDimensionSpec(                                                                -->
+                            <!--     element_name='metric_time',                                                     -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                            <!--   )                                                                                 -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOverTimeRangeNode>
                                 <!-- description = 'Join Self Over Time Range' -->
                                 <!-- node_id = NodeId(id_str='jotr_0') -->
-                                <!-- queried_agg_time_dimension_specs =                                         -->
-                                <!--   (                                                                        -->
-                                <!--     TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH), -->
-                                <!--     TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),   -->
-                                <!--   )                                                                        -->
+                                <!-- queried_agg_time_dimension_specs =                                                    -->
+                                <!--   (                                                                                   -->
+                                <!--     TimeDimensionSpec(                                                                -->
+                                <!--       element_name='metric_time',                                                     -->
+                                <!--       time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                                <!--     ),                                                                                -->
+                                <!--     TimeDimensionSpec(                                                                -->
+                                <!--       element_name='metric_time',                                                     -->
+                                <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),     -->
+                                <!--     ),                                                                                -->
+                                <!--   )                                                                                   -->
                                 <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_to_grain__dfp_0.xml
@@ -20,7 +20,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
@@ -47,13 +51,22 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinToTimeSpineNode>
                                 <!-- description = 'Join to Time Spine Dataset' -->
                                 <!-- node_id = NodeId(id_str='jts_0') -->
-                                <!-- requested_agg_time_dimension_specs =                                     -->
-                                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                <!-- requested_agg_time_dimension_specs =                                              -->
+                                <!--   (                                                                               -->
+                                <!--     TimeDimensionSpec(                                                            -->
+                                <!--       element_name='metric_time',                                                 -->
+                                <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--     ),                                                                            -->
+                                <!--   )                                                                               -->
                                 <!-- use_custom_agg_time_dimension = False -->
                                 <!-- time_range_constraint = None -->
                                 <!-- offset_window = None -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -22,13 +22,22 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -22,13 +22,22 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__month']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                        <!-- include_spec =                                                                      -->
+                        <!--   TimeDimensionSpec(                                                                -->
+                        <!--     element_name='metric_time',                                                     -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                        <!--   )                                                                                 -->
                         <!-- distinct = False -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_agg_time_dimension_specs =                                       -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
+                            <!-- requested_agg_time_dimension_specs =                                                  -->
+                            <!--   (                                                                                   -->
+                            <!--     TimeDimensionSpec(                                                                -->
+                            <!--       element_name='metric_time',                                                     -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                            <!--     ),                                                                                -->
+                            <!--   )                                                                                   -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -22,13 +22,22 @@
                         <!-- description = "Pass Only Elements: ['bookers', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
@@ -37,8 +46,13 @@
                             <JoinOverTimeRangeNode>
                                 <!-- description = 'Join Self Over Time Range' -->
                                 <!-- node_id = NodeId(id_str='jotr_0') -->
-                                <!-- queried_agg_time_dimension_specs =                                       -->
-                                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                <!-- queried_agg_time_dimension_specs =                                                -->
+                                <!--   (                                                                               -->
+                                <!--     TimeDimensionSpec(                                                            -->
+                                <!--       element_name='metric_time',                                                 -->
+                                <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--     ),                                                                            -->
+                                <!--   )                                                                               -->
                                 <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
@@ -7,7 +7,11 @@
             <!-- node_id = NodeId(id_str='pfe_2') -->
             <!-- include_spec =                                                                                         -->
             <!--   DimensionSpec(element_name='is_lux_latest', entity_links=(EntityReference(element_name='listing'),)) -->
-            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+            <!-- include_spec =                                                                      -->
+            <!--   TimeDimensionSpec(                                                                -->
+            <!--     element_name='metric_time',                                                     -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+            <!--   )                                                                                 -->
             <!-- distinct = True -->
             <ConstrainTimeRangeNode>
                 <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]' -->
@@ -27,7 +31,11 @@
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['metric_time__month',]" -->
                         <!-- node_id = NodeId(id_str='pfe_1') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                        <!-- include_spec =                                                                      -->
+                        <!--   TimeDimensionSpec(                                                                -->
+                        <!--     element_name='metric_time',                                                     -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                        <!--   )                                                                                 -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -16,8 +16,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -30,7 +35,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -58,8 +67,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -72,13 +86,22 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_1') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <JoinToTimeSpineNode>
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_1') -->
-                                    <!-- requested_agg_time_dimension_specs =                                     -->
-                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                    <!-- requested_agg_time_dimension_specs =                                              -->
+                                    <!--   (                                                                               -->
+                                    <!--     TimeDimensionSpec(                                                            -->
+                                    <!--       element_name='metric_time',                                                 -->
+                                    <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     ),                                                                            -->
+                                    <!--   )                                                                               -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -81,7 +84,10 @@
                     <!--       time_dimension_specs=(                                      -->
                     <!--         TimeDimensionSpec(                                        -->
                     <!--           element_name='metric_time',                             -->
-                    <!--           time_granularity=DAY,                                   -->
+                    <!--           time_granularity=ExpandedTimeGranularity(               -->
+                    <!--             name='day',                                           -->
+                    <!--             base_granularity=DAY,                                 -->
+                    <!--           ),                                                      -->
                     <!--         ),                                                        -->
                     <!--       ),                                                          -->
                     <!--     ),                                                            -->
@@ -90,8 +96,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint =                             -->
                         <!--   TimeRangeConstraint(                              -->
@@ -136,7 +147,10 @@
                                 <!--       time_dimension_specs=(                                      -->
                                 <!--         TimeDimensionSpec(                                        -->
                                 <!--           element_name='metric_time',                             -->
-                                <!--           time_granularity=DAY,                                   -->
+                                <!--           time_granularity=ExpandedTimeGranularity(               -->
+                                <!--             name='day',                                           -->
+                                <!--             base_granularity=DAY,                                 -->
+                                <!--           ),                                                      -->
                                 <!--         ),                                                        -->
                                 <!--       ),                                                          -->
                                 <!--     ),                                                            -->
@@ -145,8 +159,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <ConstrainTimeRangeNode>
                                         <!-- description =                                                          -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_metric_time__dfp_0.xml
@@ -9,8 +9,13 @@
             <JoinToTimeSpineNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_0') -->
-                <!-- requested_agg_time_dimension_specs =                                     -->
-                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                <!-- requested_agg_time_dimension_specs =                                              -->
+                <!--   (                                                                               -->
+                <!--     TimeDimensionSpec(                                                            -->
+                <!--       element_name='metric_time',                                                 -->
+                <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                <!--     ),                                                                            -->
+                <!--   )                                                                               -->
                 <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = None -->
@@ -23,7 +28,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_non_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_non_metric_time__dfp_0.xml
@@ -13,12 +13,12 @@
                     <!-- description = "Pass Only Elements: ['bookings', 'booking__paid_at__day']" -->
                     <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                    <!-- include_spec =                                               -->
-                    <!--   TimeDimensionSpec(                                         -->
-                    <!--     element_name='paid_at',                                  -->
-                    <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                    <!--     time_granularity=DAY,                                    -->
-                    <!--   )                                                          -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='paid_at',                                                     -->
+                    <!--     entity_links=(EntityReference(element_name='booking'),),                    -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_limit_rows_plan__dfp_0.xml
@@ -17,7 +17,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -73,7 +73,11 @@
                             <!-- description = "Pass Only Elements: ['average_booking_value', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->
                             <!-- include_spec = MeasureSpec(element_name='average_booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -138,8 +142,11 @@
                                     <!--     element_name='is_lux_latest',                            -->
                                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -156,8 +163,14 @@
                                             <!--    "'listing']")                                                        -->
                                             <!-- node_id = NodeId(id_str='pfe_0') -->
                                             <!-- include_spec = MeasureSpec(element_name='average_booking_value') -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
@@ -260,7 +273,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_7') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -325,8 +342,11 @@
                                     <!--     element_name='is_lux_latest',                            -->
                                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -342,8 +362,14 @@
                                             <!--   "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                             <!-- node_id = NodeId(id_str='pfe_4') -->
                                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
@@ -393,7 +419,11 @@
                             <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_8') -->
                             <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -64,7 +64,11 @@
                             <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -119,8 +123,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
@@ -148,7 +155,11 @@
                             <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_2') -->
                             <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_only__dfp_0.xml
@@ -5,7 +5,11 @@
         <FilterElementsNode>
             <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
             <!-- node_id = NodeId(id_str='pfe_0') -->
-            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+            <!-- include_spec =                                                                  -->
+            <!--   TimeDimensionSpec(                                                            -->
+            <!--     element_name='metric_time',                                                 -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--   )                                                                             -->
             <!-- distinct = True -->
             <MetricTimeDimensionTransformNode>
                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_quarter__dfp_0.xml
@@ -5,7 +5,11 @@
         <FilterElementsNode>
             <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
             <!-- node_id = NodeId(id_str='pfe_0') -->
-            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=QUARTER) -->
+            <!-- include_spec =                                                                          -->
+            <!--   TimeDimensionSpec(                                                                    -->
+            <!--     element_name='metric_time',                                                         -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='quarter', base_granularity=QUARTER), -->
+            <!--   )                                                                                     -->
             <!-- distinct = True -->
             <MetricTimeDimensionTransformNode>
                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
@@ -11,8 +11,16 @@
             <!--   DimensionSpec(element_name='home_state_latest', entity_links=(EntityReference(element_name='user'),)) -->
             <!-- include_spec =                                                                                         -->
             <!--   DimensionSpec(element_name='is_lux_latest', entity_links=(EntityReference(element_name='listing'),)) -->
-            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+            <!-- include_spec =                                                                  -->
+            <!--   TimeDimensionSpec(                                                            -->
+            <!--     element_name='metric_time',                                                 -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--   )                                                                             -->
+            <!-- include_spec =                                                                      -->
+            <!--   TimeDimensionSpec(                                                                -->
+            <!--     element_name='metric_time',                                                     -->
+            <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+            <!--   )                                                                                 -->
             <!-- distinct = True -->
             <JoinOnEntitiesNode>
                 <!-- description = 'Join Standard Outputs' -->
@@ -33,8 +41,16 @@
                 <FilterElementsNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day', 'metric_time__month']" -->
                     <!-- node_id = NodeId(id_str='pfe_2') -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
+                    <!-- include_spec =                                                                      -->
+                    <!--   TimeDimensionSpec(                                                                -->
+                    <!--     element_name='metric_time',                                                     -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                    <!--   )                                                                                 -->
                     <!-- distinct = False -->
                     <MetricTimeDimensionTransformNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time__dfp_0.xml
@@ -8,7 +8,11 @@
             <FilterElementsNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                <!-- include_spec =                                                                  -->
+                <!--   TimeDimensionSpec(                                                            -->
+                <!--     element_name='metric_time',                                                 -->
+                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                <!--   )                                                                             -->
                 <!-- distinct = True -->
                 <MetricTimeDimensionTransformNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_metric_time_week__dfp_0.xml
@@ -8,7 +8,11 @@
             <FilterElementsNode>
                 <!-- description = "Pass Only Elements: ['metric_time__week',]" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=WEEK) -->
+                <!-- include_spec =                                                                    -->
+                <!--   TimeDimensionSpec(                                                              -->
+                <!--     element_name='metric_time',                                                   -->
+                <!--     time_granularity=ExpandedTimeGranularity(name='week', base_granularity=WEEK), -->
+                <!--   )                                                                               -->
                 <!-- distinct = True -->
                 <MetricTimeDimensionTransformNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time__dfp_0.xml
@@ -8,12 +8,12 @@
             <FilterElementsNode>
                 <!-- description = "Pass Only Elements: ['booking__paid_at__day',]" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                <!-- include_spec =                                               -->
-                <!--   TimeDimensionSpec(                                         -->
-                <!--     element_name='paid_at',                                  -->
-                <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                <!--     time_granularity=DAY,                                    -->
-                <!--   )                                                          -->
+                <!-- include_spec =                                                                  -->
+                <!--   TimeDimensionSpec(                                                            -->
+                <!--     element_name='paid_at',                                                     -->
+                <!--     entity_links=(EntityReference(element_name='booking'),),                    -->
+                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                <!--   )                                                                             -->
                 <!-- distinct = True -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_min_max_only_time_year__dfp_0.xml
@@ -8,12 +8,12 @@
             <FilterElementsNode>
                 <!-- description = "Pass Only Elements: ['booking__paid_at__year',]" -->
                 <!-- node_id = NodeId(id_str='pfe_0') -->
-                <!-- include_spec =                                               -->
-                <!--   TimeDimensionSpec(                                         -->
-                <!--     element_name='paid_at',                                  -->
-                <!--     entity_links=(EntityReference(element_name='booking'),), -->
-                <!--     time_granularity=YEAR,                                   -->
-                <!--   )                                                          -->
+                <!-- include_spec =                                                                    -->
+                <!--   TimeDimensionSpec(                                                              -->
+                <!--     element_name='paid_at',                                                       -->
+                <!--     entity_links=(EntityReference(element_name='booking'),),                      -->
+                <!--     time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                <!--   )                                                                               -->
                 <!-- distinct = True -->
                 <ReadSqlSourceNode>
                     <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multi_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -26,7 +26,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -41,8 +45,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
@@ -94,7 +101,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -109,8 +120,11 @@
                                     <!-- description = "Pass Only Elements: ['views', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_3') -->
                                     <!-- include_spec = MeasureSpec(element_name='views') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multihop_join_plan__dfp_0.xml
@@ -34,11 +34,17 @@
                         <!--       PartitionTimeDimensionJoinDescription(                      -->
                         <!--         start_node_time_dimension_spec=TimeDimensionSpec(         -->
                         <!--           element_name='ds_partitioned',                          -->
-                        <!--           time_granularity=DAY,                                   -->
+                        <!--           time_granularity=ExpandedTimeGranularity(               -->
+                        <!--             name='day',                                           -->
+                        <!--             base_granularity=DAY,                                 -->
+                        <!--           ),                                                      -->
                         <!--         ),                                                        -->
                         <!--         node_to_join_time_dimension_spec=TimeDimensionSpec(       -->
                         <!--           element_name='ds_partitioned',                          -->
-                        <!--           time_granularity=DAY,                                   -->
+                        <!--           time_granularity=ExpandedTimeGranularity(               -->
+                        <!--             name='day',                                           -->
+                        <!--             base_granularity=DAY,                                 -->
+                        <!--           ),                                                      -->
                         <!--         ),                                                        -->
                         <!--       ),                                                          -->
                         <!--     ),                                                            -->
@@ -47,7 +53,11 @@
                             <!-- description = "Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='txn_count') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='ds_partitioned', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='ds_partitioned',                                              -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- include_spec = LinklessEntitySpec(element_name='account_id') -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
@@ -71,7 +81,11 @@
                             <!--     element_name='customer_name',                                -->
                             <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
                             <!--   )                                                              -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='ds_partitioned', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='ds_partitioned',                                              -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- include_spec = LinklessEntitySpec(element_name='account_id') -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
@@ -86,11 +100,17 @@
                                 <!--       PartitionTimeDimensionJoinDescription(                       -->
                                 <!--         start_node_time_dimension_spec=TimeDimensionSpec(          -->
                                 <!--           element_name='ds_partitioned',                           -->
-                                <!--           time_granularity=DAY,                                    -->
+                                <!--           time_granularity=ExpandedTimeGranularity(                -->
+                                <!--             name='day',                                            -->
+                                <!--             base_granularity=DAY,                                  -->
+                                <!--           ),                                                       -->
                                 <!--         ),                                                         -->
                                 <!--         node_to_join_time_dimension_spec=TimeDimensionSpec(        -->
                                 <!--           element_name='ds_partitioned',                           -->
-                                <!--           time_granularity=DAY,                                    -->
+                                <!--           time_granularity=ExpandedTimeGranularity(                -->
+                                <!--             name='day',                                            -->
+                                <!--             base_granularity=DAY,                                  -->
+                                <!--           ),                                                       -->
                                 <!--         ),                                                         -->
                                 <!--       ),                                                           -->
                                 <!--     ),                                                             -->
@@ -160,170 +180,218 @@
                                     <!--     element_name='customer_atomic_weight',                       -->
                                     <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
                                     <!--   )                                                              -->
-                                    <!-- include_spec =                                                           -->
-                                    <!--   TimeDimensionSpec(element_name='ds_partitioned', time_granularity=DAY) -->
-                                    <!-- include_spec =                                                            -->
-                                    <!--   TimeDimensionSpec(element_name='ds_partitioned', time_granularity=WEEK) -->
-                                    <!-- include_spec =                                                             -->
-                                    <!--   TimeDimensionSpec(element_name='ds_partitioned', time_granularity=MONTH) -->
-                                    <!-- include_spec =                                                               -->
-                                    <!--   TimeDimensionSpec(element_name='ds_partitioned', time_granularity=QUARTER) -->
-                                    <!-- include_spec =                                                            -->
-                                    <!--   TimeDimensionSpec(element_name='ds_partitioned', time_granularity=YEAR) -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=YEAR,                -->
-                                    <!--   )                                -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=QUARTER,             -->
-                                    <!--   )                                -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=MONTH,               -->
-                                    <!--   )                                -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=DAY,                 -->
-                                    <!--   )                                -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=DOW,                 -->
-                                    <!--   )                                -->
-                                    <!-- include_spec =                     -->
-                                    <!--   TimeDimensionSpec(               -->
-                                    <!--     element_name='ds_partitioned', -->
-                                    <!--     time_granularity=DAY,          -->
-                                    <!--     date_part=DOY,                 -->
-                                    <!--   )                                -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='ds_partitioned',                                                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='week', base_granularity=WEEK), -->
+                                    <!--   )                                                                               -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='ds_partitioned',            -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='month',                           -->
+                                    <!--       base_granularity=MONTH,                 -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='ds_partitioned',            -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='quarter',                         -->
+                                    <!--       base_granularity=QUARTER,               -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='ds_partitioned',                                                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                                    <!--   )                                                                               -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=YEAR,                                                             -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=QUARTER,                                                          -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=MONTH,                                                            -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DAY,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOW,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOY,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='ds_partitioned',                                                -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                  -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='week', base_granularity=WEEK), -->
+                                    <!--   )                                                                               -->
                                     <!-- include_spec =                                                   -->
                                     <!--   TimeDimensionSpec(                                             -->
                                     <!--     element_name='ds_partitioned',                               -->
                                     <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(                    -->
+                                    <!--       name='month',                                              -->
+                                    <!--       base_granularity=MONTH,                                    -->
+                                    <!--     ),                                                           -->
                                     <!--   )                                                              -->
                                     <!-- include_spec =                                                   -->
                                     <!--   TimeDimensionSpec(                                             -->
                                     <!--     element_name='ds_partitioned',                               -->
                                     <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=WEEK,                                       -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(                    -->
+                                    <!--       name='quarter',                                            -->
+                                    <!--       base_granularity=QUARTER,                                  -->
+                                    <!--     ),                                                           -->
                                     <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=MONTH,                                      -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=QUARTER,                                    -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=YEAR,                                       -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=YEAR,                                              -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=QUARTER,                                           -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=MONTH,                                             -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=DAY,                                               -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=DOW,                                               -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                   -->
-                                    <!--   TimeDimensionSpec(                                             -->
-                                    <!--     element_name='ds_partitioned',                               -->
-                                    <!--     entity_links=(EntityReference(element_name='customer_id'),), -->
-                                    <!--     time_granularity=DAY,                                        -->
-                                    <!--     date_part=DOY,                                               -->
-                                    <!--   )                                                              -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
-                                    <!-- include_spec =                                                         -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=WEEK) -->
-                                    <!-- include_spec =                                                          -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
-                                    <!-- include_spec =                                                            -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=QUARTER) -->
-                                    <!-- include_spec =                                                         -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=YEAR) -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=YEAR,             -->
-                                    <!--   )                             -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=QUARTER,          -->
-                                    <!--   )                             -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=MONTH,            -->
-                                    <!--   )                             -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=DAY,              -->
-                                    <!--   )                             -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=DOW,              -->
-                                    <!--   )                             -->
-                                    <!-- include_spec =                  -->
-                                    <!--   TimeDimensionSpec(            -->
-                                    <!--     element_name='metric_time', -->
-                                    <!--     time_granularity=DAY,       -->
-                                    <!--     date_part=DOY,              -->
-                                    <!--   )                             -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='ds_partitioned',                                                -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                  -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                                    <!--   )                                                                               -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=YEAR,                                                             -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=QUARTER,                                                          -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=MONTH,                                                            -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DAY,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOW,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds_partitioned',                                              -->
+                                    <!--     entity_links=(EntityReference(element_name='customer_id'),),                -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOY,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='metric_time',                                                   -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='week', base_granularity=WEEK), -->
+                                    <!--   )                                                                               -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='metric_time',               -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='month',                           -->
+                                    <!--       base_granularity=MONTH,                 -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='metric_time',               -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='quarter',                         -->
+                                    <!--       base_granularity=QUARTER,               -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                                                    -->
+                                    <!--   TimeDimensionSpec(                                                              -->
+                                    <!--     element_name='metric_time',                                                   -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='year', base_granularity=YEAR), -->
+                                    <!--   )                                                                               -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=YEAR,                                                             -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=QUARTER,                                                          -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=MONTH,                                                            -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DAY,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOW,                                                              -->
+                                    <!--   )                                                                             -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     date_part=DOY,                                                              -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = EntitySpec(element_name='customer_id') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_multiple_metrics_plan__dfp_0.xml
@@ -21,7 +21,11 @@
                         <!--     element_name='is_instant',                               -->
                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -53,7 +57,11 @@
                         <!--     element_name='is_instant',                               -->
                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -9,8 +9,13 @@
             <JoinToTimeSpineNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
                 <!-- node_id = NodeId(id_str='jts_1') -->
-                <!-- requested_agg_time_dimension_specs =                                     -->
-                <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                <!-- requested_agg_time_dimension_specs =                                              -->
+                <!--   (                                                                               -->
+                <!--     TimeDimensionSpec(                                                            -->
+                <!--       element_name='metric_time',                                                 -->
+                <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                <!--     ),                                                                            -->
+                <!--   )                                                                               -->
                 <!-- use_custom_agg_time_dimension = False -->
                 <!-- time_range_constraint = None -->
                 <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
@@ -39,13 +44,22 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <JoinToTimeSpineNode>
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_0') -->
-                                    <!-- requested_agg_time_dimension_specs =                                     -->
-                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                    <!-- requested_agg_time_dimension_specs =                                              -->
+                                    <!--   (                                                                               -->
+                                    <!--     TimeDimensionSpec(                                                            -->
+                                    <!--       element_name='metric_time',                                                 -->
+                                    <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     ),                                                                            -->
+                                    <!--   )                                                                               -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -79,7 +82,10 @@
                 <!--           time_dimension_specs=(                                      -->
                 <!--             TimeDimensionSpec(                                        -->
                 <!--               element_name='metric_time',                             -->
-                <!--               time_granularity=DAY,                                   -->
+                <!--               time_granularity=ExpandedTimeGranularity(               -->
+                <!--                 name='day',                                           -->
+                <!--                 base_granularity=DAY,                                 -->
+                <!--               ),                                                      -->
                 <!--             ),                                                        -->
                 <!--           ),                                                          -->
                 <!--         ),                                                            -->
@@ -95,7 +101,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__month']" -->
                         <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                        <!-- include_spec =                                                                      -->
+                        <!--   TimeDimensionSpec(                                                                -->
+                        <!--     element_name='metric_time',                                                     -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                        <!--   )                                                                                 -->
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
@@ -129,7 +139,10 @@
                             <!--       time_dimension_specs=(                                      -->
                             <!--         TimeDimensionSpec(                                        -->
                             <!--           element_name='metric_time',                             -->
-                            <!--           time_granularity=DAY,                                   -->
+                            <!--           time_granularity=ExpandedTimeGranularity(               -->
+                            <!--             name='day',                                           -->
+                            <!--             base_granularity=DAY,                                 -->
+                            <!--           ),                                                      -->
                             <!--         ),                                                        -->
                             <!--       ),                                                          -->
                             <!--     ),                                                            -->
@@ -139,15 +152,30 @@
                                 <!--   "Pass Only Elements: ['bookings', 'metric_time__month', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec =                                                          -->
-                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                      -->
+                                <!--   TimeDimensionSpec(                                                                -->
+                                <!--     element_name='metric_time',                                                     -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                                <!--   )                                                                                 -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <JoinToTimeSpineNode>
                                     <!-- description = 'Join to Time Spine Dataset' -->
                                     <!-- node_id = NodeId(id_str='jts_0') -->
-                                    <!-- requested_agg_time_dimension_specs =                                       -->
-                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
+                                    <!-- requested_agg_time_dimension_specs =            -->
+                                    <!--   (                                             -->
+                                    <!--     TimeDimensionSpec(                          -->
+                                    <!--       element_name='metric_time',               -->
+                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                    <!--         name='month',                           -->
+                                    <!--         base_granularity=MONTH,                 -->
+                                    <!--       ),                                        -->
+                                    <!--     ),                                          -->
+                                    <!--   )                                             -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- time_range_constraint = None -->
                                     <!-- offset_window = None -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -82,7 +85,10 @@
                     <!--           time_dimension_specs=(                                       -->
                     <!--             TimeDimensionSpec(                                         -->
                     <!--               element_name='metric_time',                              -->
-                    <!--               time_granularity=DAY,                                    -->
+                    <!--               time_granularity=ExpandedTimeGranularity(                -->
+                    <!--                 name='day',                                            -->
+                    <!--                 base_granularity=DAY,                                  -->
+                    <!--               ),                                                       -->
                     <!--             ),                                                         -->
                     <!--           ),                                                           -->
                     <!--         ),                                                             -->
@@ -97,7 +103,11 @@
                             <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__month']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                            <!-- include_spec =                                                                      -->
+                            <!--   TimeDimensionSpec(                                                                -->
+                            <!--     element_name='metric_time',                                                     -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                            <!--   )                                                                                 -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -131,7 +141,10 @@
                                 <!--       time_dimension_specs=(                                      -->
                                 <!--         TimeDimensionSpec(                                        -->
                                 <!--           element_name='metric_time',                             -->
-                                <!--           time_granularity=DAY,                                   -->
+                                <!--           time_granularity=ExpandedTimeGranularity(               -->
+                                <!--             name='day',                                           -->
+                                <!--             base_granularity=DAY,                                 -->
+                                <!--           ),                                                      -->
                                 <!--         ),                                                        -->
                                 <!--       ),                                                          -->
                                 <!--     ),                                                            -->
@@ -142,16 +155,33 @@
                                     <!--    "'metric_time__day']")                                         -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                                    <!-- include_spec =                                                          -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='metric_time',               -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='month',                           -->
+                                    <!--       base_granularity=MONTH,                 -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinToTimeSpineNode>
                                         <!-- description = 'Join to Time Spine Dataset' -->
                                         <!-- node_id = NodeId(id_str='jts_0') -->
-                                        <!-- requested_agg_time_dimension_specs =                                       -->
-                                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH),) -->
+                                        <!-- requested_agg_time_dimension_specs =            -->
+                                        <!--   (                                             -->
+                                        <!--     TimeDimensionSpec(                          -->
+                                        <!--       element_name='metric_time',               -->
+                                        <!--       time_granularity=ExpandedTimeGranularity( -->
+                                        <!--         name='month',                           -->
+                                        <!--         base_granularity=MONTH,                 -->
+                                        <!--       ),                                        -->
+                                        <!--     ),                                          -->
+                                        <!--   )                                             -->
                                         <!-- use_custom_agg_time_dimension = False -->
                                         <!-- time_range_constraint = None -->
                                         <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity=WEEK) -->
@@ -208,7 +238,10 @@
                     <!--           time_dimension_specs=(                                      -->
                     <!--             TimeDimensionSpec(                                        -->
                     <!--               element_name='metric_time',                             -->
-                    <!--               time_granularity=DAY,                                   -->
+                    <!--               time_granularity=ExpandedTimeGranularity(               -->
+                    <!--                 name='day',                                           -->
+                    <!--                 base_granularity=DAY,                                 -->
+                    <!--               ),                                                      -->
                     <!--             ),                                                        -->
                     <!--           ),                                                          -->
                     <!--         ),                                                            -->
@@ -222,7 +255,11 @@
                             <!-- description = "Pass Only Elements: ['bookers', 'metric_time__month']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->
                             <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
+                            <!-- include_spec =                                                                      -->
+                            <!--   TimeDimensionSpec(                                                                -->
+                            <!--     element_name='metric_time',                                                     -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='month', base_granularity=MONTH), -->
+                            <!--   )                                                                                 -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -256,7 +293,10 @@
                                 <!--       time_dimension_specs=(                                      -->
                                 <!--         TimeDimensionSpec(                                        -->
                                 <!--           element_name='metric_time',                             -->
-                                <!--           time_granularity=DAY,                                   -->
+                                <!--           time_granularity=ExpandedTimeGranularity(               -->
+                                <!--             name='day',                                           -->
+                                <!--             base_granularity=DAY,                                 -->
+                                <!--           ),                                                      -->
                                 <!--         ),                                                        -->
                                 <!--       ),                                                          -->
                                 <!--     ),                                                            -->
@@ -266,10 +306,19 @@
                                     <!--   "Pass Only Elements: ['bookers', 'metric_time__month', 'metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_2') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                                    <!-- include_spec =                                                          -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=MONTH) -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                -->
+                                    <!--   TimeDimensionSpec(                          -->
+                                    <!--     element_name='metric_time',               -->
+                                    <!--     time_granularity=ExpandedTimeGranularity( -->
+                                    <!--       name='month',                           -->
+                                    <!--       base_granularity=MONTH,                 -->
+                                    <!--     ),                                        -->
+                                    <!--   )                                           -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_order_by_plan__dfp_0.xml
@@ -5,11 +5,14 @@
         <OrderByLimitNode>
             <!-- description = "Order By ['metric_time__day', 'bookings']" -->
             <!-- node_id = NodeId(id_str='obl_0') -->
-            <!-- order_by_spec =                                                                        -->
-            <!--   OrderBySpec(                                                                         -->
-            <!--     instance_spec=TimeDimensionSpec(element_name='metric_time', time_granularity=DAY), -->
-            <!--     descending=False,                                                                  -->
-            <!--   )                                                                                    -->
+            <!-- order_by_spec =                                                                   -->
+            <!--   OrderBySpec(                                                                    -->
+            <!--     instance_spec=TimeDimensionSpec(                                              -->
+            <!--       element_name='metric_time',                                                 -->
+            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--     ),                                                                            -->
+            <!--     descending=False,                                                             -->
+            <!--   )                                                                               -->
             <!-- order_by_spec = OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True) -->
             <!-- limit = 'None' -->
             <ComputeMetricsNode>
@@ -23,7 +26,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_single_semantic_model_ratio_metrics_plan__dfp_0.xml
@@ -26,7 +26,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -41,8 +45,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
@@ -94,7 +101,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -109,8 +120,11 @@
                                     <!-- description = "Pass Only Elements: ['bookers', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_3') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -89,7 +92,10 @@
                         <!--       time_dimension_specs=(                                      -->
                         <!--         TimeDimensionSpec(                                        -->
                         <!--           element_name='metric_time',                             -->
-                        <!--           time_granularity=DAY,                                   -->
+                        <!--           time_granularity=ExpandedTimeGranularity(               -->
+                        <!--             name='day',                                           -->
+                        <!--             base_granularity=DAY,                                 -->
+                        <!--           ),                                                      -->
                         <!--         ),                                                        -->
                         <!--       ),                                                          -->
                         <!--     ),                                                            -->
@@ -104,7 +110,11 @@
                             <!--     element_name='is_instant',                               -->
                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -5,8 +5,13 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+            <!-- requested_agg_time_dimension_specs =                                              -->
+            <!--   (                                                                               -->
+            <!--     TimeDimensionSpec(                                                            -->
+            <!--       element_name='metric_time',                                                 -->
+            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--     ),                                                                            -->
+            <!--   )                                                                               -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
@@ -27,7 +32,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -5,8 +5,13 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+            <!-- requested_agg_time_dimension_specs =                                              -->
+            <!--   (                                                                               -->
+            <!--     TimeDimensionSpec(                                                            -->
+            <!--       element_name='metric_time',                                                 -->
+            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--     ),                                                                            -->
+            <!--   )                                                                               -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
@@ -27,7 +32,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -5,8 +5,13 @@
         <JoinToTimeSpineNode>
             <!-- description = 'Join to Time Spine Dataset' -->
             <!-- node_id = NodeId(id_str='jts_0') -->
-            <!-- requested_agg_time_dimension_specs =                                     -->
-            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+            <!-- requested_agg_time_dimension_specs =                                              -->
+            <!--   (                                                                               -->
+            <!--     TimeDimensionSpec(                                                            -->
+            <!--       element_name='metric_time',                                                 -->
+            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+            <!--     ),                                                                            -->
+            <!--   )                                                                               -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
@@ -27,7 +32,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -65,7 +65,11 @@
                         <!--     element_name='home_state_latest',                     -->
                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                         <!--   )                                                       -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
@@ -125,7 +129,11 @@
                                 <!--     element_name='referrer_id',                            -->
                                 <!--     entity_links=(EntityReference(element_name='visit'),), -->
                                 <!--   )                                                        -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <JoinOnEntitiesNode>
                                     <!-- description = 'Join Standard Outputs' -->
@@ -147,8 +155,14 @@
                                         <!--     element_name='referrer_id',                            -->
                                         <!--     entity_links=(EntityReference(element_name='visit'),), -->
                                         <!--   )                                                        -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                         <!-- distinct = False -->
                                         <MetricTimeDimensionTransformNode>
@@ -191,7 +205,11 @@
                         <!--     element_name='home_state_latest',                     -->
                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                         <!--   )                                                       -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -212,16 +230,26 @@
                                 <!--     element_name='referrer_id',                            -->
                                 <!--     entity_links=(EntityReference(element_name='visit'),), -->
                                 <!--   )                                                        -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                 <!-- distinct = False -->
                                 <JoinConversionEventsNode>
                                     <!-- description = 'Find conversions for user within the range of 7 day' -->
                                     <!-- node_id = NodeId(id_str='jce_0') -->
-                                    <!-- base_time_dimension_spec =                                   -->
-                                    <!--   TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
-                                    <!-- conversion_time_dimension_spec =                             -->
-                                    <!--   TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
+                                    <!-- base_time_dimension_spec =                                                      -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds',                                                          -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
+                                    <!-- conversion_time_dimension_spec =                                                -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds',                                                          -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- entity_spec = EntitySpec(element_name='user') -->
                                     <!-- window = PydanticMetricTimeWindow(count=7, granularity=DAY) -->
                                     <!-- unique_key_specs = MetadataSpec(element_name='mf_internal_uuid') -->
@@ -241,9 +269,22 @@
                                         <!--     element_name='home_state_latest',                     -->
                                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                                         <!--   )                                                       -->
-                                        <!-- include_spec = TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='ds',                        -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- include_spec = EntitySpec(element_name='user') -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -65,7 +65,11 @@
                         <!--     element_name='home_state_latest',                     -->
                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                         <!--   )                                                       -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <FilterElementsNode>
                             <!-- description =                                                                         -->
@@ -83,7 +87,11 @@
                             <!--     element_name='referrer_id',                            -->
                             <!--     entity_links=(EntityReference(element_name='visit'),), -->
                             <!--   )                                                        -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -105,8 +113,11 @@
                                     <!--     element_name='referrer_id',                            -->
                                     <!--     entity_links=(EntityReference(element_name='visit'),), -->
                                     <!--   )                                                        -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                     <!-- distinct = False -->
                                     <WhereConstraintNode>
@@ -191,7 +202,11 @@
                         <!--     element_name='home_state_latest',                     -->
                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                         <!--   )                                                       -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -212,16 +227,26 @@
                                 <!--     element_name='referrer_id',                            -->
                                 <!--     entity_links=(EntityReference(element_name='visit'),), -->
                                 <!--   )                                                        -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                 <!-- distinct = False -->
                                 <JoinConversionEventsNode>
                                     <!-- description = 'Find conversions for user within the range of 7 day' -->
                                     <!-- node_id = NodeId(id_str='jce_1') -->
-                                    <!-- base_time_dimension_spec =                                   -->
-                                    <!--   TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
-                                    <!-- conversion_time_dimension_spec =                             -->
-                                    <!--   TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
+                                    <!-- base_time_dimension_spec =                                                      -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds',                                                          -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
+                                    <!-- conversion_time_dimension_spec =                                                -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='ds',                                                          -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- entity_spec = EntitySpec(element_name='user') -->
                                     <!-- window = PydanticMetricTimeWindow(count=7, granularity=DAY) -->
                                     <!-- unique_key_specs = MetadataSpec(element_name='mf_internal_uuid') -->
@@ -241,9 +266,22 @@
                                         <!--     element_name='home_state_latest',                     -->
                                         <!--     entity_links=(EntityReference(element_name='user'),), -->
                                         <!--   )                                                       -->
-                                        <!-- include_spec = TimeDimensionSpec(element_name='ds', time_granularity=DAY) -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='ds',                        -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- include_spec = EntitySpec(element_name='user') -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
@@ -61,7 +61,11 @@
                     <!--     element_name='country_latest',                           -->
                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                     <!--   )                                                          -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
@@ -121,7 +125,11 @@
                             <!--     element_name='is_instant',                               -->
                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -143,15 +151,26 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <JoinOverTimeRangeNode>
                                         <!-- description = 'Join Self Over Time Range' -->
                                         <!-- node_id = NodeId(id_str='jotr_0') -->
-                                        <!-- queried_agg_time_dimension_specs =                                       -->
-                                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                        <!-- queried_agg_time_dimension_specs =              -->
+                                        <!--   (                                             -->
+                                        <!--     TimeDimensionSpec(                          -->
+                                        <!--       element_name='metric_time',               -->
+                                        <!--       time_granularity=ExpandedTimeGranularity( -->
+                                        <!--         name='day',                             -->
+                                        <!--         base_granularity=DAY,                   -->
+                                        <!--       ),                                        -->
+                                        <!--     ),                                          -->
+                                        <!--   )                                             -->
                                         <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                                         <MetricTimeDimensionTransformNode>
                                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -61,7 +61,11 @@
                     <!--     element_name='country_latest',                           -->
                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                     <!--   )                                                          -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <FilterElementsNode>
                         <!-- description =                                                                           -->
@@ -79,7 +83,11 @@
                         <!--     element_name='is_instant',                               -->
                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -101,14 +109,23 @@
                                 <!--     element_name='is_instant',                               -->
                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                 <!-- distinct = False -->
                                 <JoinOverTimeRangeNode>
                                     <!-- description = 'Join Self Over Time Range' -->
                                     <!-- node_id = NodeId(id_str='jotr_1') -->
-                                    <!-- queried_agg_time_dimension_specs =                                       -->
-                                    <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                                    <!-- queried_agg_time_dimension_specs =                                                -->
+                                    <!--   (                                                                               -->
+                                    <!--     TimeDimensionSpec(                                                            -->
+                                    <!--       element_name='metric_time',                                                 -->
+                                    <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--     ),                                                                            -->
+                                    <!--   )                                                                               -->
                                     <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
                                     <WhereConstraintNode>
                                         <!-- description = 'Constrain Output with WHERE' -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -102,8 +102,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_0') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -122,7 +127,11 @@
                                 <!--     element_name='country_latest',                           -->
                                 <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <WhereConstraintNode>
                                     <!-- description = 'Constrain Output with WHERE' -->
@@ -182,8 +191,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -205,8 +220,14 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <MetricTimeDimensionTransformNode>
@@ -298,8 +319,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -318,7 +344,11 @@
                                 <!--     element_name='country_latest',                           -->
                                 <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <WhereConstraintNode>
                                     <!-- description = 'Constrain Output with WHERE' -->
@@ -378,8 +408,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -401,20 +437,29 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <JoinToTimeSpineNode>
                                                     <!-- description = 'Join to Time Spine Dataset' -->
                                                     <!-- node_id = NodeId(id_str='jts_1') -->
-                                                    <!-- requested_agg_time_dimension_specs =  -->
-                                                    <!--   (                               -->
-                                                    <!--     TimeDimensionSpec(            -->
-                                                    <!--       element_name='metric_time', -->
-                                                    <!--       time_granularity=DAY,       -->
-                                                    <!--     ),                            -->
-                                                    <!--   )                               -->
+                                                    <!-- requested_agg_time_dimension_specs =            -->
+                                                    <!--   (                                             -->
+                                                    <!--     TimeDimensionSpec(                          -->
+                                                    <!--       element_name='metric_time',               -->
+                                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                    <!--         name='day',                             -->
+                                                    <!--         base_granularity=DAY,                   -->
+                                                    <!--       ),                                        -->
+                                                    <!--     ),                                          -->
+                                                    <!--   )                                             -->
                                                     <!-- use_custom_agg_time_dimension = False -->
                                                     <!-- time_range_constraint = None -->
                                                     <!-- offset_window =                                       -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -102,8 +102,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_3') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -122,7 +127,11 @@
                                 <!--     element_name='country_latest',                           -->
                                 <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <FilterElementsNode>
                                     <!-- description =                                                     -->
@@ -140,8 +149,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -163,8 +175,14 @@
                                             <!--     element_name='is_instant',                               -->
                                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                             <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <WhereConstraintNode>
@@ -300,8 +318,13 @@
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_5') -->
-                        <!-- requested_agg_time_dimension_specs =                                     -->
-                        <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                        <!-- requested_agg_time_dimension_specs =                                              -->
+                        <!--   (                                                                               -->
+                        <!--     TimeDimensionSpec(                                                            -->
+                        <!--       element_name='metric_time',                                                 -->
+                        <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--     ),                                                                            -->
+                        <!--   )                                                                               -->
                         <!-- use_custom_agg_time_dimension = False -->
                         <!-- time_range_constraint = None -->
                         <!-- offset_window = None -->
@@ -320,7 +343,11 @@
                                 <!--     element_name='country_latest',                           -->
                                 <!--     entity_links=(EntityReference(element_name='listing'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <WhereConstraintNode>
                                     <!-- description = 'Constrain Output with WHERE' -->
@@ -380,8 +407,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -403,20 +436,29 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <JoinToTimeSpineNode>
                                                     <!-- description = 'Join to Time Spine Dataset' -->
                                                     <!-- node_id = NodeId(id_str='jts_4') -->
-                                                    <!-- requested_agg_time_dimension_specs =  -->
-                                                    <!--   (                               -->
-                                                    <!--     TimeDimensionSpec(            -->
-                                                    <!--       element_name='metric_time', -->
-                                                    <!--       time_granularity=DAY,       -->
-                                                    <!--     ),                            -->
-                                                    <!--   )                               -->
+                                                    <!-- requested_agg_time_dimension_specs =            -->
+                                                    <!--   (                                             -->
+                                                    <!--     TimeDimensionSpec(                          -->
+                                                    <!--       element_name='metric_time',               -->
+                                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                    <!--         name='day',                             -->
+                                                    <!--         base_granularity=DAY,                   -->
+                                                    <!--       ),                                        -->
+                                                    <!--     ),                                          -->
+                                                    <!--   )                                             -->
                                                     <!-- use_custom_agg_time_dimension = False -->
                                                     <!-- time_range_constraint = None -->
                                                     <!-- offset_window =                                       -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -145,8 +145,13 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_0') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = None -->
@@ -213,8 +218,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -236,8 +247,14 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <MetricTimeDimensionTransformNode>
@@ -372,8 +389,13 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_2') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = None -->
@@ -440,8 +462,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -463,20 +491,29 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <JoinToTimeSpineNode>
                                                     <!-- description = 'Join to Time Spine Dataset' -->
                                                     <!-- node_id = NodeId(id_str='jts_1') -->
-                                                    <!-- requested_agg_time_dimension_specs =  -->
-                                                    <!--   (                               -->
-                                                    <!--     TimeDimensionSpec(            -->
-                                                    <!--       element_name='metric_time', -->
-                                                    <!--       time_granularity=DAY,       -->
-                                                    <!--     ),                            -->
-                                                    <!--   )                               -->
+                                                    <!-- requested_agg_time_dimension_specs =            -->
+                                                    <!--   (                                             -->
+                                                    <!--     TimeDimensionSpec(                          -->
+                                                    <!--       element_name='metric_time',               -->
+                                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                    <!--         name='day',                             -->
+                                                    <!--         base_granularity=DAY,                   -->
+                                                    <!--       ),                                        -->
+                                                    <!--     ),                                          -->
+                                                    <!--   )                                             -->
                                                     <!-- use_custom_agg_time_dimension = False -->
                                                     <!-- time_range_constraint = None -->
                                                     <!-- offset_window =                                       -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -145,8 +145,13 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_3') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = None -->
@@ -171,8 +176,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -194,8 +202,14 @@
                                             <!--     element_name='is_instant',                               -->
                                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                             <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <WhereConstraintNode>
@@ -374,8 +388,13 @@
                         <JoinToTimeSpineNode>
                             <!-- description = 'Join to Time Spine Dataset' -->
                             <!-- node_id = NodeId(id_str='jts_5') -->
-                            <!-- requested_agg_time_dimension_specs =                                     -->
-                            <!--   (TimeDimensionSpec(element_name='metric_time', time_granularity=DAY),) -->
+                            <!-- requested_agg_time_dimension_specs =                                              -->
+                            <!--   (                                                                               -->
+                            <!--     TimeDimensionSpec(                                                            -->
+                            <!--       element_name='metric_time',                                                 -->
+                            <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--     ),                                                                            -->
+                            <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- time_range_constraint = None -->
                             <!-- offset_window = None -->
@@ -442,8 +461,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- distinct = False -->
                                         <JoinOnEntitiesNode>
                                             <!-- description = 'Join Standard Outputs' -->
@@ -465,20 +490,29 @@
                                                 <!--     element_name='is_instant',                               -->
                                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                                 <!--   )                                                          -->
-                                                <!-- include_spec =                                                        -->
-                                                <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                                <!-- include_spec =                                -->
+                                                <!--   TimeDimensionSpec(                          -->
+                                                <!--     element_name='metric_time',               -->
+                                                <!--     time_granularity=ExpandedTimeGranularity( -->
+                                                <!--       name='day',                             -->
+                                                <!--       base_granularity=DAY,                   -->
+                                                <!--     ),                                        -->
+                                                <!--   )                                           -->
                                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                                 <!-- distinct = False -->
                                                 <JoinToTimeSpineNode>
                                                     <!-- description = 'Join to Time Spine Dataset' -->
                                                     <!-- node_id = NodeId(id_str='jts_4') -->
-                                                    <!-- requested_agg_time_dimension_specs =  -->
-                                                    <!--   (                               -->
-                                                    <!--     TimeDimensionSpec(            -->
-                                                    <!--       element_name='metric_time', -->
-                                                    <!--       time_granularity=DAY,       -->
-                                                    <!--     ),                            -->
-                                                    <!--   )                               -->
+                                                    <!-- requested_agg_time_dimension_specs =            -->
+                                                    <!--   (                                             -->
+                                                    <!--     TimeDimensionSpec(                          -->
+                                                    <!--       element_name='metric_time',               -->
+                                                    <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                    <!--         name='day',                             -->
+                                                    <!--         base_granularity=DAY,                   -->
+                                                    <!--       ),                                        -->
+                                                    <!--     ),                                          -->
+                                                    <!--   )                                             -->
                                                     <!-- use_custom_agg_time_dimension = False -->
                                                     <!-- time_range_constraint = None -->
                                                     <!-- offset_window =                                       -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -112,7 +112,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -172,8 +176,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -195,8 +202,14 @@
                                             <!--     element_name='is_instant',                               -->
                                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                             <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <MetricTimeDimensionTransformNode>
@@ -297,7 +310,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -357,8 +374,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -380,20 +400,29 @@
                                             <!--     element_name='is_instant',                               -->
                                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                             <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <JoinToTimeSpineNode>
                                                 <!-- description = 'Join to Time Spine Dataset' -->
                                                 <!-- node_id = NodeId(id_str='jts_0') -->
-                                                <!-- requested_agg_time_dimension_specs =  -->
-                                                <!--   (                               -->
-                                                <!--     TimeDimensionSpec(            -->
-                                                <!--       element_name='metric_time', -->
-                                                <!--       time_granularity=DAY,       -->
-                                                <!--     ),                            -->
-                                                <!--   )                               -->
+                                                <!-- requested_agg_time_dimension_specs =            -->
+                                                <!--   (                                             -->
+                                                <!--     TimeDimensionSpec(                          -->
+                                                <!--       element_name='metric_time',               -->
+                                                <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                <!--         name='day',                             -->
+                                                <!--         base_granularity=DAY,                   -->
+                                                <!--       ),                                        -->
+                                                <!--     ),                                          -->
+                                                <!--   )                                             -->
                                                 <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- time_range_constraint = None -->
                                                 <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -112,7 +112,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <FilterElementsNode>
                                 <!-- description =                                                     -->
@@ -130,7 +134,11 @@
                                 <!--     element_name='is_instant',                               -->
                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <JoinOnEntitiesNode>
                                     <!-- description = 'Join Standard Outputs' -->
@@ -152,8 +160,14 @@
                                         <!--     element_name='is_instant',                               -->
                                         <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                         <!--   )                                                          -->
-                                        <!-- include_spec =                                                        -->
-                                        <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                        <!-- include_spec =                                -->
+                                        <!--   TimeDimensionSpec(                          -->
+                                        <!--     element_name='metric_time',               -->
+                                        <!--     time_granularity=ExpandedTimeGranularity( -->
+                                        <!--       name='day',                             -->
+                                        <!--       base_granularity=DAY,                   -->
+                                        <!--     ),                                        -->
+                                        <!--   )                                           -->
                                         <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                         <!-- distinct = False -->
                                         <WhereConstraintNode>
@@ -295,7 +309,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
@@ -355,8 +373,11 @@
                                     <!--     element_name='is_instant',                               -->
                                     <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                     <!--   )                                                          -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
@@ -378,20 +399,29 @@
                                             <!--     element_name='is_instant',                               -->
                                             <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                             <!--   )                                                          -->
-                                            <!-- include_spec =                                                        -->
-                                            <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                            <!-- include_spec =                                -->
+                                            <!--   TimeDimensionSpec(                          -->
+                                            <!--     element_name='metric_time',               -->
+                                            <!--     time_granularity=ExpandedTimeGranularity( -->
+                                            <!--       name='day',                             -->
+                                            <!--       base_granularity=DAY,                   -->
+                                            <!--     ),                                        -->
+                                            <!--   )                                           -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                             <!-- distinct = False -->
                                             <JoinToTimeSpineNode>
                                                 <!-- description = 'Join to Time Spine Dataset' -->
                                                 <!-- node_id = NodeId(id_str='jts_1') -->
-                                                <!-- requested_agg_time_dimension_specs =  -->
-                                                <!--   (                               -->
-                                                <!--     TimeDimensionSpec(            -->
-                                                <!--       element_name='metric_time', -->
-                                                <!--       time_granularity=DAY,       -->
-                                                <!--     ),                            -->
-                                                <!--   )                               -->
+                                                <!-- requested_agg_time_dimension_specs =            -->
+                                                <!--   (                                             -->
+                                                <!--     TimeDimensionSpec(                          -->
+                                                <!--       element_name='metric_time',               -->
+                                                <!--       time_granularity=ExpandedTimeGranularity( -->
+                                                <!--         name='day',                             -->
+                                                <!--         base_granularity=DAY,                   -->
+                                                <!--       ),                                        -->
+                                                <!--     ),                                          -->
+                                                <!--   )                                             -->
                                                 <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- time_range_constraint = None -->
                                                 <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -89,7 +92,10 @@
                         <!--       time_dimension_specs=(                                      -->
                         <!--         TimeDimensionSpec(                                        -->
                         <!--           element_name='metric_time',                             -->
-                        <!--           time_granularity=DAY,                                   -->
+                        <!--           time_granularity=ExpandedTimeGranularity(               -->
+                        <!--             name='day',                                           -->
+                        <!--             base_granularity=DAY,                                 -->
+                        <!--           ),                                                      -->
                         <!--         ),                                                        -->
                         <!--       ),                                                          -->
                         <!--     ),                                                            -->
@@ -104,7 +110,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -119,8 +129,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
@@ -37,7 +37,10 @@
             <!--           time_dimension_specs=(                                      -->
             <!--             TimeDimensionSpec(                                        -->
             <!--               element_name='metric_time',                             -->
-            <!--               time_granularity=DAY,                                   -->
+            <!--               time_granularity=ExpandedTimeGranularity(               -->
+            <!--                 name='day',                                           -->
+            <!--                 base_granularity=DAY,                                 -->
+            <!--               ),                                                      -->
             <!--             ),                                                        -->
             <!--           ),                                                          -->
             <!--         ),                                                            -->
@@ -89,7 +92,10 @@
                         <!--       time_dimension_specs=(                                      -->
                         <!--         TimeDimensionSpec(                                        -->
                         <!--           element_name='metric_time',                             -->
-                        <!--           time_granularity=DAY,                                   -->
+                        <!--           time_granularity=ExpandedTimeGranularity(               -->
+                        <!--             name='day',                                           -->
+                        <!--             base_granularity=DAY,                                 -->
+                        <!--           ),                                                      -->
                         <!--         ),                                                        -->
                         <!--       ),                                                          -->
                         <!--     ),                                                            -->
@@ -104,7 +110,11 @@
                             <!--     element_name='country_latest',                           -->
                             <!--     entity_links=(EntityReference(element_name='listing'),), -->
                             <!--   )                                                          -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <JoinOnEntitiesNode>
                                 <!-- description = 'Join Standard Outputs' -->
@@ -119,8 +129,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                     <!-- node_id = NodeId(id_str='pfe_4') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfp_0.xml
@@ -22,7 +22,11 @@
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -37,7 +41,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day', 'listing']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
@@ -89,7 +97,11 @@
                         <!--     element_name='country_latest',                           -->
                         <!--     entity_links=(EntityReference(element_name='listing'),), -->
                         <!--   )                                                          -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
@@ -105,7 +117,11 @@
                                 <!--   "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
                                 <!-- node_id = NodeId(id_str='pfe_3') -->
                                 <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_1_semantic_model__dfpo_0.xml
@@ -22,7 +22,11 @@
                     <!--     element_name='country_latest',                           -->
                     <!--     entity_links=(EntityReference(element_name='listing'),), -->
                     <!--   )                                                          -->
-                    <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                    <!-- include_spec =                                                                  -->
+                    <!--   TimeDimensionSpec(                                                            -->
+                    <!--     element_name='metric_time',                                                 -->
+                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                    <!--   )                                                                             -->
                     <!-- distinct = False -->
                     <JoinOnEntitiesNode>
                         <!-- description = 'Join Standard Outputs' -->
@@ -39,7 +43,11 @@
                             <!-- node_id = NodeId(id_str='pfe_12') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
                             <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- include_spec = LinklessEntitySpec(element_name='listing') -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfp_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -42,7 +46,11 @@
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_metrics_from_2_semantic_models__dfpo_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -42,7 +46,11 @@
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_3') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfp_0.xml
@@ -23,7 +23,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_0') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -49,7 +53,11 @@
                                 <!-- description = "Pass Only Elements: ['bookers', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_1') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookers') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -84,7 +92,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_2') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -110,7 +122,11 @@
                                 <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_3') -->
                                 <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_2_ratio_metrics_from_1_semantic_model__dfpo_0.xml
@@ -23,7 +23,11 @@
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='bookers') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfp_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -42,7 +46,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_1') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -68,7 +76,11 @@
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_3_metrics_from_2_semantic_models__dfpo_0.xml
@@ -18,7 +18,11 @@
                         <!-- node_id = NodeId(id_str='pfe_6') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -44,7 +48,11 @@
                         <!-- description = "Pass Only Elements: ['listings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_5') -->
                         <!-- include_spec = MeasureSpec(element_name='listings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -42,7 +46,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_2') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
@@ -96,7 +104,11 @@
                                 <!--     element_name='is_instant',                               -->
                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_3') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -42,7 +46,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_5') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <WhereConstraintNode>
                             <!-- description = 'Constrain Output with WHERE' -->
@@ -96,7 +104,11 @@
                                 <!--     element_name='is_instant',                               -->
                                 <!--     entity_links=(EntityReference(element_name='booking'),), -->
                                 <!--   )                                                          -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfp_0.xml
@@ -20,7 +20,11 @@
                             <!-- description = "Pass Only Elements: ['referred_bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
@@ -46,7 +50,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric__dfpo_0.xml
@@ -19,7 +19,11 @@
                         <!-- node_id = NodeId(id_str='pfe_4') -->
                         <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfp_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -49,7 +53,11 @@
                                 <!-- description = "Pass Only Elements: ['referred_bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_1') -->
                                 <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -75,7 +83,11 @@
                                 <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                 <!-- node_id = NodeId(id_str='pfe_2') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_derived_metric_with_non_derived_metric__dfpo_0.xml
@@ -16,7 +16,11 @@
                         <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_3') -->
                         <!-- include_spec = MeasureSpec(element_name='booking_value') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
@@ -49,7 +53,11 @@
                             <!-- node_id = NodeId(id_str='pfe_6') -->
                             <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfp_0.xml
@@ -20,7 +20,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
@@ -51,7 +55,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_1') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_duplicate_measures__dfpo_0.xml
@@ -18,7 +18,11 @@
                         <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                         <!-- node_id = NodeId(id_str='pfe_4') -->
                         <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                        <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                        <!-- include_spec =                                                                  -->
+                        <!--   TimeDimensionSpec(                                                            -->
+                        <!--     element_name='metric_time',                                                 -->
+                        <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                        <!--   )                                                                             -->
                         <!-- distinct = False -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfp_0.xml
@@ -27,8 +27,11 @@
                                     <!-- description = "Pass Only Elements: ['referred_bookings', 'metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_0') -->
                                     <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
@@ -54,8 +57,11 @@
                                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                                     <!-- node_id = NodeId(id_str='pfe_1') -->
                                     <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                    <!-- include_spec =                                                        -->
-                                    <!--   TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                    <!-- include_spec =                                                                  -->
+                                    <!--   TimeDimensionSpec(                                                            -->
+                                    <!--     element_name='metric_time',                                                 -->
+                                    <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                    <!--   )                                                                             -->
                                     <!-- distinct = False -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
@@ -83,7 +89,11 @@
                             <!-- description = "Pass Only Elements: ['instant_bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_2') -->
                             <!-- include_spec = MeasureSpec(element_name='instant_bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
@@ -109,7 +119,11 @@
                             <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_nested_derived_metric__dfpo_0.xml
@@ -27,7 +27,11 @@
                                 <!-- node_id = NodeId(id_str='pfe_6') -->
                                 <!-- include_spec = MeasureSpec(element_name='referred_bookings') -->
                                 <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                                <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                                <!-- include_spec =                                                                  -->
+                                <!--   TimeDimensionSpec(                                                            -->
+                                <!--     element_name='metric_time',                                                 -->
+                                <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                <!--   )                                                                             -->
                                 <!-- distinct = False -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
@@ -57,7 +61,11 @@
                             <!-- node_id = NodeId(id_str='pfe_9') -->
                             <!-- include_spec = MeasureSpec(element_name='instant_bookings') -->
                             <!-- include_spec = MeasureSpec(element_name='bookings') -->
-                            <!-- include_spec = TimeDimensionSpec(element_name='metric_time', time_granularity=DAY) -->
+                            <!-- include_spec =                                                                  -->
+                            <!--   TimeDimensionSpec(                                                            -->
+                            <!--     element_name='metric_time',                                                 -->
+                            <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                            <!--   )                                                                             -->
                             <!-- distinct = False -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->


### PR DESCRIPTION
Use ExpandedTimeGranularity in TimeDimensionSpec

In order to support custom granularities we need a way to propagate
them through the dataflow plan building and plan conversion processes.
We typically use the TimeDimensionSpec classes for carrying that
information, since the specs indicate the grain of the specific
variation of the TimeDimension element we're operating on. We
decided to use an ExpandedTimeGranularity construct to encapsulate
the custom granularity metadata in a manner interchangeable with the
default granularity enumeration values, with the idea that these
would make it more obvious when and how to do comparisons and things.

This change updates the TimeDimensionSpec itself to use the new construct.
The changes here are meant to be as mechanical as possible, so there are
places where restructuring or follow-up is needed. It was not possible to
do purely mechanical changes in all cases.