### PR TITLE
Make SemanticManifestLookup available for spec pattern creation

### DIFF
--- a/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
@@ -9,6 +9,7 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from typing_extensions import override
 
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.patterns.entity_link_pattern import (
@@ -50,7 +51,7 @@ class DunderNamingScheme(QueryItemNamingScheme):
         return names[0]
 
     @override
-    def spec_pattern(self, input_str: str) -> EntityLinkPattern:
+    def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> EntityLinkPattern:
         if not self.input_str_follows_scheme(input_str):
             raise ValueError(f"{repr(input_str)} does not follow this scheme.")
 

--- a/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
@@ -5,6 +5,7 @@ from typing import Optional
 from dbt_semantic_interfaces.references import MetricReference
 from typing_extensions import override
 
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.patterns.metric_pattern import MetricSpecPattern
@@ -25,7 +26,7 @@ class MetricNamingScheme(QueryItemNamingScheme):
         return names[0]
 
     @override
-    def spec_pattern(self, input_str: str) -> MetricSpecPattern:
+    def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> MetricSpecPattern:
         input_str = input_str.lower()
         if not self.input_str_follows_scheme(input_str):
             raise RuntimeError(f"{repr(input_str)} does not follow this scheme.")

--- a/metricflow-semantics/metricflow_semantics/naming/naming_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/naming_scheme.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional
 
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 
 if TYPE_CHECKING:
@@ -29,11 +30,14 @@ class QueryItemNamingScheme(ABC):
         pass
 
     @abstractmethod
-    def spec_pattern(self, input_str: str) -> SpecPattern:
+    def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> SpecPattern:
         """Given an input that follows this scheme, return a spec pattern that matches the described input.
 
-        If the input_str does not follow this scheme, raise a ValueError. In practice, input_str_follows_scheme() should
-        be called on the input_str beforehand.
+        This is used to generate suggestions from available group-by-items if the user specifies a group-by-item that is
+        invalid.
+
+        If this scheme cannot accommodate the spec, return None. This is needed to handle unsupported cases in
+        DunderNamingScheme, such as DatePart, but naming schemes should otherwise be complete.
         """
         pass
 

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
@@ -12,6 +12,7 @@ from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import Whe
 from dbt_semantic_interfaces.references import EntityReference
 from typing_extensions import override
 
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.naming.object_builder_str import ObjectBuilderNameConverter
 from metricflow_semantics.specs.instance_spec import InstanceSpec
@@ -36,7 +37,7 @@ class ObjectBuilderNamingScheme(QueryItemNamingScheme):
         return ObjectBuilderNameConverter.input_str_from_spec(instance_spec)
 
     @override
-    def spec_pattern(self, input_str: str) -> SpecPattern:
+    def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> SpecPattern:
         if not self.input_str_follows_scheme(input_str):
             raise ValueError(
                 f"The specified input {repr(input_str)} does not match the input described by the object builder "

--- a/metricflow-semantics/metricflow_semantics/protocols/query_parameter.py
+++ b/metricflow-semantics/metricflow_semantics/protocols/query_parameter.py
@@ -6,6 +6,7 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 
 if TYPE_CHECKING:
+    from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
     from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import (
         ResolverInputForGroupByItem,
         ResolverInputForMetric,
@@ -22,8 +23,9 @@ class MetricQueryParameter(Protocol):
         """The name of the metric."""
         raise NotImplementedError
 
-    @property
-    def query_resolver_input(self) -> ResolverInputForMetric:  # noqa: D102
+    def query_resolver_input(  # noqa: D102
+        self, semantic_manifest_lookup: SemanticManifestLookup
+    ) -> ResolverInputForMetric:
         raise NotImplementedError
 
 
@@ -36,8 +38,9 @@ class DimensionOrEntityQueryParameter(Protocol):
         """The name of the metric."""
         raise NotImplementedError
 
-    @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
+    def query_resolver_input(  # noqa: D102
+        self, semantic_manifest_lookup: SemanticManifestLookup
+    ) -> ResolverInputForGroupByItem:
         raise NotImplementedError
 
 
@@ -58,8 +61,9 @@ class TimeDimensionQueryParameter(Protocol):  # noqa: D101
         """Date part to extract from the dimension."""
         raise NotImplementedError
 
-    @property
-    def query_resolver_input(self) -> ResolverInputForGroupByItem:  # noqa: D102
+    def query_resolver_input(  # noqa: D102
+        self, semantic_manifest_lookup: SemanticManifestLookup
+    ) -> ResolverInputForGroupByItem:
         raise NotImplementedError
 
 
@@ -80,8 +84,9 @@ class OrderByQueryParameter(Protocol):
         """Indicates if the order should be ascending or descending."""
         raise NotImplementedError
 
-    @property
-    def query_resolver_input(self) -> ResolverInputForOrderByItem:  # noqa: D102
+    def query_resolver_input(  # noqa: D102
+        self, semantic_manifest_lookup: SemanticManifestLookup
+    ) -> ResolverInputForOrderByItem:
         raise NotImplementedError
 
 

--- a/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/snapshot_helpers.py
@@ -343,9 +343,11 @@ def assert_spec_set_snapshot_equal(  # noqa: D103
 
 
 def assert_linkable_spec_set_snapshot_equal(  # noqa: D103
-    request: FixtureRequest, mf_test_configuration: SnapshotConfiguration, set_id: str, spec_set: LinkableSpecSet
+    request: FixtureRequest,
+    mf_test_configuration: SnapshotConfiguration,
+    set_id: str,
+    spec_set: LinkableSpecSet,
 ) -> None:
-    # TODO: This will be used in a later PR and this message will be removed.
     naming_scheme = ObjectBuilderNamingScheme()
     assert_snapshot_text_equal(
         request=request,

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
@@ -6,6 +6,7 @@ import pytest
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.dunder_scheme import DunderNamingScheme
 from metricflow_semantics.specs.dimension_spec import DimensionSpec
 from metricflow_semantics.specs.entity_spec import EntitySpec
@@ -84,9 +85,15 @@ def test_input_follows_scheme(dunder_naming_scheme: DunderNamingScheme) -> None:
 
 
 def test_spec_pattern(  # noqa: D103
-    dunder_naming_scheme: DunderNamingScheme, specs: Sequence[LinkableInstanceSpec]
+    dunder_naming_scheme: DunderNamingScheme,
+    specs: Sequence[LinkableInstanceSpec],
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:  # noqa: D103
-    assert tuple(dunder_naming_scheme.spec_pattern("listing__user__country").match(specs)) == (
+    assert tuple(
+        dunder_naming_scheme.spec_pattern(
+            "listing__user__country", semantic_manifest_lookup=simple_semantic_manifest_lookup
+        ).match(specs)
+    ) == (
         DimensionSpec(
             element_name="country",
             entity_links=(
@@ -96,13 +103,21 @@ def test_spec_pattern(  # noqa: D103
         ),
     )
 
-    assert tuple(dunder_naming_scheme.spec_pattern("metric_time").match(specs)) == (
+    assert tuple(
+        dunder_naming_scheme.spec_pattern(
+            "metric_time", semantic_manifest_lookup=simple_semantic_manifest_lookup
+        ).match(specs)
+    ) == (
         MTD_SPEC_WEEK,
         MTD_SPEC_MONTH,
         MTD_SPEC_YEAR,
     )
 
-    assert tuple(dunder_naming_scheme.spec_pattern("booking__listing__user").match(specs)) == (
+    assert tuple(
+        dunder_naming_scheme.spec_pattern(
+            "booking__listing__user", semantic_manifest_lookup=simple_semantic_manifest_lookup
+        ).match(specs)
+    ) == (
         EntitySpec(
             element_name="user",
             entity_links=(
@@ -112,4 +127,8 @@ def test_spec_pattern(  # noqa: D103
         ),
     )
 
-    assert tuple(dunder_naming_scheme.spec_pattern("metric_time__month").match(specs)) == (MTD_SPEC_MONTH,)
+    assert tuple(
+        dunder_naming_scheme.spec_pattern(
+            "metric_time__month", semantic_manifest_lookup=simple_semantic_manifest_lookup
+        ).match(specs)
+    ) == (MTD_SPEC_MONTH,)

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_metric_name_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_metric_name_scheme.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Sequence
 
 import pytest
+from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.naming.metric_scheme import MetricNamingScheme
 from metricflow_semantics.specs.dimension_spec import DimensionSpec
 from metricflow_semantics.specs.instance_spec import InstanceSpec
@@ -15,21 +16,25 @@ def metric_naming_scheme() -> MetricNamingScheme:  # noqa: D103
 
 
 def test_input_str(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
-    assert metric_naming_scheme.input_str(MetricSpec(element_name="example_metric")) == "example_metric"
+    assert metric_naming_scheme.input_str(MetricSpec(element_name="bookings")) == "bookings"
 
 
 def test_input_follows_scheme(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
-    assert metric_naming_scheme.input_str_follows_scheme("some_metric_name")
+    assert metric_naming_scheme.input_str_follows_scheme("listings")
 
 
-def test_spec_pattern(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
-    spec_pattern = metric_naming_scheme.spec_pattern("metric_0")
-
-    specs: Sequence[InstanceSpec] = (
-        MetricSpec(element_name="metric_0"),
-        MetricSpec(element_name="metric_1"),
-        # Shouldn't happen in practice, but checks to see that only metric specs are matched.
-        DimensionSpec(element_name="metric_0", entity_links=()),
+def test_spec_pattern(  # noqa: D103
+    metric_naming_scheme: MetricNamingScheme, simple_semantic_manifest_lookup: SemanticManifestLookup
+) -> None:
+    spec_pattern = metric_naming_scheme.spec_pattern(
+        "bookings", semantic_manifest_lookup=simple_semantic_manifest_lookup
     )
 
-    assert (MetricSpec(element_name="metric_0"),) == tuple(spec_pattern.match(specs))
+    specs: Sequence[InstanceSpec] = (
+        MetricSpec(element_name="bookings"),
+        MetricSpec(element_name="listings"),
+        # Shouldn't happen in practice, but checks to see that only metric specs are matched.
+        DimensionSpec(element_name="bookings", entity_links=()),
+    )
+
+    assert (MetricSpec(element_name="bookings"),) == tuple(spec_pattern.match(specs))

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/filter_spec_resolution/test_spec_lookup.py
@@ -21,7 +21,6 @@ from dbt_semantic_interfaces.references import MetricReference
 from dbt_semantic_interfaces.transformations.transform_rule import SemanticManifestTransformRule
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_pattern_factory import (
     DefaultWhereFilterPatternFactory,
 )
@@ -58,7 +57,6 @@ def assert_spec_lookup_snapshot_equal(  # noqa: D103
 def test_filter_spec_resolution(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
     dag_case_id: str,

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_filters.py
@@ -7,7 +7,6 @@ import pytest
 from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow_semantics.naming.naming_scheme import QueryItemNamingScheme
 from metricflow_semantics.naming.object_builder_scheme import ObjectBuilderNamingScheme
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.group_by_item_resolver import GroupByItemResolver
@@ -27,7 +26,6 @@ logger = logging.getLogger(__name__)
 def test_ambiguous_metric_time_in_query_filter(  # noqa: D103
     request: FixtureRequest,
     mf_test_configuration: MetricFlowTestConfiguration,
-    naming_scheme: QueryItemNamingScheme,
     ambiguous_resolution_manifest_lookup: SemanticManifestLookup,
     resolution_dags: Dict[AmbiguousResolutionQueryId, GroupByItemResolutionDag],
     dag_case_id: str,
@@ -40,7 +38,9 @@ def test_ambiguous_metric_time_in_query_filter(  # noqa: D103
     )
 
     input_str = f"TimeDimension('{METRIC_TIME_ELEMENT_NAME}')"
-    spec_pattern = ObjectBuilderNamingScheme().spec_pattern(input_str)
+    spec_pattern = ObjectBuilderNamingScheme().spec_pattern(
+        input_str, semantic_manifest_lookup=ambiguous_resolution_manifest_lookup
+    )
 
     assert isinstance(resolution_dag.sink_node, QueryGroupByItemResolutionNode)
     result = group_by_item_resolver.resolve_matching_item_for_filters(

--- a/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/group_by_item/test_matching_item_for_querying.py
@@ -38,7 +38,9 @@ def test_ambiguous_metric_time_in_query(  # noqa: D103
         resolution_dag=resolution_dag,
     )
 
-    spec_pattern = ObjectBuilderNamingScheme().spec_pattern(f"TimeDimension('{METRIC_TIME_ELEMENT_NAME}')")
+    spec_pattern = ObjectBuilderNamingScheme().spec_pattern(
+        f"TimeDimension('{METRIC_TIME_ELEMENT_NAME}')", semantic_manifest_lookup=ambiguous_resolution_manifest_lookup
+    )
 
     result = group_by_item_resolver.resolve_matching_item_for_querying(
         spec_pattern=spec_pattern,
@@ -76,7 +78,10 @@ def test_unavailable_group_by_item_in_derived_metric_parent(
         manifest_lookup=ambiguous_resolution_manifest_lookup,
         resolution_dag=resolution_dag,
     )
-    spec_pattern = naming_scheme.spec_pattern("Dimension('monthly_measure_entity__creation_time')")
+    spec_pattern = naming_scheme.spec_pattern(
+        "Dimension('monthly_measure_entity__creation_time')",
+        semantic_manifest_lookup=ambiguous_resolution_manifest_lookup,
+    )
 
     result = group_by_item_resolver.resolve_matching_item_for_querying(
         spec_pattern=spec_pattern,
@@ -106,7 +111,9 @@ def test_invalid_group_by_item(  # noqa: D103
     input_str = "Dimension('monthly_measure_entity__invalid_dimension')"
 
     result = group_by_item_resolver.resolve_matching_item_for_querying(
-        spec_pattern=naming_scheme.spec_pattern(input_str),
+        spec_pattern=naming_scheme.spec_pattern(
+            input_str, semantic_manifest_lookup=ambiguous_resolution_manifest_lookup
+        ),
         suggestion_generator=None,
     )
 


### PR DESCRIPTION
MetricFlow's query input parameter processing runs through a
pattern matching/parsing step that then produces a parameter spec
for subsequent matching during group by resolution. In practice,
every query parameter either directly references or is derived
directly from one or more elements in a semantic manifest.

Converting a parameter into a corresponsing spec pattern for a
given query input can, therefore, benefit from access to
the semantic manifest lookup objects we provide. This will
allow us to do things like map custom granularities to their
corresponding base granularities when doing group by resolution.

This change simply makes the semantic manifest available to the
method that converts between the query input parameter and the
spec pattern. It isolates the availability of the semantic
manifest lookup to this method because the other methods in the
relevant classes should generally not be using the lookup to
perform their operations, and the change as implemented
here also has a more limited blast radius.