### PR TITLE
`TimeSpineSource` additions & rename `SqlTableFromClauseNode` -> `SqlTableNode`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, Optional, Sequence
 
+from dbt_semantic_interfaces.implementations.time_spine import PydanticTimeSpineCustomGranularityColumn
 from dbt_semantic_interfaces.protocols import SemanticManifest
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
@@ -29,7 +30,7 @@ class TimeSpineSource:
     # The time granularity of the base column.
     base_granularity: TimeGranularity = DEFAULT_TIME_GRANULARITY
     db_name: Optional[str] = None
-    custom_granularities: Sequence[str] = ()
+    custom_granularities: Sequence[PydanticTimeSpineCustomGranularityColumn] = ()
 
     @property
     def spine_table(self) -> SqlTable:
@@ -48,7 +49,14 @@ class TimeSpineSource:
                 db_name=time_spine.node_relation.database,
                 base_column=time_spine.primary_column.name,
                 base_granularity=time_spine.primary_column.time_granularity,
-                custom_granularities=[column.name for column in time_spine.custom_granularities],
+                custom_granularities=tuple(
+                    [
+                        PydanticTimeSpineCustomGranularityColumn(
+                            name=custom_granularity.name, column_name=custom_granularity.column_name
+                        )
+                        for custom_granularity in time_spine.custom_granularities
+                    ]
+                ),
             )
             for time_spine in semantic_manifest.project_configuration.time_spines
         }
@@ -74,3 +82,12 @@ class TimeSpineSource:
             )
 
         return time_spine_sources
+
+    @staticmethod
+    def build_custom_time_spine_sources(time_spine_sources: Sequence[TimeSpineSource]) -> Dict[str, TimeSpineSource]:
+        """Creates a set of time spine sources with custom granularities based on what's in the manifest."""
+        return {
+            custom_granularity.name: time_spine_source
+            for time_spine_source in time_spine_sources
+            for custom_granularity in time_spine_source.custom_granularities
+        }

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -49,7 +49,7 @@ from metricflow.sql.sql_exprs import (
 from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -491,9 +491,7 @@ class SemanticModelToDataSetConverter:
             all_select_columns.extend(select_columns)
 
         # Generate the "from" clause depending on whether it's an SQL query or an SQL table.
-        from_source = SqlTableFromClauseNode.create(
-            sql_table=SqlTable.from_string(semantic_model.node_relation.relation_name)
-        )
+        from_source = SqlTableNode.create(sql_table=SqlTable.from_string(semantic_model.node_relation.relation_name))
 
         select_statement_node = SqlSelectStatementNode.create(
             description=f"Read Elements From Semantic Model '{semantic_model.name}'",
@@ -552,7 +550,7 @@ class SemanticModelToDataSetConverter:
             sql_select_node=SqlSelectStatementNode.create(
                 description=TIME_SPINE_DATA_SET_DESCRIPTION,
                 select_columns=tuple(select_columns),
-                from_source=SqlTableFromClauseNode.create(sql_table=time_spine_source.spine_table),
+                from_source=SqlTableNode.create(sql_table=time_spine_source.spine_table),
                 from_source_alias=from_source_alias,
             ),
         )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -138,7 +138,7 @@ from metricflow.sql.sql_plan import (
     SqlQueryPlanNode,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -312,7 +312,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             sql_select_node=SqlSelectStatementNode.create(
                 description=TIME_SPINE_DATA_SET_DESCRIPTION,
                 select_columns=select_columns,
-                from_source=SqlTableFromClauseNode.create(sql_table=time_spine_source.spine_table),
+                from_source=SqlTableNode.create(sql_table=time_spine_source.spine_table),
                 from_source_alias=time_spine_table_alias,
                 group_bys=select_columns if apply_group_by else (),
                 where=(

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -16,7 +16,7 @@ from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -191,8 +191,8 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:
-        """This node is effectively a FROM statement inside a SELECT statement node, so pruning cannot apply."""
+    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:
+        """There are no SELECT columns in this node, so pruning cannot apply."""
         return node
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -25,7 +25,7 @@ from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -700,7 +700,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             distinct=parent_select_node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
@@ -764,7 +764,7 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -13,7 +13,7 @@ from metricflow.sql.sql_plan import (
     SqlQueryPlanNodeVisitor,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -188,7 +188,7 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=parent_select_node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -12,7 +12,7 @@ from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             distinct=node.distinct,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlQueryPlanNode:  # noqa: D102
         return node
 
     def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> SqlQueryPlanNode:  # noqa: D102

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -25,7 +25,7 @@ from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -301,7 +301,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
             bind_parameters=combined_params,
         )
 
-    def visit_table_from_clause_node(self, node: SqlTableFromClauseNode) -> SqlPlanRenderResult:  # noqa: D102
+    def visit_table_node(self, node: SqlTableNode) -> SqlPlanRenderResult:  # noqa: D102
         return SqlPlanRenderResult(
             sql=node.sql_table.sql,
             bind_parameters=SqlBindParameters(),

--- a/tests_metricflow/dataflow/builder/test_node_data_set.py
+++ b/tests_metricflow/dataflow/builder/test_node_data_set.py
@@ -30,7 +30,7 @@ from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpre
 from metricflow.sql.sql_plan import (
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.fixtures.manifest_fixtures import MetricFlowEngineTestFixture, SemanticManifestSetup
 
@@ -77,9 +77,7 @@ def test_no_parent_node_data_set(
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="src",
         ),
     )

--- a/tests_metricflow/mf_logging/test_dag_to_text.py
+++ b/tests_metricflow/mf_logging/test_dag_to_text.py
@@ -18,7 +18,7 @@ from metricflow.sql.sql_plan import (
     SqlQueryPlan,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def test_multithread_dag_to_text() -> None:
                     column_alias="bar",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="schema", table_name="table")),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="schema", table_name="table")),
             from_source_alias="src",
         ),
     )
