### PR TITLE
Disable predicate pushdown optimizer

### DIFF
--- a/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
+++ b/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
@@ -30,7 +30,7 @@ class DataflowPlanOptimization(Enum):
         return frozenset((DataflowPlanOptimization.SOURCE_SCAN, DataflowPlanOptimization.PREDICATE_PUSHDOWN))
 
     @staticmethod
-    def enabled_obtimizations() -> FrozenSet[DataflowPlanOptimization]:
+    def enabled_optimizations() -> FrozenSet[DataflowPlanOptimization]:
         """Set of DataflowPlanOptimization that are currently enabled.
 
         Predicate pushdown optimizer is currently disabled.

--- a/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
+++ b/metricflow/dataflow/optimizer/dataflow_optimizer_factory.py
@@ -29,6 +29,14 @@ class DataflowPlanOptimization(Enum):
         """Convenience method for getting a set of all available optimizations."""
         return frozenset((DataflowPlanOptimization.SOURCE_SCAN, DataflowPlanOptimization.PREDICATE_PUSHDOWN))
 
+    @staticmethod
+    def enabled_obtimizations() -> FrozenSet[DataflowPlanOptimization]:
+        """Set of DataflowPlanOptimization that are currently enabled.
+
+        Predicate pushdown optimizer is currently disabled.
+        """
+        return frozenset((DataflowPlanOptimization.SOURCE_SCAN,))
+
 
 class DataflowPlanOptimizerFactory:
     """Factory class for initializing an enumerated set of optimizers.

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -111,7 +111,7 @@ class MetricFlowQueryRequest:
     order_by: Optional[Sequence[OrderByQueryParameter]] = None
     min_max_only: bool = False
     sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4
-    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.enabled_obtimizations()
+    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.enabled_optimizations()
     query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
 
     @staticmethod
@@ -130,7 +130,7 @@ class MetricFlowQueryRequest:
         sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
         dataflow_plan_optimizations: FrozenSet[
             DataflowPlanOptimization
-        ] = DataflowPlanOptimization.enabled_obtimizations(),
+        ] = DataflowPlanOptimization.enabled_optimizations(),
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
         min_max_only: bool = False,
     ) -> MetricFlowQueryRequest:

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -111,7 +111,7 @@ class MetricFlowQueryRequest:
     order_by: Optional[Sequence[OrderByQueryParameter]] = None
     min_max_only: bool = False
     sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4
-    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.all_optimizations()
+    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.enabled_obtimizations()
     query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
 
     @staticmethod
@@ -128,7 +128,9 @@ class MetricFlowQueryRequest:
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
         sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
