### PR TITLE
Lazily generate group-by-item candidates for suggestions

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/group_by_item_resolver.py
@@ -92,6 +92,7 @@ class GroupByItemResolver:
         push_down_visitor = _PushDownGroupByItemCandidatesVisitor(
             manifest_lookup=self._manifest_lookup,
             source_spec_patterns=(spec_pattern, NoGroupByMetricPattern()),
+            group_by_item_resolver=self,
             suggestion_generator=suggestion_generator,
         )
 
@@ -163,6 +164,7 @@ class GroupByItemResolver:
         push_down_visitor = _PushDownGroupByItemCandidatesVisitor(
             manifest_lookup=self._manifest_lookup,
             source_spec_patterns=(spec_pattern,),
+            group_by_item_resolver=self,
             suggestion_generator=suggestion_generator,
             filter_location=filter_location,
         )
@@ -206,6 +208,7 @@ class GroupByItemResolver:
     def resolve_available_items(
         self,
         resolution_node: Optional[ResolutionDagSinkNode] = None,
+        source_spec_patterns: Sequence[SpecPattern] = (),
     ) -> AvailableGroupByItemsResolution:
         """Return all available group-by-items at a given node.
 
@@ -217,7 +220,8 @@ class GroupByItemResolver:
 
         push_down_visitor = _PushDownGroupByItemCandidatesVisitor(
             manifest_lookup=self._manifest_lookup,
-            source_spec_patterns=(),
+            source_spec_patterns=source_spec_patterns,
+            group_by_item_resolver=self,
             suggestion_generator=None,
         )
 

--- a/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
+++ b/metricflow-semantics/metricflow_semantics/query/suggestion_generator.py
@@ -41,16 +41,22 @@ class QueryItemSuggestionGenerator:
         self._input_str = input_str
         self._candidate_filters = candidate_filters
 
+    @property
+    def candidate_filters(self) -> Sequence[SpecPattern]:
+        """Return the filters that should be applied to the candidate specs when generating suggestions."""
+        return self._candidate_filters
+
     def input_suggestions(
         self,
         candidate_specs: Sequence[InstanceSpec],
         max_suggestions: int = 6,
     ) -> Sequence[str]:
         """Return the best specs that match the given pattern from candidate_specs and match the candidate_filer."""
+        # Use edit distance to figure out the closest matches, so convert the specs to strings.
+
         for candidate_filter in self._candidate_filters:
             candidate_specs = candidate_filter.match(candidate_specs)
 
-        # Use edit distance to figure out the closest matches, so convert the specs to strings.
         candidate_strs = set()
         for candidate_spec in candidate_specs:
             candidate_str = self._input_naming_scheme.input_str(candidate_spec)


### PR DESCRIPTION
When the user specifies an invalid group-by item, suggestions for alternatives are shown to the user. These can be generated lazily to improve performance when there are no errors.