@@ -80,13 +80,13 @@ def test_multithread_dag_to_text() -> None:
                 <!--     expr=SqlStringExpression(node_id=str_0 sql_expr='foo'), -->
                 <!--     column_alias='bar',                                     -->
                 <!--   )                                                         -->
-                <!-- from_source =                           -->
-                <!--   SqlTableFromClauseNode(node_id=tfc_0) -->
+                <!-- from_source =                 -->
+                <!--   SqlTableNode(node_id=tfc_0) -->
                 <!-- where =  -->
                 <!--   None -->
                 <!-- distinct =  -->
                 <!--   False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description =      -->
                     <!--   ('Read '         -->
                     <!--    'from '         -->
@@ -97,7 +97,7 @@ def test_multithread_dag_to_text() -> None:
                     <!--   )                 -->
                     <!-- table_id =       -->
                     <!--   'schema.table' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlQueryPlan>
         """

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -378,14 +378,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                 <!-- table_id = '***************************.fct_visits' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -842,14 +842,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
                                             <!-- node_id = NodeId(id_str='tfc_28011') -->
                                             <!-- table_id = '***************************.fct_visits' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1403,14 +1403,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
                                             <!-- node_id = NodeId(id_str='tfc_28002') -->
                                             <!-- table_id = '***************************.fct_buys' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -68,14 +68,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.mf_time_spine' -->
                         <!-- node_id = NodeId(id_str='tfc_0') -->
                         <!-- table_id = '***************************.mf_time_spine' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
@@ -469,14 +469,14 @@
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                 <!--     column_alias='visit__session',                       -->
                                 <!--   )                                                      -->
-                                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
-                                <SqlTableFromClauseNode>
+                                <SqlTableNode>
                                     <!-- description = 'Read from ***************************.fct_visits' -->
                                     <!-- node_id = NodeId(id_str='tfc_28011') -->
                                     <!-- table_id = '***************************.fct_visits' -->
-                                </SqlTableFromClauseNode>
+                                </SqlTableNode>
                             </SqlSelectStatementNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
@@ -506,14 +506,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_212), -->
                     <!--     column_alias='metric_time__day',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_1) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.mf_time_spine' -->
                         <!-- node_id = NodeId(id_str='tfc_1') -->
                         <!-- table_id = '***************************.mf_time_spine' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
@@ -1008,14 +1008,14 @@
                                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                             <!--     column_alias='visit__session',                       -->
                                             <!--   )                                                      -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                             <!-- where = None -->
                                             <!-- distinct = False -->
-                                            <SqlTableFromClauseNode>
+                                            <SqlTableNode>
                                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                                 <!-- table_id = '***************************.fct_visits' -->
-                                            </SqlTableFromClauseNode>
+                                            </SqlTableNode>
                                         </SqlSelectStatementNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
@@ -1569,14 +1569,14 @@
                                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                             <!--     column_alias='buy__session_id',                      -->
                                             <!--   )                                                      -->
-                                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                            <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                             <!-- where = None -->
                                             <!-- distinct = False -->
-                                            <SqlTableFromClauseNode>
+                                            <SqlTableNode>
                                                 <!-- description = 'Read from ***************************.fct_buys' -->
                                                 <!-- node_id = NodeId(id_str='tfc_28002') -->
                                                 <!-- table_id = '***************************.fct_buys' -->
-                                            </SqlTableFromClauseNode>
+                                            </SqlTableNode>
                                         </SqlSelectStatementNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
@@ -406,14 +406,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                 <!-- table_id = '***************************.fct_visits' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -901,14 +901,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
                                             <!-- node_id = NodeId(id_str='tfc_28011') -->
                                             <!-- table_id = '***************************.fct_visits' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1462,14 +1462,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
                                             <!-- node_id = NodeId(id_str='tfc_28002') -->
                                             <!-- table_id = '***************************.fct_buys' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
@@ -429,14 +429,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                 <!-- table_id = '***************************.fct_visits' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -961,14 +961,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
                                             <!-- node_id = NodeId(id_str='tfc_28011') -->
                                             <!-- table_id = '***************************.fct_visits' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1522,14 +1522,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
                                             <!-- node_id = NodeId(id_str='tfc_28002') -->
                                             <!-- table_id = '***************************.fct_buys' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -381,14 +381,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                 <!-- table_id = '***************************.fct_visits' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -845,14 +845,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
                                             <!-- node_id = NodeId(id_str='tfc_28011') -->
                                             <!-- table_id = '***************************.fct_visits' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1406,14 +1406,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
                                             <!-- node_id = NodeId(id_str='tfc_28002') -->
                                             <!-- table_id = '***************************.fct_buys' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
@@ -429,14 +429,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                             <!--     column_alias='visit__session',                       -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_visits' -->
                                 <!-- node_id = NodeId(id_str='tfc_28011') -->
                                 <!-- table_id = '***************************.fct_visits' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -949,14 +949,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28121), -->
                                         <!--     column_alias='visit__session',                       -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28011) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28011) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_visits' -->
                                             <!-- node_id = NodeId(id_str='tfc_28011') -->
                                             <!-- table_id = '***************************.fct_visits' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1510,14 +1510,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28043), -->
                                         <!--     column_alias='buy__session_id',                      -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28002) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28002) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_buys' -->
                                             <!-- node_id = NodeId(id_str='tfc_28002') -->
                                             <!-- table_id = '***************************.fct_buys' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_combine_output_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_combine_output_node__plan0.xml
@@ -435,14 +435,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
                         <!-- node_id = NodeId(id_str='tfc_28001') -->
                         <!-- table_id = '***************************.fct_bookings' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
@@ -851,14 +851,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
                         <!-- node_id = NodeId(id_str='tfc_28001') -->
                         <!-- table_id = '***************************.fct_bookings' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -480,14 +480,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
                             <!-- node_id = NodeId(id_str='tfc_28001') -->
                             <!-- table_id = '***************************.fct_bookings' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
@@ -764,14 +764,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28005') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -1098,14 +1098,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                                         <!--     column_alias='booking__host',                        -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_bookings' -->
                                             <!-- node_id = NodeId(id_str='tfc_28001') -->
                                             <!-- table_id = '***************************.fct_bookings' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -1749,15 +1749,15 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                                         <!--     column_alias='listing__user',                        -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description =                                                 -->
                                             <!--   'Read from ***************************.dim_listings_latest' -->
                                             <!-- node_id = NodeId(id_str='tfc_28005') -->
                                             <!-- table_id = '***************************.dim_listings_latest' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -2426,14 +2426,14 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28112), -->
                                         <!--     column_alias='view__user',                           -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28010) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28010) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description = 'Read from ***************************.fct_views' -->
                                             <!-- node_id = NodeId(id_str='tfc_28010') -->
                                             <!-- table_id = '***************************.fct_views' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>
@@ -3077,15 +3077,15 @@
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                                         <!--     column_alias='listing__user',                        -->
                                         <!--   )                                                      -->
-                                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
-                                        <SqlTableFromClauseNode>
+                                        <SqlTableNode>
                                             <!-- description =                                                 -->
                                             <!--   'Read from ***************************.dim_listings_latest' -->
                                             <!-- node_id = NodeId(id_str='tfc_28005') -->
                                             <!-- table_id = '***************************.dim_listings_latest' -->
-                                        </SqlTableFromClauseNode>
+                                        </SqlTableNode>
                                     </SqlSelectStatementNode>
                                 </SqlSelectStatementNode>
                             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -488,14 +488,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
                             <!-- node_id = NodeId(id_str='tfc_28001') -->
                             <!-- table_id = '***************************.fct_bookings' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
@@ -772,14 +772,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28005') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -485,14 +485,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
                             <!-- node_id = NodeId(id_str='tfc_28001') -->
                             <!-- table_id = '***************************.fct_bookings' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
@@ -769,14 +769,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                         <!--     column_alias='listing__user',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_listings_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28005') -->
                             <!-- table_id = '***************************.dim_listings_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
@@ -403,14 +403,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                     <!--     column_alias='booking__host',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.fct_bookings' -->
                         <!-- node_id = NodeId(id_str='tfc_28001') -->
                         <!-- table_id = '***************************.fct_bookings' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -645,14 +645,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28005') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
@@ -791,14 +791,14 @@
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28009') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -406,14 +406,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
@@ -537,14 +537,14 @@
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28009') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
@@ -262,14 +262,14 @@
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                 <!-- table_id = '***************************.fct_bookings' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>
 </SqlQueryPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -335,14 +335,14 @@
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
                     <!-- node_id = NodeId(id_str='tfc_28001') -->
                     <!-- table_id = '***************************.fct_bookings' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -20,14 +20,14 @@
             <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.mf_time_spine' -->
                 <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.mf_time_spine' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
@@ -979,14 +979,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
                                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -20,14 +20,14 @@
             <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.mf_time_spine' -->
                 <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.mf_time_spine' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
@@ -979,14 +979,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
                                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -20,14 +20,14 @@
             <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_0) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_0) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.mf_time_spine' -->
                 <!-- node_id = NodeId(id_str='tfc_0') -->
                 <!-- table_id = '***************************.mf_time_spine' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
@@ -979,14 +979,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
                                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
@@ -358,14 +358,14 @@
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
                     <!-- node_id = NodeId(id_str='tfc_28001') -->
                     <!-- table_id = '***************************.fct_bookings' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -353,14 +353,14 @@
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
                     <!-- node_id = NodeId(id_str='tfc_28001') -->
                     <!-- table_id = '***************************.fct_bookings' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
@@ -567,14 +567,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
@@ -781,14 +781,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -466,14 +466,14 @@
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                         <!--     column_alias='booking__host',                        -->
                         <!--   )                                                      -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.fct_bookings' -->
                             <!-- node_id = NodeId(id_str='tfc_28001') -->
                             <!-- table_id = '***************************.fct_bookings' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
@@ -203,14 +203,14 @@
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
                 <!-- node_id = NodeId(id_str='tfc_28000') -->
                 <!-- table_id = '***************************.fct_accounts' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
@@ -361,14 +361,14 @@
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
                     <!-- node_id = NodeId(id_str='tfc_28000') -->
                     <!-- table_id = '***************************.fct_accounts' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -203,14 +203,14 @@
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
                 <!-- node_id = NodeId(id_str='tfc_28000') -->
                 <!-- table_id = '***************************.fct_accounts' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MAX(ds__day)' -->
@@ -363,14 +363,14 @@
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
                     <!-- node_id = NodeId(id_str='tfc_28000') -->
                     <!-- table_id = '***************************.fct_accounts' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -203,14 +203,14 @@
             <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
             <!-- col41 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_accounts' -->
                 <!-- node_id = NodeId(id_str='tfc_28000') -->
                 <!-- table_id = '***************************.fct_accounts' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
@@ -363,14 +363,14 @@
                 <!-- col40 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28010), column_alias='user') -->
                 <!-- col41 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28011), column_alias='account__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28000) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28000) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_accounts' -->
                     <!-- node_id = NodeId(id_str='tfc_28000') -->
                     <!-- table_id = '***************************.fct_accounts' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
@@ -342,14 +342,14 @@
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
                 <!-- col87 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.fct_bookings' -->
                     <!-- node_id = NodeId(id_str='tfc_28001') -->
                     <!-- table_id = '***************************.fct_bookings' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
@@ -560,14 +560,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
@@ -194,13 +194,13 @@
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28034), column_alias='booking__listing') -->
         <!-- col86 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
         <!-- col87 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+        <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
         <!-- where = None -->
         <!-- distinct = False -->
-        <SqlTableFromClauseNode>
+        <SqlTableNode>
             <!-- description = 'Read from ***************************.fct_bookings' -->
             <!-- node_id = NodeId(id_str='tfc_28001') -->
             <!-- table_id = '***************************.fct_bookings' -->
-        </SqlTableFromClauseNode>
+        </SqlTableNode>
     </SqlSelectStatementNode>
 </SqlQueryPlan>

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -649,14 +649,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28005') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
@@ -795,14 +795,14 @@
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28009') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -406,14 +406,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
@@ -537,14 +537,14 @@
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28009') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -484,14 +484,14 @@
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                 <!-- table_id = '***************************.fct_bookings' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>
 </SqlQueryPlan>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -511,14 +511,14 @@
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28035), column_alias='booking__guest') -->
             <!-- col87 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28036), column_alias='booking__host') -->
-            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
             <!-- where = None -->
             <!-- distinct = False -->
-            <SqlTableFromClauseNode>
+            <SqlTableNode>
                 <!-- description = 'Read from ***************************.fct_bookings' -->
                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                 <!-- table_id = '***************************.fct_bookings' -->
-            </SqlTableFromClauseNode>
+            </SqlTableNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>
 </SqlQueryPlan>

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -972,14 +972,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
                                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -1878,14 +1878,14 @@
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_28036), -->
                             <!--     column_alias='booking__host',                        -->
                             <!--   )                                                      -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28001) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28001) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.fct_bookings' -->
                                 <!-- node_id = NodeId(id_str='tfc_28001') -->
                                 <!-- table_id = '***************************.fct_bookings' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -663,14 +663,14 @@
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_28074), -->
                     <!--     column_alias='listing__user',                        -->
                     <!--   )                                                      -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_listings_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28005') -->
                         <!-- table_id = '***************************.dim_listings_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
@@ -836,14 +836,14 @@
                             <!--     expr=SqlExtractExpression(node_id=ex_28299), -->
                             <!--     column_alias='ds__extract_doy',              -->
                             <!--   )                                              -->
-                            <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28018) -->
+                            <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
-                            <SqlTableFromClauseNode>
+                            <SqlTableNode>
                                 <!-- description = 'Read from ***************************.mf_time_spine' -->
                                 <!-- node_id = NodeId(id_str='tfc_28018') -->
                                 <!-- table_id = '***************************.mf_time_spine' -->
-                            </SqlTableFromClauseNode>
+                            </SqlTableNode>
                         </SqlSelectStatementNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
@@ -984,14 +984,14 @@
                         <!--   )                                                      -->
                         <!-- col24 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.dim_users_latest' -->
                             <!-- node_id = NodeId(id_str='tfc_28009') -->
                             <!-- table_id = '***************************.dim_users_latest' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -87,14 +87,14 @@
                 <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28298), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                        -->
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28299), column_alias='ds__extract_doy') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28018) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
                     <!-- node_id = NodeId(id_str='tfc_28018') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -88,14 +88,14 @@
                 <!-- col9 = SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28298), column_alias='ds__extract_dow') -->
                 <!-- col10 =                                                                                        -->
                 <!--   SqlSelectColumn(expr=SqlExtractExpression(node_id=ex_28299), column_alias='ds__extract_doy') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28018) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.mf_time_spine' -->
                     <!-- node_id = NodeId(id_str='tfc_28018') -->
                     <!-- table_id = '***************************.mf_time_spine' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>
     </SqlSelectStatementNode>

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -419,14 +419,14 @@
                 <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28073), column_alias='user') -->
                 <!-- col55 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28074), column_alias='listing__user') -->
-                <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28005) -->
+                <!-- from_source = SqlTableNode(node_id=tfc_28005) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
-                <SqlTableFromClauseNode>
+                <SqlTableNode>
                     <!-- description = 'Read from ***************************.dim_listings_latest' -->
                     <!-- node_id = NodeId(id_str='tfc_28005') -->
                     <!-- table_id = '***************************.dim_listings_latest' -->
-                </SqlTableFromClauseNode>
+                </SqlTableNode>
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
@@ -579,14 +579,14 @@
                         <!--     expr=SqlExtractExpression(node_id=ex_28299), -->
                         <!--     column_alias='ds__extract_doy',              -->
                         <!--   )                                              -->
-                        <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28018) -->
+                        <!-- from_source = SqlTableNode(node_id=tfc_28018) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
-                        <SqlTableFromClauseNode>
+                        <SqlTableNode>
                             <!-- description = 'Read from ***************************.mf_time_spine' -->
                             <!-- node_id = NodeId(id_str='tfc_28018') -->
                             <!-- table_id = '***************************.mf_time_spine' -->
-                        </SqlTableFromClauseNode>
+                        </SqlTableNode>
                     </SqlSelectStatementNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
@@ -712,14 +712,14 @@
                     <!--   )                                                      -->
                     <!-- col24 =                                                                                     -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28104), column_alias='user') -->
-                    <!-- from_source = SqlTableFromClauseNode(node_id=tfc_28009) -->
+                    <!-- from_source = SqlTableNode(node_id=tfc_28009) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
-                    <SqlTableFromClauseNode>
+                    <SqlTableNode>
                         <!-- description = 'Read from ***************************.dim_users_latest' -->
                         <!-- node_id = NodeId(id_str='tfc_28009') -->
                         <!-- table_id = '***************************.dim_users_latest' -->
-                    </SqlTableFromClauseNode>
+                    </SqlTableNode>
                 </SqlSelectStatementNode>
             </SqlSelectStatementNode>
         </SqlSelectStatementNode>

--- a/tests_metricflow/sql/optimizer/test_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_column_pruner.py
@@ -21,7 +21,7 @@ from metricflow.sql.sql_plan import (
     SqlQueryPlanNode,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
@@ -141,9 +141,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
@@ -180,7 +178,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
+                    from_source=SqlTableNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",
@@ -529,9 +527,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
@@ -568,7 +564,7 @@ def string_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
+                    from_source=SqlTableNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",
@@ -698,7 +694,7 @@ def grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                         column_alias="col2",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
+                from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
                 from_source_alias="src0",
             ),
             from_source_alias="src1",
@@ -765,9 +761,7 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                 column_alias="col0",
             ),
         ),
-        from_source=SqlTableFromClauseNode.create(
-            sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
-        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
         from_source_alias="src3",
         join_descs=(
             SqlJoinDescription(
@@ -824,9 +818,7 @@ def join_grandparent_pruning_select_statement() -> SqlSelectStatementNode:
                                 column_alias="join_col",
                             ),
                         ),
-                        from_source=SqlTableFromClauseNode.create(
-                            sql_table=SqlTable(schema_name="demo", table_name="src0")
-                        ),
+                        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
                         from_source_alias="src0",
                     ),
                     from_source_alias="src1",
@@ -902,9 +894,7 @@ def test_prune_distinct_select(
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
@@ -22,7 +22,7 @@ from metricflow.sql.sql_plan import (
     SqlOrderByDescription,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
@@ -113,9 +113,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="ds",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode.create(
-                    sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-                ),
+                from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
                 from_source_alias="src0",
                 limit=2,
             ),
@@ -263,9 +261,7 @@ def join_select_statement() -> SqlSelectStatementNode:
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="fct_bookings_src",
         ),
         from_source_alias="bookings_src",
@@ -287,9 +283,7 @@ def join_select_statement() -> SqlSelectStatementNode:
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
-                        sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
-                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
                     from_source_alias="dim_listings_src",
                 ),
                 right_source_alias="listings_src",
@@ -426,9 +420,7 @@ def colliding_select_statement() -> SqlSelectStatementNode:
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="colliding_alias",
         ),
         from_source_alias="bookings_src",
@@ -450,9 +442,7 @@ def colliding_select_statement() -> SqlSelectStatementNode:
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
-                        sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
-                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
                     from_source_alias="colliding_alias",
                 ),
                 right_source_alias="listings_src",
@@ -603,9 +593,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                     column_alias="listing",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="fct_bookings_src",
         ),
         from_source_alias="bookings_src",
@@ -627,9 +615,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
-                        sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
-                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
                     from_source_alias="dim_listings_src1",
                 ),
                 right_source_alias="listings_src1",
@@ -661,9 +647,7 @@ def reduce_all_join_select_statement() -> SqlSelectStatementNode:
                             column_alias="listing",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
-                        sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
-                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
                     from_source_alias="dim_listings_src2",
                 ),
                 right_source_alias="listings_src2",
@@ -799,9 +783,7 @@ def reducing_join_statement() -> SqlSelectStatementNode:
                         column_alias="bookings",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode.create(
-                    sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-                ),
+                from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
                 from_source_alias="src0",
             ),
             from_source_alias="src1",
@@ -824,9 +806,7 @@ def reducing_join_statement() -> SqlSelectStatementNode:
                             column_alias="listings",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
-                        sql_table=SqlTable(schema_name="demo", table_name="fct_listings")
-                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_listings")),
                     from_source_alias="src4",
                 ),
                 right_source_alias="src3",
@@ -917,9 +897,7 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
                     column_alias="listings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_listings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_listings")),
             from_source_alias="src4",
         ),
         from_source_alias="src2",
@@ -950,7 +928,7 @@ def reducing_join_left_node_statement() -> SqlSelectStatementNode:
                                 column_alias="bookings",
                             ),
                         ),
-                        from_source=SqlTableFromClauseNode.create(
+                        from_source=SqlTableNode.create(
                             sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
                         ),
                         from_source_alias="src0",
@@ -1019,9 +997,7 @@ def test_rewriting_distinct_select_node_is_not_reduced(
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_sub_query_reducer.py
@@ -18,7 +18,7 @@ from metricflow.sql.sql_plan import (
     SqlOrderByDescription,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
@@ -100,9 +100,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                         column_alias="col1",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode.create(
-                    sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
-                ),
+                from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
                 from_source_alias="src0",
                 limit=2,
             ),
@@ -200,13 +198,11 @@ def rewrite_order_by_statement() -> SqlSelectStatementNode:
                         column_alias="col1",
                     ),
                 ),
-                from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
+                from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="src0")),
                 from_source_alias="src0",
                 join_descs=(
                     SqlJoinDescription(
-                        right_source=SqlTableFromClauseNode.create(
-                            sql_table=SqlTable(schema_name="demo", table_name="src1")
-                        ),
+                        right_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="src1")),
                         right_source_alias="src1",
                         on_condition=SqlComparisonExpression.create(
                             left_expr=SqlColumnReferenceExpression.create(
@@ -291,9 +287,7 @@ def test_distinct_select_node_is_not_reduced(
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             distinct=True,
         ),

--- a/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
@@ -18,7 +18,7 @@ from metricflow.sql.sql_plan import (
     SqlJoinDescription,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
 
@@ -91,9 +91,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                     column_alias="join_col",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="from_source_table")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="from_source_table")),
             from_source_alias="from_source_table",
         ),
         from_source_alias="from_source",
@@ -121,7 +119,7 @@ def base_select_statement() -> SqlSelectStatementNode:
                             column_alias="join_col",
                         ),
                     ),
-                    from_source=SqlTableFromClauseNode.create(
+                    from_source=SqlTableNode.create(
                         sql_table=SqlTable(schema_name="demo", table_name="joined_source_table")
                     ),
                     from_source_alias="joined_source_table",

--- a/tests_metricflow/sql/test_engine_specific_rendering.py
+++ b/tests_metricflow/sql/test_engine_specific_rendering.py
@@ -23,7 +23,7 @@ from metricflow.sql.sql_plan import (
     SqlOrderByDescription,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_rendered_sql_equal
 
@@ -46,7 +46,7 @@ def test_cast_to_timestamp(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -84,7 +84,7 @@ def test_generate_uuid(
             column_alias="uuid",
         ),
     ]
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
 
     assert_rendered_sql_equal(
@@ -125,7 +125,7 @@ def test_continuous_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -174,7 +174,7 @@ def test_discrete_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -223,7 +223,7 @@ def test_approximate_continuous_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None
@@ -272,7 +272,7 @@ def test_approximate_discrete_percentile_expr(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="foo", table_name="bar"))
     from_source_alias = "a"
     joins_descs: List[SqlJoinDescription] = []
     where = None

--- a/tests_metricflow/sql/test_sql_plan_render.py
+++ b/tests_metricflow/sql/test_sql_plan_render.py
@@ -25,7 +25,7 @@ from metricflow.sql.sql_plan import (
     SqlOrderByDescription,
     SqlSelectColumn,
     SqlSelectStatementNode,
-    SqlTableFromClauseNode,
+    SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_rendered_sql_equal
 
@@ -49,7 +49,7 @@ def test_component_rendering(
         ),
     ]
 
-    from_source = SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings"))
+    from_source = SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings"))
 
     from_source = from_source
     from_source_alias = "a"
@@ -109,7 +109,7 @@ def test_component_rendering(
     # Test single join
     joins_descs.append(
         SqlJoinDescription(
-            right_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_users")),
+            right_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_users")),
             right_source_alias="b",
             on_condition=SqlComparisonExpression.create(
                 left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "user_id")),
@@ -140,9 +140,7 @@ def test_component_rendering(
     # Test multiple join
     joins_descs.append(
         SqlJoinDescription(
-            right_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="dim_listings")
-            ),
+            right_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="dim_listings")),
             right_source_alias="c",
             on_condition=SqlComparisonExpression.create(
                 left_expr=SqlColumnReferenceExpression.create(SqlColumnReference("a", "user_id")),
@@ -240,9 +238,7 @@ def test_render_where(  # noqa: D103
                     column_alias="booking_value",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             where=SqlComparisonExpression.create(
                 left_expr=SqlColumnReferenceExpression.create(
@@ -286,9 +282,7 @@ def test_render_order_by(  # noqa: D103
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             order_bys=(
                 SqlOrderByDescription(
@@ -329,9 +323,7 @@ def test_render_limit(  # noqa: D103
                     column_alias="bookings",
                 ),
             ),
-            from_source=SqlTableFromClauseNode.create(
-                sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")
-            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
             from_source_alias="a",
             limit=1,
         ),
@@ -356,7 +348,7 @@ def test_render_create_table_as(  # noqa: D103
                 column_alias="bookings",
             ),
         ),
-        from_source=SqlTableFromClauseNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name="demo", table_name="fct_bookings")),
         from_source_alias="a",
         limit=1,
     )


### PR DESCRIPTION
More setup that will be used for rendering custom granularity SQL.

Previously, we were never rendering a join with only a table (no subquery), but that will change for custom granularities. Those joins will use this node, which essentially just renders a table name and alias. I've renamed the node to reflect that change.

Also adds some functionality to `TimeSpineSource` that will be needed soon.