-        dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.all_optimizations(),
+        dataflow_plan_optimizations: FrozenSet[
+            DataflowPlanOptimization
+        ] = DataflowPlanOptimization.enabled_obtimizations(),
         query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC,
         min_max_only: bool = False,
     ) -> MetricFlowQueryRequest:

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -54,11 +54,11 @@ def render_and_check(
     # Run dataflow -> sql conversion with all optimizers
     if is_distinct_values_plan:
         optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-            query_spec, optimizations=DataflowPlanOptimization.all_optimizations()
+            query_spec, optimizations=DataflowPlanOptimization.enabled_obtimizations()
         )
     else:
         optimized_plan = dataflow_plan_builder.build_plan(
-            query_spec, optimizations=DataflowPlanOptimization.all_optimizations()
+            query_spec, optimizations=DataflowPlanOptimization.enabled_obtimizations()
         )
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -54,11 +54,11 @@ def render_and_check(
     # Run dataflow -> sql conversion with all optimizers
     if is_distinct_values_plan:
         optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(
-            query_spec, optimizations=DataflowPlanOptimization.enabled_obtimizations()
+            query_spec, optimizations=DataflowPlanOptimization.enabled_optimizations()
         )
     else:
         optimized_plan = dataflow_plan_builder.build_plan(
-            query_spec, optimizations=DataflowPlanOptimization.enabled_obtimizations()
+            query_spec, optimizations=DataflowPlanOptimization.enabled_optimizations()
         )
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATETIME_TRUNC(ds, day) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN '2020-01-01' AND '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN '2020-01-01' AND '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_categorical_filter__plan0_optimized.sql
@@ -12,7 +12,6 @@ FROM (
     , MAX(subq_30.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -21,12 +20,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    ) subq_18
     WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_time_constraint__plan0_optimized.sql
@@ -10,8 +10,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
@@ -19,17 +17,15 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id']
       SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
+        referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       visit__referrer_id
   ) subq_23

--- a/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metric_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_with_window_and_time_constraint__plan0_optimized.sql
@@ -12,8 +12,6 @@ FROM (
     , MAX(subq_34.buys) AS buys
   FROM (
     -- Constrain Output with WHERE
-    -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
-    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,17 +20,16 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'visits_source'
       -- Metric Time Dimension 'ds'
+      -- Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]
+      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , referrer_id AS visit__referrer_id
         , 1 AS visits
       FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_19
-    WHERE (
-      metric_time__day BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
-    ) AND (
-      visit__referrer_id = 'ref_id_01'
-    )
+      WHERE DATE_TRUNC('day', ds) BETWEEN timestamp '2020-01-01' AND timestamp '2020-01-02'
+    ) subq_21
+    WHERE visit__referrer_id = 'ref_id_01'
     GROUP BY
       metric_time__day
       , visit__referrer_id

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0_optimized.sql
@@ -8,9 +8,9 @@ FROM (
   FROM (
     -- Combine Aggregated Outputs
     SELECT
-      MAX(subq_45.average_booking_value) AS average_booking_value
-      , MAX(subq_45.bookings) AS bookings
-      , MAX(subq_52.booking_value) AS booking_value
+      MAX(subq_44.average_booking_value) AS average_booking_value
+      , MAX(subq_44.bookings) AS bookings
+      , MAX(subq_51.booking_value) AS booking_value
     FROM (
       -- Constrain Output with WHERE
       -- Pass Only Elements: ['average_booking_value', 'bookings']
@@ -23,38 +23,30 @@ FROM (
         -- Join Standard Outputs
         -- Pass Only Elements: ['average_booking_value', 'bookings', 'listing__is_lux_latest', 'booking__is_instant']
         SELECT
-          listings_latest_src_28000.is_lux AS listing__is_lux_latest
-          , subq_36.bookings AS bookings
-          , subq_36.average_booking_value AS average_booking_value
+          subq_35.booking__is_instant AS booking__is_instant
+          , listings_latest_src_28000.is_lux AS listing__is_lux_latest
+          , subq_35.bookings AS bookings
+          , subq_35.average_booking_value AS average_booking_value
         FROM (
-          -- Constrain Output with WHERE
+          -- Read Elements From Semantic Model 'bookings_source'
+          -- Metric Time Dimension 'ds'
           -- Pass Only Elements: ['average_booking_value', 'bookings', 'booking__is_instant', 'listing']
           SELECT
-            listing
-            , bookings
-            , average_booking_value
-          FROM (
-            -- Read Elements From Semantic Model 'bookings_source'
-            -- Metric Time Dimension 'ds'
-            SELECT
-              listing_id AS listing
-              , is_instant AS booking__is_instant
-              , 1 AS bookings
-              , booking_value AS average_booking_value
-            FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_34
-          WHERE booking__is_instant
-        ) subq_36
+            listing_id AS listing
+            , is_instant AS booking__is_instant
+            , 1 AS bookings
+            , booking_value AS average_booking_value
+          FROM ***************************.fct_bookings bookings_source_src_28000
+        ) subq_35
         LEFT OUTER JOIN
           ***************************.dim_listings_latest listings_latest_src_28000
         ON
-          subq_36.listing = listings_latest_src_28000.listing_id
-      ) subq_41
-      WHERE listing__is_lux_latest
-    ) subq_45
+          subq_35.listing = listings_latest_src_28000.listing_id
+      ) subq_40
+      WHERE (listing__is_lux_latest) AND (booking__is_instant)
+    ) subq_44
     CROSS JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['booking_value', 'booking__is_instant']
       -- Pass Only Elements: ['booking_value',]
       -- Aggregate Measures
       -- Compute Metrics via Expressions
@@ -63,12 +55,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['booking_value', 'booking__is_instant']
         SELECT
           is_instant AS booking__is_instant
           , booking_value
         FROM ***************************.fct_bookings bookings_source_src_28000
       ) subq_47
       WHERE booking__is_instant
