### PR TITLE
Lowercase all names passed into `StructuredLinkableSpecName`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import Optional, Tuple
 
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
@@ -14,7 +13,6 @@ DUNDER = "__"
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
 class StructuredLinkableSpecName:
     """Parse a qualified name into different parts.
 
@@ -28,6 +26,18 @@ class StructuredLinkableSpecName:
     element_name: str
     time_granularity_name: Optional[str] = None
     date_part: Optional[DatePart] = None
+
+    def __init__(  # noqa: D107
+        self,
+        entity_link_names: Tuple[str, ...],
+        element_name: str,
+        time_granularity_name: Optional[str] = None,
+        date_part: Optional[DatePart] = None,
+    ) -> None:
+        self.entity_link_names = tuple([entity_link_name.lower() for entity_link_name in entity_link_names])
+        self.element_name = element_name.lower()
+        self.time_granularity_name = time_granularity_name.lower() if time_granularity_name else None
+        self.date_part = date_part
 
     def __post_init__(self) -> None:
         """Post init method to ensure all name values are lower-case.

--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -6,8 +6,6 @@ from typing import Optional, Tuple
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
-from metricflow_semantics.time.granularity import ExpandedTimeGranularity
-
 DUNDER = "__"
 
 logger = logging.getLogger(__name__)
@@ -22,49 +20,18 @@ class StructuredLinkableSpecName:
     granularity: TimeGranularity.WEEK
     """
 
-    entity_link_names: Tuple[str, ...]
-    element_name: str
-    time_granularity_name: Optional[str] = None
-    date_part: Optional[DatePart] = None
-
-    def __init__(  # noqa: D107
+    def __init__(
         self,
         entity_link_names: Tuple[str, ...],
         element_name: str,
         time_granularity_name: Optional[str] = None,
         date_part: Optional[DatePart] = None,
     ) -> None:
+        """Set attributes, ensuring names are lowercased."""
         self.entity_link_names = tuple([entity_link_name.lower() for entity_link_name in entity_link_names])
         self.element_name = element_name.lower()
         self.time_granularity_name = time_granularity_name.lower() if time_granularity_name else None
         self.date_part = date_part
-
-    def __post_init__(self) -> None:
-        """Post init method to ensure all name values are lower-case.
-
-        This implies that all values in the TimeGranularity enumeration must be lower-case.
-        """
-        assert self.element_name.lower() == self.element_name, (
-            f"Element name {self.element_name} is not all lower-case. This should have been addressed at model "
-            "parse time!"
-        )
-        assert all([link_name.lower() == link_name for link_name in self.entity_link_names]), (
-            f"Found entity link name that includes upper-case letters. Entity link names: {self.entity_link_names}. "
-            "This should have been addressed at model parse time!"
-        )
-
-        if self.time_granularity_name:
-            is_standard_name = ExpandedTimeGranularity.is_standard_granularity_name(self.time_granularity_name)
-            if is_standard_name:
-                follow_up = (
-                    "This indicates a bug where someone added a non-lowercase value to the TimeGranularity "
-                    "enum in dbt-semantic-interfaces!"
-                )
-            else:
-                follow_up = "This should have been addressed at model parse time!"
-            assert (
-                self.time_granularity_name.lower() == self.time_granularity_name
-            ), f"The time_granularity_name {self.time_granularity_name} includes upper-case letters. {follow_up}"
 
     @staticmethod
     def from_name(qualified_name: str) -> StructuredLinkableSpecName:


### PR DESCRIPTION
Per title - lowercase all inputs to avoid errors later.