### PR TITLE
Add empty manifest check for `SavedQueryDependencyResolver`

### DIFF
--- a/metricflow-semantics/tests_metricflow_semantics/api/v0_1/test_saved_query_dependency_resolver.py
+++ b/metricflow-semantics/tests_metricflow_semantics/api/v0_1/test_saved_query_dependency_resolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from dbt_semantic_interfaces.implementations.project_configuration import PydanticProjectConfiguration
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
@@ -22,4 +23,15 @@ def test_saved_query_dependency_resolver(resolver: SavedQueryDependencyResolver)
     assert tuple(dependency_set.semantic_model_references) == (
         SemanticModelReference(semantic_model_name="bookings_source"),
         SemanticModelReference(semantic_model_name="listings_latest"),
+    )
+
+
+def test_empty_manifest() -> None:  # noqa: D103
+    """In case the manifest is empty, checks that the resolver can be created."""
+    SavedQueryDependencyResolver(
+        PydanticSemanticManifest(
+            semantic_models=[],
+            metrics=[],
+            project_configuration=PydanticProjectConfiguration(),
+        )
     )


### PR DESCRIPTION
There seems to be issues with initializing `MetricflowQueryParser` with an empty manifest. This is related to recent time spine changes, but resolving that might take some time, so putting out this PR as a temporary solution.