-    ) subq_52
-  ) subq_53
-) subq_54
+    ) subq_51
+  ) subq_52
+) subq_53

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.third_hop_table third_hop_table_src_22000
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
     -- Pass Only Elements: ['customers_with_other_data', 'customer_id__customer_third_hop_id']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -24,12 +23,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'customer_other_data'
       -- Metric Time Dimension 'acquired_ds'
+      -- Pass Only Elements: ['customers_with_other_data', 'customer_id__country', 'customer_id__customer_third_hop_id']
       SELECT
         customer_third_hop_id AS customer_id__customer_third_hop_id
         , country AS customer_id__country
         , 1 AS customers_with_other_data
       FROM ***************************.customer_other_data customer_other_data_src_22000
-    ) subq_20
+    ) subq_21
     WHERE customer_id__country = 'paraguay'
     GROUP BY
       customer_id__customer_third_hop_id

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,37 +11,38 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATETIME_TRUNC(ds, day) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
       metric_time__day
       , user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATETIME_TRUNC(bookings_source_src_28000.ds, day) <= subq_17.ds
+      ) AND (
+        DATETIME_TRUNC(bookings_source_src_28000.ds, day) > DATE_SUB(CAST(subq_17.ds AS DATETIME), INTERVAL 2 day)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > DATE_SUB(CAST(subq_18.ds AS DATETIME), INTERVAL 2 day)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
   metric_time__day
   , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,37 +24,38 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATETIME_TRUNC(ds, day) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
           metric_time__day
           , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
   user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,38 +11,39 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATETIME_TRUNC(ds, day) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
       metric_time__day
       , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
   listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_17.ds)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_17.ds - INTERVAL 2 day
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > subq_18.ds - INTERVAL 2 day
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_17.ds - MAKE_INTERVAL(days => 2)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > subq_18.ds - MAKE_INTERVAL(days => 2)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_17.ds)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_17.ds)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > DATEADD(day, -2, subq_18.ds)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -11,40 +11,41 @@ FROM (
     , MAX(subq_37.visits) AS visits
     , MAX(subq_54.buys) AS buys
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , users_latest_src_28000.home_state_latest AS user__home_state_latest
-      , SUM(subq_31.visits) AS visits
+      metric_time__day
+      , user__home_state_latest
+      , SUM(visits) AS visits
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['visits', 'user__home_state_latest', 'visit__referrer_id', 'metric_time__day']
       SELECT
-        metric_time__day
-        , subq_29.user
-        , visits
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.visit__referrer_id AS visit__referrer_id
+        , users_latest_src_28000.home_state_latest AS user__home_state_latest
+        , subq_30.visits AS visits
       FROM (
         -- Read Elements From Semantic Model 'visits_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , user_id AS user
           , referrer_id AS visit__referrer_id
           , 1 AS visits
         FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_29
-      WHERE visit__referrer_id = '123456'
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_users_latest users_latest_src_28000
-    ON
-      subq_31.user = users_latest_src_28000.user_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_users_latest users_latest_src_28000
+      ON
+        subq_30.user = users_latest_src_28000.user_id
+    ) subq_34
+    WHERE visit__referrer_id = '123456'
     GROUP BY
-      subq_31.metric_time__day
-      , users_latest_src_28000.home_state_latest
+      metric_time__day
+      , user__home_state_latest
   ) subq_37
   FULL OUTER JOIN (
     -- Join Standard Outputs

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0_optimized.sql
@@ -1,49 +1,43 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookers', 'listing__country_latest', 'metric_time__day']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_20.metric_time__day AS metric_time__day
-  , listings_latest_src_28000.country AS listing__country_latest
-  , COUNT(DISTINCT subq_20.bookers) AS every_two_days_bookers
+  metric_time__day
+  , listing__country_latest
+  , COUNT(DISTINCT bookers) AS every_two_days_bookers
 FROM (
-  -- Join Self Over Time Range
-  -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookers', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
   SELECT
-    subq_18.ds AS metric_time__day
-    , subq_16.listing AS listing
-    , subq_16.bookers AS bookers
-  FROM ***************************.mf_time_spine subq_18
-  INNER JOIN (
-    -- Constrain Output with WHERE
+    subq_19.metric_time__day AS metric_time__day
+    , subq_19.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_19.bookers AS bookers
+  FROM (
+    -- Join Self Over Time Range
+    -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']
     SELECT
-      metric_time__day
-      , listing
-      , bookers
-    FROM (
-      -- Read Elements From Semantic Model 'bookings_source'
-      -- Metric Time Dimension 'ds'
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , listing_id AS listing
-        , is_instant AS booking__is_instant
-        , guest_id AS bookers
-      FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_15
-    WHERE booking__is_instant
-  ) subq_16
+      subq_17.ds AS metric_time__day
+      , bookings_source_src_28000.listing_id AS listing
+      , bookings_source_src_28000.is_instant AS booking__is_instant
+      , bookings_source_src_28000.guest_id AS bookers
+    FROM ***************************.mf_time_spine subq_17
+    INNER JOIN
+      ***************************.fct_bookings bookings_source_src_28000
+    ON
+      (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_17.ds
+      ) AND (
+        DATE_TRUNC('day', bookings_source_src_28000.ds) > DATE_ADD('day', -2, subq_17.ds)
+      )
+  ) subq_19
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
   ON
-    (
-      subq_16.metric_time__day <= subq_18.ds
-    ) AND (
-      subq_16.metric_time__day > DATE_ADD('day', -2, subq_18.ds)
-    )
-) subq_20
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_20.listing = listings_latest_src_28000.listing_id
+    subq_19.listing = listings_latest_src_28000.listing_id
+) subq_24
+WHERE booking__is_instant
 GROUP BY
-  subq_20.metric_time__day
-  , listings_latest_src_28000.country
+  metric_time__day
+  , listing__country_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_different_filters_on_same_measure_source_categorical_dimension__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.max_booking_value) AS max_booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['average_booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value AS average_booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0_optimized.sql
@@ -24,40 +24,41 @@ FROM (
         , subq_44.bookings AS bookings
       FROM ***************************.mf_time_spine subq_46
       LEFT OUTER JOIN (
-        -- Join Standard Outputs
-        -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+        -- Constrain Output with WHERE
         -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
         -- Aggregate Measures
         SELECT
-          subq_37.metric_time__day AS metric_time__day
-          , listings_latest_src_28000.country AS listing__country_latest
-          , SUM(subq_37.bookings) AS bookings
+          metric_time__day
+          , listing__country_latest
+          , SUM(bookings) AS bookings
         FROM (
-          -- Constrain Output with WHERE
-          -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+          -- Join Standard Outputs
+          -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
           SELECT
-            metric_time__day
-            , listing
-            , bookings
+            subq_36.metric_time__day AS metric_time__day
+            , subq_36.booking__is_instant AS booking__is_instant
+            , listings_latest_src_28000.country AS listing__country_latest
+            , subq_36.bookings AS bookings
           FROM (
             -- Read Elements From Semantic Model 'bookings_source'
             -- Metric Time Dimension 'ds'
+            -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
             SELECT
               DATE_TRUNC('day', ds) AS metric_time__day
               , listing_id AS listing
               , is_instant AS booking__is_instant
               , 1 AS bookings
             FROM ***************************.fct_bookings bookings_source_src_28000
-          ) subq_35
-          WHERE booking__is_instant
-        ) subq_37
-        LEFT OUTER JOIN
-          ***************************.dim_listings_latest listings_latest_src_28000
-        ON
-          subq_37.listing = listings_latest_src_28000.listing_id
+          ) subq_36
+          LEFT OUTER JOIN
+            ***************************.dim_listings_latest listings_latest_src_28000
+          ON
+            subq_36.listing = listings_latest_src_28000.listing_id
+        ) subq_41
+        WHERE booking__is_instant
         GROUP BY
-          subq_37.metric_time__day
-          , listings_latest_src_28000.country
+          metric_time__day
+          , listing__country_latest
       ) subq_44
       ON
         subq_46.ds = subq_44.metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,32 +1,34 @@
