### PR TITLE
Use list for where filters

### DIFF
--- a/.changes/unreleased/Breaking Changes-20241007-142032.yaml
+++ b/.changes/unreleased/Breaking Changes-20241007-142032.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Changes MetricFlowQueryRequest.where_constraint to where_constraints and now accepts a list
+time: 2024-10-07T14:20:32.823935-04:00
+custom:
+    Author: WilliamDee,courtneyholcomb
+    Issue: "1431"

--- a/dbt-metricflow/dbt_metricflow/cli/main.py
+++ b/dbt-metricflow/dbt_metricflow/cli/main.py
@@ -281,7 +281,7 @@ def query(
         limit=limit,
         time_constraint_start=start_time,
         time_constraint_end=end_time,
-        where_constraint=where,
+        where_constraints=[where] if where else None,
         order_by_names=order,
     )
 

--- a/metricflow-semantics/metricflow_semantics/api/v0_1/saved_query_dependency_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/api/v0_1/saved_query_dependency_resolver.py
@@ -49,7 +49,7 @@ class SavedQueryDependencyResolver:
 
         parse_result = self._query_parser.parse_and_validate_saved_query(
             saved_query_parameter=SavedQueryParameter(saved_query_name),
-            where_filter=None,
+            where_filters=None,
             limit=None,
             time_constraint_start=None,
             time_constraint_end=None,

--- a/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
+++ b/metricflow-semantics/tests_metricflow_semantics/query/test_query_parser.py
@@ -328,7 +328,7 @@ def test_parse_and_validate_where_constraint_dims(
             group_by_names=[MTD],
             time_constraint_start=as_datetime("2020-01-15"),
             time_constraint_end=as_datetime("2020-02-15"),
-            where_constraint_str="{{ Dimension('booking__invalid_dim') }} = '1'",
+            where_constraint_strs=["{{ Dimension('booking__invalid_dim') }} = '1'"],
         )
 
     with pytest.raises(InvalidQueryException, match="Error parsing where filter"):
@@ -337,7 +337,7 @@ def test_parse_and_validate_where_constraint_dims(
             group_by_names=[MTD],
             time_constraint_start=as_datetime("2020-01-15"),
             time_constraint_end=as_datetime("2020-02-15"),
-            where_constraint_str="{{ Dimension('invalid_format') }} = '1'",
+            where_constraint_strs=["{{ Dimension('invalid_format') }} = '1'"],
         )
 
     result = bookings_query_parser.parse_and_validate_query(
@@ -345,7 +345,7 @@ def test_parse_and_validate_where_constraint_dims(
         group_by_names=[MTD],
         time_constraint_start=as_datetime("2020-01-15"),
         time_constraint_end=as_datetime("2020-02-15"),
-        where_constraint_str="{{ Dimension('booking__is_instant') }} = '1'",
+        where_constraint_strs=["{{ Dimension('booking__is_instant') }} = '1'"],
     )
     assert_object_snapshot_equal(request=request, mf_test_configuration=mf_test_configuration, obj=result)
     assert (
@@ -366,7 +366,7 @@ def test_parse_and_validate_where_constraint_metric_time(
         query_parser.parse_and_validate_query(
             metric_names=["revenue"],
             group_by_names=[MTD],
-            where_constraint_str="{{ TimeDimension('metric_time', 'day') }} > '2020-01-15'",
+            where_constraint_strs=["{{ TimeDimension('metric_time', 'day') }} > '2020-01-15'"],
         )
 
 
@@ -622,5 +622,5 @@ def test_invalid_group_by_metric(bookings_query_parser: MetricFlowQueryParser) -
     """Tests that a query for an invalid group by metric gives an appropriate group by metric suggestion."""
     with pytest.raises(InvalidQueryException, match="Metric\\('bookings', group_by=\\['listing'\\]\\)"):
         bookings_query_parser.parse_and_validate_query(
-            metric_names=("bookings",), where_constraint_str="{{ Metric('listings', ['garbage']) }} > 1"
+            metric_names=("bookings",), where_constraint_strs=["{{ Metric('listings', ['garbage']) }} > 1"]
         )

--- a/tests_metricflow/cli/test_cli.py
+++ b/tests_metricflow/cli/test_cli.py
@@ -176,7 +176,6 @@ def test_saved_query(  # noqa: D103
     resp = cli_runner.run(
         query, args=["--saved-query", "p0_booking", "--order", "metric_time__day,listing__capacity_latest"]
     )
-    print(resp.output)
 
     assert resp.exit_code == 0
 
@@ -294,5 +293,4 @@ def test_saved_query_with_cumulative_metric(  # noqa: D103
         snapshot_str=resp.output,
         sql_engine=sql_client.sql_engine_type,
     )
-    print(resp.output)
     assert resp.exit_code == 0

--- a/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
@@ -209,7 +209,7 @@ def test_simple_join_categorical_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -236,7 +236,7 @@ def test_simple_join_metric_time_pushdown_with_two_targets(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time') }} = '2024-01-01'"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time') }} = '2024-01-01'")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -260,7 +260,7 @@ def test_conversion_metric_predicate_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate_7days",),
         group_by_names=("metric_time", "user__home_state_latest"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('visit__referrer_id') }} = '123456'"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('visit__referrer_id') }} = '123456'")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -290,7 +290,7 @@ def test_cumulative_metric_predicate_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("every_two_days_bookers",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -314,7 +314,7 @@ def test_aggregate_output_join_metric_predicate_pushdown(
     """
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("views_times_booking_value",),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('listing__is_lux_latest') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('listing__is_lux_latest') }}")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -343,7 +343,7 @@ def test_offset_metric_predicate_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -371,7 +371,7 @@ def test_fill_nulls_time_spine_metric_predicate_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks_fill_nulls_with_0",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
     _check_optimization(
         request=request,
@@ -405,7 +405,7 @@ def test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks_fill_nulls_with_0",),
         group_by_names=("listing__country_latest", "booking__is_instant", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
     _check_optimization(
         request=request,

--- a/tests_metricflow/integration/query_output/test_cumulative_metrics.py
+++ b/tests_metricflow/integration/query_output/test_cumulative_metrics.py
@@ -144,7 +144,7 @@ def test_cumulative_metric_with_non_adjustable_filter(
             metric_names=["trailing_2_months_revenue"],
             group_by_names=["metric_time"],
             order_by_names=["metric_time"],
-            where_constraint=where_constraint,
+            where_constraints=[where_constraint],
             time_constraint_end=as_datetime("2020-12-31"),
         )
     )

--- a/tests_metricflow/integration/query_output/test_metric_filter_output.py
+++ b/tests_metricflow/integration/query_output/test_metric_filter_output.py
@@ -22,7 +22,7 @@ def test_query_with_simple_metric_in_where_filter(  # noqa: D103
             metric_names=["listings", "bookings"],
             group_by_names=["listing"],
             order_by_names=["listing"],
-            where_constraint="{{ Metric('bookings', ['listing']) }} > 3",
+            where_constraints=["{{ Metric('bookings', ['listing']) }} > 3"],
         )
     )
     assert query_result.result_df is not None, "Unexpected empty result."
@@ -48,7 +48,7 @@ def test_metric_with_metric_in_where_filter(  # noqa: D103
             metric_names=["active_listings", "bookings"],
             group_by_names=["listing"],
             order_by_names=["listing"],
-            where_constraint="{{ Metric('bookings', ['listing']) }} > 1",
+            where_constraints=["{{ Metric('bookings', ['listing']) }} > 1"],
         )
     )
     assert query_result.result_df is not None, "Unexpected empty result."

--- a/tests_metricflow/integration/test_configured_cases.py
+++ b/tests_metricflow/integration/test_configured_cases.py
@@ -280,7 +280,7 @@ def test_case(
             limit=case.limit,
             time_constraint_start=parser.parse(case.time_constraint[0]) if case.time_constraint else None,
             time_constraint_end=parser.parse(case.time_constraint[1]) if case.time_constraint else None,
-            where_constraint=(
+            where_constraints=[
                 jinja2.Template(
                     case.where_filter,
                     undefined=jinja2.StrictUndefined,
@@ -302,9 +302,9 @@ def test_case(
                     generate_random_uuid=check_query_helpers.generate_random_uuid,
                     cast_to_ts=check_query_helpers.cast_to_ts,
                 )
-                if case.where_filter
-                else None
-            ),
+            ]
+            if case.where_filter
+            else None,
             order_by_names=case.order_bys,
             min_max_only=case.min_max_only,
         )

--- a/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
+++ b/tests_metricflow/plan_conversion/dataflow_to_sql/test_distinct_values_to_sql.py
@@ -55,9 +55,11 @@ def test_dimension_values_with_a_join_and_a_filter(
     """Tests querying 2 dimensions that require a join and a filter."""
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("user__home_state_latest", "listing__is_lux_latest"),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('user__home_state_latest') }} = 'us'",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('user__home_state_latest') }} = 'us'",
+            )
+        ],
     ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -1224,7 +1224,7 @@ def test_dimension_with_joined_where_constraint(
     """Tests querying 2 dimensions that require a join."""
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("user__home_state_latest",),
-        where_constraint_str="{{ Dimension('listing__country_latest') }} = 'us'",
+        where_constraint_strs=["{{ Dimension('listing__country_latest') }} = 'us'"],
     ).query_spec
     dataflow_plan = dataflow_plan_builder.build_plan_for_distinct_values(query_spec)
 

--- a/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_conversion_metric_rendering.py
@@ -28,9 +28,9 @@ def test_conversion_metric(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate",),
         group_by_names=("metric_time",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'"))
+        ],
     )
 
     render_and_check(
@@ -57,9 +57,9 @@ def test_conversion_metric_with_window(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate_7days",),
         group_by_names=("metric_time",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'"))
+        ],
     )
 
     render_and_check(
@@ -86,9 +86,9 @@ def test_conversion_metric_with_categorical_filter(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate",),
         group_by_names=("metric_time", "visit__referrer_id"),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'"))
+        ],
     )
 
     render_and_check(
@@ -115,9 +115,9 @@ def test_conversion_metric_with_time_constraint(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate",),
         group_by_names=("visit__referrer_id",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'"))
+        ],
         time_constraint_start=datetime.datetime(2020, 1, 1),
         time_constraint_end=datetime.datetime(2020, 1, 2),
     )
@@ -149,9 +149,9 @@ def test_conversion_metric_with_window_and_time_constraint(
             "metric_time",
             "visit__referrer_id",
         ),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ Dimension('visit__referrer_id') }} = 'ref_id_01'"))
+        ],
         time_constraint_start=datetime.datetime(2020, 1, 1),
         time_constraint_end=datetime.datetime(2020, 1, 2),
     )

--- a/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_cumulative_metric_rendering.py
@@ -125,12 +125,14 @@ def test_cumulative_metric_with_non_adjustable_time_filter(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("every_two_days_bookers",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=(
-                "{{ TimeDimension('metric_time', 'day') }} = '2020-01-03' "
-                "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-07'"
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template=(
+                    "{{ TimeDimension('metric_time', 'day') }} = '2020-01-03' "
+                    "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-07'"
+                )
             )
-        ),
+        ],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/query_rendering/test_custom_granularity.py
+++ b/tests_metricflow/query_rendering/test_custom_granularity.py
@@ -284,9 +284,9 @@ def test_simple_metric_with_custom_granularity_filter(
     """Simple metric queried with a filter on a custom grain, where that grain is not used in the group by."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'martian_day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'martian_day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(
@@ -313,9 +313,9 @@ def test_simple_metric_with_custom_granularity_in_filter_and_group_by(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("metric_time__martian_day",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'martian_day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'martian_day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(
@@ -340,9 +340,9 @@ def test_no_metrics_with_custom_granularity_filter(
     """Group by items only queried with a filter on a custom grain, where that grain is not used in the group by."""
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("listing__ds__day",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('listing__ds', 'martian_day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('listing__ds', 'martian_day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(
@@ -367,9 +367,9 @@ def test_no_metrics_with_custom_granularity_in_filter_and_group_by(
     """Group by items only queried with a filter on a custom grain, where that grain is also used in the group by."""
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("listing__ds__martian_day",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('listing__ds', 'martian_day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('listing__ds', 'martian_day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/query_rendering/test_derived_metric_rendering.py
+++ b/tests_metricflow/query_rendering/test_derived_metric_rendering.py
@@ -111,12 +111,14 @@ def test_derived_metric_with_offset_window_and_time_filter(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=(
-                "{{ TimeDimension('metric_time', 'day') }} = '2020-01-01' "
-                "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-14'"
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template=(
+                    "{{ TimeDimension('metric_time', 'day') }} = '2020-01-01' "
+                    "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-14'"
+                )
             )
-        ),
+        ],
     ).query_spec
 
     render_and_check(
@@ -375,12 +377,14 @@ def test_nested_offsets_with_where_constraint(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_offset_twice",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=(
-                "{{ TimeDimension('metric_time', 'day') }} = '2020-01-12' "
-                "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-13'"
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template=(
+                    "{{ TimeDimension('metric_time', 'day') }} = '2020-01-12' "
+                    "or {{ TimeDimension('metric_time', 'day') }} = '2020-01-13'"
+                )
             )
-        ),
+        ],
     ).query_spec
 
     render_and_check(
@@ -514,7 +518,7 @@ def test_nested_derived_metric_offset_with_joined_where_constraint_not_selected(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_offset_twice",),
         group_by_names=(group_by_name,),
-        where_constraint_str="{{ Dimension('booking__is_instant') }}",
+        where_constraint_strs=["{{ Dimension('booking__is_instant') }}"],
     ).query_spec
 
     render_and_check(
@@ -749,9 +753,9 @@ def test_offset_window_metric_filter_and_query_have_different_granularities(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("booking_fees_last_week_per_booker_this_week",),
         group_by_names=("metric_time__month",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(
@@ -778,9 +782,9 @@ def test_offset_to_grain_metric_filter_and_query_have_different_granularities(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_at_start_of_month",),
         group_by_names=("metric_time__month",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'")
-        ),
+        where_constraints=[
+            PydanticWhereFilter(where_sql_template=("{{ TimeDimension('metric_time', 'day') }} = '2020-01-01'"))
+        ],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
+++ b/tests_metricflow/query_rendering/test_fill_nulls_with_rendering.py
@@ -197,9 +197,11 @@ def test_join_to_time_spine_with_filters(  # noqa: D103
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_fill_nulls_with_0",),
         group_by_names=("metric_time__day",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ TimeDimension('metric_time') }} > '2020-01-01'",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ TimeDimension('metric_time') }} > '2020-01-01'",
+            )
+        ],
         time_constraint_start=datetime.datetime(2020, 1, 3),
         time_constraint_end=datetime.datetime(2020, 1, 5),
     ).query_spec

--- a/tests_metricflow/query_rendering/test_metric_filter_rendering.py
+++ b/tests_metricflow/query_rendering/test_metric_filter_rendering.py
@@ -24,9 +24,11 @@ def test_query_with_simple_metric_in_where_filter(
     """Tests a query with a simple metric in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -76,9 +78,11 @@ def test_query_with_derived_metric_in_where_filter(
     """Tests a query with a derived metric in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('views_times_booking_value', ['listing']) }} > 1",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('views_times_booking_value', ['listing']) }} > 1",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -103,9 +107,11 @@ def test_query_with_ratio_metric_in_where_filter(
     """Tests a query with a ratio metric in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('bookings_per_booker', ['listing']) }} > 1",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('bookings_per_booker', ['listing']) }} > 1",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -133,9 +139,11 @@ def test_query_with_cumulative_metric_in_where_filter(
     """
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('revenue_all_time', ['user']) }} > 1",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('revenue_all_time', ['user']) }} > 1",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -160,9 +168,11 @@ def test_query_with_multiple_metrics_in_filter(
     """Tests a query with 2 simple metrics in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('bookings', ['listing']) }} > 2 AND {{ Metric('bookers', ['listing']) }} > 1",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('bookings', ['listing']) }} > 2 AND {{ Metric('bookers', ['listing']) }} > 1",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -187,9 +197,11 @@ def test_filter_by_metric_in_same_semantic_model_as_queried_metric(
     """Tests a query with a simple metric in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookers",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('booking_value', ['guest']) }} > 1.00",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('booking_value', ['guest']) }} > 1.00",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -214,9 +226,11 @@ def test_distinct_values_query_with_metric_filter(
     """Tests a distinct values query with a metric in the query-level where filter."""
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("listing",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('bookings', ['listing']) }} > 2",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -241,9 +255,11 @@ def test_metric_filtered_by_itself(
     """Tests a query for a metric that filters by the same metric."""
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookers",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('bookers', ['listing']) }} > 1.00",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('bookers', ['listing']) }} > 1.00",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -267,9 +283,11 @@ def test_group_by_has_local_entity_prefix(  # noqa: D103
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('average_booking_value', ['listing__user']) }} > 1",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('average_booking_value', ['listing__user']) }} > 1",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -293,9 +311,11 @@ def test_filter_with_conversion_metric(  # noqa: D103
 ) -> None:
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("listings",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('visit_buy_conversion_rate', ['user']) }} > 2",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('visit_buy_conversion_rate', ['user']) }} > 2",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -320,9 +340,11 @@ def test_inner_query_single_hop(
     """Tests rendering for a metric filter using a one-hop join in the inner query."""
     query_spec = multihop_query_parser.parse_and_validate_query(
         metric_names=("third_hop_count",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('paraguayan_customers', ['customer_id__customer_third_hop_id']) }} > 0",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('paraguayan_customers', ['customer_id__customer_third_hop_id']) }} > 0",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -347,9 +369,11 @@ def test_inner_query_multi_hop(
     """Tests rendering for a metric filter using a two-hop join in the inner query."""
     query_spec = multihop_query_parser.parse_and_validate_query(
         metric_names=("third_hop_count",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Metric('txn_count', ['account_id__customer_id__customer_third_hop_id']) }} > 2",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Metric('txn_count', ['account_id__customer_id__customer_third_hop_id']) }} > 2",
+            )
+        ],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
+++ b/tests_metricflow/query_rendering/test_predicate_pushdown_rendering.py
@@ -26,9 +26,11 @@ def test_single_categorical_dimension_pushdown(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('booking__is_instant') }}",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('booking__is_instant') }}",
+            )
+        ],
     )
 
     render_and_check(
@@ -54,9 +56,11 @@ def test_multiple_categorical_dimension_pushdown(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("listings",),
         group_by_names=("user__home_state_latest",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('listing__is_lux_latest') }} OR {{ Dimension('listing__capacity_latest') }} > 4",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('listing__is_lux_latest') }} OR {{ Dimension('listing__capacity_latest') }} > 4",
+            )
+        ],
     )
 
     render_and_check(
@@ -122,9 +126,11 @@ def test_skipped_pushdown(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('booking__is_instant') }} OR {{ Dimension('listing__is_lux_latest') }}",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('booking__is_instant') }} OR {{ Dimension('listing__is_lux_latest') }}",
+            )
+        ],
     )
 
     render_and_check(
@@ -155,7 +161,7 @@ def test_metric_time_filter_with_two_targets(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("listing__country_latest",),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time') }} = '2024-01-01'"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time') }} = '2024-01-01'")],
     )
 
     render_and_check(
@@ -181,7 +187,7 @@ def test_conversion_metric_query_filters(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("visit_buy_conversion_rate_7days",),
         group_by_names=("metric_time", "user__home_state_latest"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('visit__referrer_id') }} = '123456'"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('visit__referrer_id') }} = '123456'")],
     )
 
     render_and_check(
@@ -210,7 +216,7 @@ def test_cumulative_metric_with_query_time_filters(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("every_two_days_bookers",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     )
 
     render_and_check(
@@ -239,7 +245,7 @@ def test_offset_metric_with_query_time_filters(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     )
 
     render_and_check(
@@ -268,7 +274,7 @@ def test_fill_nulls_time_spine_metric_predicate_pushdown(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings_growth_2_weeks_fill_nulls_with_0",),
         group_by_names=("listing__country_latest", "metric_time"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     )
 
     render_and_check(
@@ -297,9 +303,11 @@ def test_simple_join_to_time_spine_pushdown_filter_application(
     parsed_query = query_parser.parse_and_validate_query(
         metric_names=("bookings_join_to_time_spine",),
         group_by_names=("booking__is_instant", "metric_time"),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('booking__is_instant') }}",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('booking__is_instant') }}",
+            )
+        ],
     )
 
     render_and_check(
@@ -327,7 +335,7 @@ def test_saved_query_with_metric_joins_and_filter(
     """
     parsed_query = query_parser.parse_and_validate_saved_query(
         saved_query_parameter=SavedQueryParameter("saved_query_with_metric_joins_and_filter"),
-        where_filter=None,
+        where_filters=None,
         limit=None,
         time_constraint_start=None,
         time_constraint_end=None,

--- a/tests_metricflow/query_rendering/test_query_rendering.py
+++ b/tests_metricflow/query_rendering/test_query_rendering.py
@@ -77,9 +77,11 @@ def test_filter_with_where_constraint_on_join_dim(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings",),
         group_by_names=("booking__is_instant",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
+            )
+        ],
     ).query_spec
 
     render_and_check(
@@ -165,9 +167,11 @@ def test_distinct_values(
     query_spec = query_parser.parse_and_validate_query(
         group_by_names=("listing__country_latest",),
         order_by_names=("-listing__country_latest",),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('listing__country_latest') }} = 'us'",
+            )
+        ],
         limit=100,
     ).query_spec
 
@@ -295,9 +299,11 @@ def test_join_to_scd_dimension(
     query_spec = scd_query_parser.parse_and_validate_query(
         metric_names=("family_bookings",),
         group_by_names=(METRIC_TIME_ELEMENT_NAME,),
-        where_constraint=PydanticWhereFilter(
-            where_sql_template="{{ Dimension('listing__capacity') }} > 2",
-        ),
+        where_constraints=[
+            PydanticWhereFilter(
+                where_sql_template="{{ Dimension('listing__capacity') }} > 2",
+            )
+        ],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
+++ b/tests_metricflow/query_rendering/test_time_spine_join_rendering.py
@@ -61,7 +61,7 @@ def test_simple_join_to_time_spine_with_filter(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_fill_nulls_with_0",),
         group_by_names=("metric_time__day",),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
 
     render_and_check(
@@ -87,7 +87,7 @@ def test_simple_join_to_time_spine_with_queried_filter(
     query_spec = query_parser.parse_and_validate_query(
         metric_names=("bookings_fill_nulls_with_0",),
         group_by_names=("metric_time__day", "booking__is_instant"),
-        where_constraint=PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}"),
+        where_constraints=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
     ).query_spec
 
     render_and_check(

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -386,7 +386,7 @@ FROM (
               subq_2.listing = subq_5.listing
           ) subq_6
         ) subq_7
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_8
     ) subq_9
     GROUP BY
@@ -698,7 +698,7 @@ FULL OUTER JOIN (
               subq_14.listing = subq_17.listing
           ) subq_18
         ) subq_19
-        WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+        WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
       ) subq_20
     ) subq_21
     GROUP BY
@@ -1100,7 +1100,7 @@ FULL OUTER JOIN (
                   subq_26.listing = subq_29.listing
               ) subq_30
             ) subq_31
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_32
         ) subq_33
         GROUP BY
@@ -1412,7 +1412,7 @@ FULL OUTER JOIN (
                   subq_38.listing = subq_41.listing
               ) subq_42
             ) subq_43
-            WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+            WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
           ) subq_44
         ) subq_45
         GROUP BY

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0_optimized.sql
@@ -35,7 +35,7 @@ FROM (
     ON
       subq_52.listing = listings_latest_src_28000.listing_id
   ) subq_57
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_61
@@ -70,7 +70,7 @@ FULL OUTER JOIN (
     ON
       subq_64.listing = listings_latest_src_28000.listing_id
   ) subq_69
-  WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+  WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
   GROUP BY
     listing__capacity_latest
 ) subq_73
@@ -113,7 +113,7 @@ FULL OUTER JOIN (
       ON
         subq_76.listing = listings_latest_src_28000.listing_id
     ) subq_81
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_85
@@ -148,7 +148,7 @@ FULL OUTER JOIN (
       ON
         subq_88.listing = listings_latest_src_28000.listing_id
     ) subq_93
-    WHERE ( listing__is_lux_latest ) AND ( metric_time__day >= '2020-01-02' )
+    WHERE (listing__is_lux_latest) AND (metric_time__day >= '2020-01-02')
     GROUP BY
       listing__capacity_latest
   ) subq_97


### PR DESCRIPTION
## Context

There's a bug where time filters is not being re-applied after joining to timespine. Currently, we take all filter strings in a list of filters and mash them together. We need to keep them separate so that we can differentiate metric_time filters.

Resolves SL-2955