### PR TITLE
Add `JoinToCustomGranularityNode` to dataflow plan builder

### DIFF
--- a/.changes/unreleased/Features-20240827-112415.yaml
+++ b/.changes/unreleased/Features-20240827-112415.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Handle custom granularities in DataflowPlan.
+time: 2024-08-27T11:24:15.909853-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1382"


### PR DESCRIPTION
When a custom grain is requested, add `JoinToCustomGranularityNode` to the dataflow plan after joining all elements, but before aggregating or filtering.
TODO: test before marking ready for review