### PR TITLE
Reduce recursive-call overhead in `MetricTimeQueryValidationRule`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -67,6 +67,9 @@ class SemanticModelLookup:
         # Cache for defined time granularity.
         self._time_dimension_to_defined_time_granularity: Dict[TimeDimensionReference, TimeGranularity] = {}
 
+        # Cache for agg. time dimension for measure.
+        self._measure_reference_to_agg_time_dimension_specs: Dict[MeasureReference, Sequence[TimeDimensionSpec]] = {}
+
     def get_dimension_references(self) -> Sequence[DimensionReference]:
         """Retrieve all dimension references from the collection of semantic models."""
         return tuple(self._dimension_index.keys())
@@ -364,6 +367,17 @@ class SemanticModelLookup:
         self, measure_reference: MeasureReference
     ) -> Sequence[TimeDimensionSpec]:
         """Get the agg time dimension specs that can be used in place of metric time for this measure."""
+        result = self._measure_reference_to_agg_time_dimension_specs.get(measure_reference)
+        if result is not None:
+            return result
+
+        result = self._get_agg_time_dimension_specs_for_measure(measure_reference)
+        self._measure_reference_to_agg_time_dimension_specs[measure_reference] = result
+        return result
+
+    def _get_agg_time_dimension_specs_for_measure(
+        self, measure_reference: MeasureReference
+    ) -> Sequence[TimeDimensionSpec]:
         agg_time_dimension = self.get_agg_time_dimension_for_measure(measure_reference)
         # A measure's agg_time_dimension is required to be in the same semantic model as the measure,
         # so we can assume the same semantic model for both measure and dimension.

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/base_validation_rule.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/base_validation_rule.py
@@ -15,8 +15,11 @@ from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import Res
 class PostResolutionQueryValidationRule(ABC):
     """A validation rule that runs after all query inputs have been resolved to specs."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
+    def __init__(  # noqa: D107
+        self, manifest_lookup: SemanticManifestLookup, resolver_input_for_query: ResolverInputForQuery
+    ) -> None:
         self._manifest_lookup = manifest_lookup
+        self._resolver_input_for_query = resolver_input_for_query
 
     def _get_metric(self, metric_reference: MetricReference) -> Metric:
         return self._manifest_lookup.metric_lookup.get_metric(metric_reference)
@@ -25,7 +28,6 @@ class PostResolutionQueryValidationRule(ABC):
     def validate_metric_in_resolution_dag(
         self,
         metric_reference: MetricReference,
-        resolver_input_for_query: ResolverInputForQuery,
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         """Given a metric that exists in a resolution DAG, check that the query is valid.
@@ -39,7 +41,6 @@ class PostResolutionQueryValidationRule(ABC):
         self,
         metrics_in_query: Sequence[MetricReference],
         where_filter_intersection: WhereFilterIntersection,
-        resolver_input_for_query: ResolverInputForQuery,
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         """Validate the parameters to the query are valid.

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/duplicate_metric.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/duplicate_metric.py
@@ -7,11 +7,9 @@ from dbt_semantic_interfaces.protocols import WhereFilterIntersection
 from dbt_semantic_interfaces.references import MetricReference
 from typing_extensions import override
 
-from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
 from metricflow_semantics.query.issues.issues_base import MetricFlowQueryResolutionIssueSet
 from metricflow_semantics.query.issues.parsing.duplicate_metric import DuplicateMetricIssue
-from metricflow_semantics.query.resolver_inputs.query_resolver_inputs import ResolverInputForQuery
 from metricflow_semantics.query.validation_rules.base_validation_rule import PostResolutionQueryValidationRule
 
 logger = logging.getLogger(__name__)
@@ -20,14 +18,10 @@ logger = logging.getLogger(__name__)
 class DuplicateMetricValidationRule(PostResolutionQueryValidationRule):
     """Validates that a query does not include the same metric multiple times."""
 
-    def __init__(self, manifest_lookup: SemanticManifestLookup) -> None:  # noqa: D107
-        super().__init__(manifest_lookup=manifest_lookup)
-
     @override
     def validate_metric_in_resolution_dag(
         self,
         metric_reference: MetricReference,
-        resolver_input_for_query: ResolverInputForQuery,
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         return MetricFlowQueryResolutionIssueSet.empty_instance()
@@ -37,7 +31,6 @@ class DuplicateMetricValidationRule(PostResolutionQueryValidationRule):
         self,
         metrics_in_query: Sequence[MetricReference],
         where_filter_intersection: WhereFilterIntersection,
-        resolver_input_for_query: ResolverInputForQuery,
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         duplicate_metric_references = tuple(


### PR DESCRIPTION
The check in `MetricTimeQueryValidationRule` is called for every metric in a derived metric's ancestors, so this moves expensive parts of the check to only where it's needed and caches results when possible to reduce runtimes. The signature for the validation rule classes were changed, so there are a number of diff lines related to that.