### PR TITLE
Don't drop parent attributes when joining to custom granularity

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -1499,6 +1499,11 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 from_source=parent_data_set.checked_sql_select_node.from_source,
                 from_source_alias=parent_alias,
                 join_descs=parent_data_set.checked_sql_select_node.join_descs + (join_description,),
+                where=parent_data_set.checked_sql_select_node.where,
+                group_bys=parent_data_set.checked_sql_select_node.group_bys,
+                order_bys=parent_data_set.checked_sql_select_node.order_bys,
+                limit=parent_data_set.checked_sql_select_node.limit,
+                distinct=parent_data_set.checked_sql_select_node.distinct,
             ),
         )
 


### PR DESCRIPTION
An oversight when building this SQL rendering logic - we were dropping some of the SQL select node attributes from the dataset when joining to time spine. This fixes that.
I'm not actually sure of what query scenario might have this attributes before the custom granularity join, so this is more of a "just in case" fix.