### PR TITLE
Switch query parameter classes onto ExpandedTimeGranularity

### DIFF
--- a/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
@@ -18,6 +18,7 @@ from metricflow_semantics.specs.patterns.entity_link_pattern import (
     ParameterSetField,
 )
 from metricflow_semantics.specs.spec_set import InstanceSpecSet, InstanceSpecSetTransform, group_spec_by_type
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 class DunderNamingScheme(QueryItemNamingScheme):
@@ -81,7 +82,8 @@ class DunderNamingScheme(QueryItemNamingScheme):
         # At this point, len(input_str_parts) >= 2
         for granularity in TimeGranularity:
             if input_str_parts[-1] == granularity.value:
-                time_grain = granularity
+                # TODO: [custom granularity] add support for custom granularity names here
+                time_grain = ExpandedTimeGranularity.from_time_granularity(granularity)
 
         # Has a time grain specified.
         if time_grain is not None:

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
@@ -81,7 +81,7 @@ class ObjectBuilderNamingScheme(QueryItemNamingScheme):
                 ParameterSetField.DATE_PART,
             ]
 
-            time_granularity = None
+            time_granularity: Optional[ExpandedTimeGranularity] = None
             if time_dimension_call_parameter_set.time_granularity is not None:
                 fields_to_compare.append(ParameterSetField.TIME_GRANULARITY)
                 time_granularity = ExpandedTimeGranularity.from_time_granularity(

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
@@ -23,6 +23,7 @@ from metricflow_semantics.specs.patterns.entity_link_pattern import (
 )
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 from metricflow_semantics.specs.patterns.typed_patterns import DimensionPattern, TimeDimensionPattern
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -80,14 +81,18 @@ class ObjectBuilderNamingScheme(QueryItemNamingScheme):
                 ParameterSetField.DATE_PART,
             ]
 
+            time_granularity = None
             if time_dimension_call_parameter_set.time_granularity is not None:
                 fields_to_compare.append(ParameterSetField.TIME_GRANULARITY)
+                time_granularity = ExpandedTimeGranularity.from_time_granularity(
+                    time_dimension_call_parameter_set.time_granularity
+                )
 
             return TimeDimensionPattern(
                 EntityLinkPatternParameterSet.from_parameters(
                     element_name=time_dimension_call_parameter_set.time_dimension_reference.element_name,
                     entity_links=time_dimension_call_parameter_set.entity_path,
-                    time_granularity=time_dimension_call_parameter_set.time_granularity,
+                    time_granularity=time_granularity,
                     date_part=time_dimension_call_parameter_set.date_part,
                     fields_to_compare=tuple(fields_to_compare),
                 )

--- a/metricflow-semantics/metricflow_semantics/protocols/query_parameter.py
+++ b/metricflow-semantics/metricflow_semantics/protocols/query_parameter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Protocol, Union, runtime_checkable
 
-from dbt_semantic_interfaces.type_enums import TimeGranularity
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 
 if TYPE_CHECKING:
@@ -52,8 +51,12 @@ class TimeDimensionQueryParameter(Protocol):  # noqa: D101
         raise NotImplementedError
 
     @property
-    def grain(self) -> Optional[TimeGranularity]:
-        """The time granularity."""
+    def grain(self) -> Optional[str]:
+        """The name of the time granularity.
+
+        This may be the name of a custom granularity or the string value of an entry in the standard
+        TimeGranularity enum.
+        """
         raise NotImplementedError
 
     @property

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -20,6 +20,7 @@ from metricflow_semantics.specs.patterns.entity_link_pattern import (
     ParameterSetField,
 )
 from metricflow_semantics.specs.spec_set import group_specs_by_type
+from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 @dataclass(frozen=True)
@@ -78,15 +79,19 @@ class TimeDimensionPattern(EntityLinkPattern):
             ParameterSetField.DATE_PART,
         ]
 
+        time_granularity = None
         if time_dimension_call_parameter_set.time_granularity is not None:
             fields_to_compare.append(ParameterSetField.TIME_GRANULARITY)
+            time_granularity = ExpandedTimeGranularity.from_time_granularity(
+                time_dimension_call_parameter_set.time_granularity
+            )
 
         return TimeDimensionPattern(
             parameter_set=EntityLinkPatternParameterSet.from_parameters(
                 fields_to_compare=tuple(fields_to_compare),
                 element_name=time_dimension_call_parameter_set.time_dimension_reference.element_name,
                 entity_links=time_dimension_call_parameter_set.entity_path,
-                time_granularity=time_dimension_call_parameter_set.time_granularity,
+                time_granularity=time_granularity,
                 date_part=time_dimension_call_parameter_set.date_part,
             )
         )

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -560,7 +560,7 @@ def test_date_part_parsing(
         query_parser.parse_and_validate_query(
             metric_names=["revenue"],
             group_by=(
-                TimeDimensionParameter(name="metric_time", grain=TimeGranularity.YEAR, date_part=DatePart.MONTH),
+                TimeDimensionParameter(name="metric_time", grain=TimeGranularity.YEAR.value, date_part=DatePart.MONTH),
             ),
         )
 

--- a/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_entity_link_pattern.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/patterns/test_entity_link_pattern.py
@@ -145,7 +145,7 @@ def test_time_dimension_match(specs: Sequence[LinkableInstanceSpec]) -> None:  #
         EntityLinkPatternParameterSet.from_parameters(
             element_name=METRIC_TIME_ELEMENT_NAME,
             entity_links=(),
-            time_granularity=TimeGranularity.WEEK,
+            time_granularity=ExpandedTimeGranularity.from_time_granularity(TimeGranularity.WEEK),
             date_part=None,
             fields_to_compare=(
                 ParameterSetField.ELEMENT_NAME,

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -261,8 +261,6 @@ def test_case(
         if date_part or grain:
             if date_part:
                 kwargs["date_part"] = DatePart(date_part)
-            if grain:
-                kwargs["grain"] = TimeGranularity(grain)
             group_by.append(TimeDimensionParameter(**kwargs))
         else:
             group_by.append(DimensionOrEntityParameter(**kwargs))


### PR DESCRIPTION
In preparation for supporting user-provided custom granularity names
at query time we need to update our query parameter processing
layer to use ExpandedTimeGranularities internally while accepting
string names from the original user input.

This change makes that update, although it is necessarily incomplete.
The TimeDimensionCallParameterSet, in particular, still uses an
enumeration-typed property for representing the user-requested grain,
but this interface is imported from dbt-semantic-interfaces and will
be updated in a later series of changes.

Follow-ups inside MetricFlow will enable lookups against custom granularity
values as we solidify our test layouts.