### PR TITLE
Improved source node logic for custom granularities

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
@@ -43,6 +43,17 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
     def time_dimension_specs_with_custom_grain(self) -> Tuple[TimeDimensionSpec, ...]:  # noqa: D102
         return tuple([spec for spec in self.time_dimension_specs if spec.time_granularity.is_custom_granularity])
 
+    def replace_custom_granularity_with_base_granularity(self) -> LinkableSpecSet:
+        """Return the same spec set, replacing any custom time granularity with its base granularity."""
+        return LinkableSpecSet(
+            dimension_specs=self.dimension_specs,
+            time_dimension_specs=tuple(
+                [time_dimension_spec.with_base_grain() for time_dimension_spec in self.time_dimension_specs]
+            ),
+            entity_specs=self.entity_specs,
+            group_by_metric_specs=self.group_by_metric_specs,
+        )
+
     def included_agg_time_dimension_specs_for_metric(
         self, metric_reference: MetricReference, metric_lookup: MetricLookup
     ) -> List[TimeDimensionSpec]:

--- a/metricflow/dataflow/builder/node_evaluator.py
+++ b/metricflow/dataflow/builder/node_evaluator.py
@@ -30,7 +30,6 @@ from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticM
 from metricflow_semantics.specs.entity_spec import LinklessEntitySpec
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.spec_set import group_specs_by_type
-from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.sql.sql_join_type import SqlJoinType
 
 from metricflow.dataflow.builder.node_data_set import DataflowPlanNodeOutputDataSetResolver
@@ -408,10 +407,6 @@ class NodeEvaluatorForLinkableInstances:
         logger.debug(LazyFormat(lambda: f"Candidate spec set is:\n{mf_pformat(candidate_spec_set)}"))
 
         data_set_linkable_specs = candidate_spec_set.linkable_specs
-        # Look for which nodes can satisfy the linkable specs at their base grains. Custom grains will be joined later.
-        required_linkable_specs_with_base_grains = [
-            spec.with_base_grain() if isinstance(spec, TimeDimensionSpec) else spec for spec in required_linkable_specs
-        ]
 
         # These are linkable specs in the start node data set. Those are considered "local".
         local_linkable_specs: List[LinkableInstanceSpec] = []
@@ -421,7 +416,7 @@ class NodeEvaluatorForLinkableInstances:
 
         # Group required_linkable_specs into local / un-joinable / or possibly joinable.
         unjoinable_linkable_specs = []
-        for required_linkable_spec in required_linkable_specs_with_base_grains:
+        for required_linkable_spec in required_linkable_specs:
             is_metric_time = required_linkable_spec.element_name == DataSet.metric_time_dimension_name()
             is_local = required_linkable_spec in data_set_linkable_specs
             is_unjoinable = (


### PR DESCRIPTION
Based on feedback in https://github.com/dbt-labs/metricflow/pull/1409, this PR makes some updates to the dataflow plan builder. These are only refactoring changes, there should be no behavioral changes. Changes include renaming some things and simplifying the code related to converting custom granularities to base granularities in source node resolution. Reviewing by commit is recommended - full details in commit descriptions.