### PR TITLE
Bug fix: custom granularity join column gets pruned

### DIFF
--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -122,6 +122,8 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             or select_column in node.group_bys
             or node.distinct
         )
+        # TODO: don't prune columns used in join condition! Tricky to derive since the join condition can be any
+        # SqlExpressionNode.
 
         if len(pruned_select_columns) == 0:
             raise RuntimeError("All columns have been pruned - this indicates an bug in the pruner or in the inputs.")

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATETIME_TRUNC(time_spine_src_28006.ds, day) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATETIME_TRUNC(time_spine_src_28006.ds, day) = subq_4.ds
 GROUP BY
   metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATETIME_TRUNC(bookings_source_src_28000.ds, day) = subq_0.ds
 ) subq_1
 GROUP BY
   booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATETIME_TRUNC(bookings_source_src_28000.ds, day) = subq_2.ds
 GROUP BY
   booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0.sql
@@ -428,7 +428,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_4
   ON
-    subq_0.metric_time__day = subq_4.ds
+    subq_3.metric_time__day = subq_4.ds
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_5
   ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_joined_to_non_default_grain__plan0_optimized.sql
@@ -13,7 +13,7 @@ CROSS JOIN
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_11
 ON
-  subq_7.metric_time__day = subq_11.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_11.ds
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_12
 ON

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0.sql
@@ -50,7 +50,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_1
   ON
-    subq_0.metric_time__day = subq_1.ds
+    subq_0.ds__day = subq_1.ds
 ) subq_2
 GROUP BY
   subq_2.metric_time__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.mf_time_spine time_spine_src_28006
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_4
 ON
-  subq_3.metric_time__day = subq_4.ds
+  DATE_TRUNC('day', time_spine_src_28006.ds) = subq_4.ds
 GROUP BY
   subq_4.martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0.sql
@@ -98,7 +98,7 @@ FROM (
   LEFT OUTER JOIN
     ***************************.mf_time_spine subq_0
   ON
-    bookings_source_src_28000.booking__ds__day = subq_0.ds
+    DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_0.ds
 ) subq_1
 GROUP BY
   subq_1.booking__ds__martian_day

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_no_metric_custom_granularity_non_metric_time__plan0_optimized.sql
@@ -7,6 +7,6 @@ FROM ***************************.fct_bookings bookings_source_src_28000
 LEFT OUTER JOIN
   ***************************.mf_time_spine subq_2
 ON
-  bookings_source_src_28000.booking__ds__day = subq_2.ds
+  DATE_TRUNC('day', bookings_source_src_28000.ds) = subq_2.ds
 GROUP BY
   subq_2.martian_day


### PR DESCRIPTION
We have an issue with the `SqlColumnPruner` where it might prune a column that's used in the join condition, if it's not used anywhere else. There isn't a simple way to fix that issue in the optimizer itself, since the join condition can contain any `SqlExpressionNode`, and this appears to only be relevant for the new custom granularity node. Thus, I've fixed this in the custom granularity node instead of the optimizer by rendering the column's expression in the join condition instead of its alias.