### PR TITLE
Streamline Object Formatting in Logs

### DIFF
--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -5,7 +5,7 @@ import pprint
 from collections.abc import Mapping
 from dataclasses import fields, is_dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sized, Union
+from typing import Any, Dict, List, Optional, Sized, Tuple, Union
 
 from dsi_pydantic_shim import BaseModel
 
@@ -458,13 +458,18 @@ def mf_pformat_many(  # type: ignore
                 include_empty_object_fields=include_empty_object_fields,
             )
 
-        item_block_lines = (
-            f"{key}:",
-            indent(
-                value_str,
-                indent_prefix=indent_prefix,
-            ),
-        )
+        lines_in_value_str = len(value_str.split("\n"))
+        item_block_lines: Tuple[str, ...]
+        if lines_in_value_str > 1:
+            item_block_lines = (
+                f"{key}:",
+                indent(
+                    value_str,
+                    indent_prefix=indent_prefix,
+                ),
+            )
+        else:
+            item_block_lines = (f"{key}: {value_str}",)
         item_block = "\n".join(item_block_lines)
         lines.append(indent(item_block))
     return "\n".join(lines)

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -466,5 +466,5 @@ def mf_pformat_many(  # type: ignore
             ),
         )
         item_block = "\n".join(item_block_lines)
-        lines.append(item_block)
-    return "\n\n".join(lines)
+        lines.append(indent(item_block))
+    return "\n".join(lines)

--- a/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
@@ -151,12 +151,8 @@ def test_pformat_many() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              (1, 2, 3)
-
-            object_1:
-              {4: 5}
+              object_0: (1, 2, 3)
+              object_1: {4: 5}
             """
         ).rstrip()
         == result
@@ -170,10 +166,9 @@ def test_pformat_many_with_raw_strings() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              foo
-              bar
+              object_0:
+                foo
+                bar
             """
         ).rstrip()
         == result
@@ -186,9 +181,7 @@ def test_pformat_many_with_strings() -> None:  # noqa: D103
         textwrap.dedent(
             """\
             Example description:
-
-            object_0:
-              'foo\\nbar'
+              object_0: 'foo\\nbar'
             """
         ).rstrip()
         == result


### PR DESCRIPTION
This PR updates `mf_pformat_many()` to return a more compact string representation.

* When possible, items are now formatted in a single line.
* Newlines between items were removed.
* Items are now formatted in an indented block.

Please see the updated tests to see what these changes look like.