--- Join Standard Outputs
--- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['listings', 'user__home_state_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  users_latest_src_28000.home_state_latest AS user__home_state_latest
-  , SUM(subq_13.listings) AS listings
+  user__home_state_latest
+  , SUM(listings) AS listings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['listings', 'user__home_state_latest', 'listing__is_lux_latest', 'listing__capacity_latest']
   SELECT
-    subq_11.user
-    , listings
+    subq_12.listing__is_lux_latest AS listing__is_lux_latest
+    , subq_12.listing__capacity_latest AS listing__capacity_latest
+    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , subq_12.listings AS listings
   FROM (
     -- Read Elements From Semantic Model 'listings_latest'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']
     SELECT
       user_id AS user
       , is_lux AS listing__is_lux_latest
       , capacity AS listing__capacity_latest
       , 1 AS listings
     FROM ***************************.dim_listings_latest listings_latest_src_28000
-  ) subq_11
-  WHERE listing__is_lux_latest OR listing__capacity_latest > 4
-) subq_13
-LEFT OUTER JOIN
-  ***************************.dim_users_latest users_latest_src_28000
-ON
-  subq_13.user = users_latest_src_28000.user_id
+  ) subq_12
+  LEFT OUTER JOIN
+    ***************************.dim_users_latest users_latest_src_28000
+  ON
+    subq_12.user = users_latest_src_28000.user_id
+) subq_16
+WHERE listing__is_lux_latest OR listing__capacity_latest > 4
 GROUP BY
