### PR TITLE
Add `cprofile_output.bin` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 # IDE
 .idea/
 .vscode/
+
+# Performance profiler results.
+**/cprofile_output.bin


### PR DESCRIPTION
I've been using this filename for profiling, and putting this in `.gitignore` streamlines the git worflow.