### PR TITLE
Upgrade DSI

### DIFF
--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.7.2.dev0
+dbt-semantic-interfaces==0.7.2
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,4 +1,7 @@
-dbt-semantic-interfaces==0.7.2.dev0
+# Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
+# This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
+# which depends on a specific commit of DSI.
+dbt-semantic-interfaces>=0.7.2, <0.8.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0


### PR DESCRIPTION
Upgrade DSI in MF.
This is blocking mantle from release currently. I made a change to dbt-core on Friday to pin core to DSI 0.7.2. This went through without issue. But when trying to sync that change to mantle, we ran into a version conflict with metricflow-semantics (which is only a dependency in mantle, not core), since was pinned to a metricfllow commit SHA that uses a lower version of DSI. Here I am upgrading the dependency in metricflow-semantics to match DSI 0.7.2 at minimum, or any other higher version that is non-breaking. This will allow us to continue developing in core using new DSI versions without having to change the metricflow-semantics commit SHA in mantle every time.
Once this commit merges, I will need to make a change to mantle to point to this commit's SHA.

Note that the only change in the new version is adding new validations, which won't impact MF at all.