-  users_latest_src_28000.home_state_latest
+  user__home_state_latest

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0_optimized.sql
@@ -11,41 +11,42 @@ FROM (
     , MAX(subq_39.bookings) AS bookings
     , MAX(subq_54.bookings_2_weeks_ago) AS bookings_2_weeks_ago
   FROM (
-    -- Join Standard Outputs
-    -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
+    -- Constrain Output with WHERE
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_31.metric_time__day AS metric_time__day
-      , listings_latest_src_28000.country AS listing__country_latest
-      , SUM(subq_31.bookings) AS bookings
+      metric_time__day
+      , listing__country_latest
+      , SUM(bookings) AS bookings
     FROM (
-      -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
+      -- Join Standard Outputs
+      -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant', 'metric_time__day']
       SELECT
-        metric_time__day
-        , listing
-        , bookings
+        subq_30.metric_time__day AS metric_time__day
+        , subq_30.booking__is_instant AS booking__is_instant
+        , listings_latest_src_28000.country AS listing__country_latest
+        , subq_30.bookings AS bookings
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , listing_id AS listing
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_29
-      WHERE booking__is_instant
-    ) subq_31
-    LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
-    ON
-      subq_31.listing = listings_latest_src_28000.listing_id
+      ) subq_30
+      LEFT OUTER JOIN
+        ***************************.dim_listings_latest listings_latest_src_28000
+      ON
+        subq_30.listing = listings_latest_src_28000.listing_id
+    ) subq_35
+    WHERE booking__is_instant
     GROUP BY
