### PR TITLE
Don't error for lack of time spines

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -76,12 +76,6 @@ class TimeSpineSource:
                     base_granularity=legacy_time_spine.grain,
                 )
 
-        # Sanity check: this should have been validated during manifest parsing.
-        if not time_spine_sources:
-            raise RuntimeError(
-                "At least one time spine must be configured to use the semantic layer, but none were found."
-            )
-
         return time_spine_sources
 
     @staticmethod


### PR DESCRIPTION
This gets called when parsing a manifest in mantle, and sometimes that manifest is empty. Don't error to allow for that case.