-      subq_31.metric_time__day
-      , listings_latest_src_28000.country
+      metric_time__day
+      , listing__country_latest
   ) subq_39
   FULL OUTER JOIN (
     -- Constrain Output with WHERE

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_pushdown_filter_application__plan0_optimized.sql
@@ -13,7 +13,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_15
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
@@ -22,12 +21,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0_optimized.sql
@@ -1,31 +1,32 @@
--- Join Standard Outputs
--- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
+-- Constrain Output with WHERE
 -- Pass Only Elements: ['bookings', 'listing__country_latest']
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  listings_latest_src_28000.country AS listing__country_latest
-  , SUM(subq_14.bookings) AS bookings
+  listing__country_latest
+  , SUM(bookings) AS bookings
 FROM (
-  -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
+  -- Join Standard Outputs
+  -- Pass Only Elements: ['bookings', 'listing__country_latest', 'booking__is_instant']
   SELECT
-    listing
-    , bookings
+    subq_13.booking__is_instant AS booking__is_instant
+    , listings_latest_src_28000.country AS listing__country_latest
+    , subq_13.bookings AS bookings
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']
     SELECT
       listing_id AS listing
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
-  WHERE booking__is_instant
-) subq_14
-LEFT OUTER JOIN
-  ***************************.dim_listings_latest listings_latest_src_28000
-ON
-  subq_14.listing = listings_latest_src_28000.listing_id
+  ) subq_13
+  LEFT OUTER JOIN
+    ***************************.dim_listings_latest listings_latest_src_28000
+  ON
+    subq_13.listing = listings_latest_src_28000.listing_id
+) subq_18
+WHERE booking__is_instant
 GROUP BY
-  listings_latest_src_28000.country
+  listing__country_latest

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATETIME_TRUNC(ds, day) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_reused_measure__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
     , MAX(subq_24.booking_value) AS booking_value
   FROM (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['booking_value', 'metric_time__day']
     -- Aggregate Measures
     -- Compute Metrics via Expressions
@@ -20,12 +19,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['booking_value', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , booking_value
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_14
+    ) subq_15
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint_with_single_expr_and_alias__plan0_optimized.sql
@@ -4,7 +4,6 @@ SELECT
   , delayed_bookings * 2 AS double_counted_delayed_bookings
 FROM (
   -- Constrain Output with WHERE
-  -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
   -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
@@ -14,12 +13,13 @@ FROM (
   FROM (
     -- Read Elements From Semantic Model 'bookings_source'
     -- Metric Time Dimension 'ds'
+    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     SELECT
       DATE_TRUNC('day', ds) AS metric_time__day
       , is_instant AS booking__is_instant
       , 1 AS bookings
     FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_8
+  ) subq_9
   WHERE NOT booking__is_instant
   GROUP BY
     metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATETIME_TRUNC(ds, day) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/BigQuery/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATETIME_TRUNC(ds, day) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Databricks/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/DuckDB/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Postgres/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Redshift/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Snowflake/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_filter__plan0_optimized.sql
@@ -10,7 +10,6 @@ FROM (
   FROM ***************************.mf_time_spine subq_16
   LEFT OUTER JOIN (
     -- Constrain Output with WHERE
-    -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
     -- Pass Only Elements: ['bookings', 'metric_time__day']
     -- Aggregate Measures
     SELECT
@@ -19,12 +18,13 @@ FROM (
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
       -- Metric Time Dimension 'ds'
+      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       SELECT
         DATE_TRUNC('day', ds) AS metric_time__day
         , is_instant AS booking__is_instant
         , 1 AS bookings
       FROM ***************************.fct_bookings bookings_source_src_28000
-    ) subq_10
+    ) subq_11
     WHERE booking__is_instant
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_time_spine_join_rendering.py/SqlQueryPlan/Trino/test_simple_join_to_time_spine_with_queried_filter__plan0_optimized.sql
@@ -18,7 +18,6 @@ FROM (
     FROM ***************************.mf_time_spine subq_15
     LEFT OUTER JOIN (
       -- Constrain Output with WHERE
-      -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
@@ -27,12 +26,13 @@ FROM (
       FROM (
         -- Read Elements From Semantic Model 'bookings_source'
         -- Metric Time Dimension 'ds'
+        -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day']
         SELECT
           DATE_TRUNC('day', ds) AS metric_time__day
           , is_instant AS booking__is_instant
           , 1 AS bookings
         FROM ***************************.fct_bookings bookings_source_src_28000
-      ) subq_10
+      ) subq_11
       WHERE booking__is_instant
       GROUP BY
         metric_time__day


### PR DESCRIPTION
Disable predicate pushdown optimizer. This has some bugs that we haven't investigated yet. It has been disabled in our servers, so it should be disabled in MetricFlow by default, too, to ensure where we're doing all our testing matches what's happening in production.