### PR TITLE
Consolidate property filters into a class

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/element_filter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import FrozenSet
+
+from typing_extensions import Self, override
+
+from metricflow_semantics.collection_helpers.merger import Mergeable
+from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+
+
+@dataclass(frozen=True)
+class LinkableElementFilter(Mergeable):
+    """Describes a way to filter the `LinkableElements` in a `LinkableElementSet`."""
+
+    with_any_of: FrozenSet[LinkableElementProperty] = LinkableElementProperty.all_properties()
+    without_any_of: FrozenSet[LinkableElementProperty] = frozenset()
+    without_all_of: FrozenSet[LinkableElementProperty] = frozenset()
+
+    @override
+    def merge(self: Self, other: LinkableElementFilter) -> LinkableElementFilter:
+        return LinkableElementFilter(
+            with_any_of=self.with_any_of.union(other.with_any_of),
+            without_any_of=self.without_any_of.union(other.without_any_of),
+            without_all_of=self.without_all_of.union(other.without_all_of),
+        )
+
+    @classmethod
+    @override
+    def empty_instance(cls) -> LinkableElementFilter:
+        return LinkableElementFilter()

--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_element_set.py
@@ -5,15 +5,15 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Dict, FrozenSet, List, Sequence, Set, Tuple
+from typing import Dict, List, Sequence, Set, Tuple
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.references import SemanticModelReference
 from typing_extensions import override
 
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
-from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantic_model_derivation import SemanticModelDerivation
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element import (
     ElementPathKey,
     LinkableDimension,
@@ -221,9 +221,7 @@ class LinkableElementSet(SemanticModelDerivation):
 
     def filter(
         self,
-        with_any_of: FrozenSet[LinkableElementProperty],
-        without_any_of: FrozenSet[LinkableElementProperty] = frozenset(),
-        without_all_of: FrozenSet[LinkableElementProperty] = frozenset(),
+        element_filter: LinkableElementFilter,
     ) -> LinkableElementSet:
         """Filter elements in the set.
 
@@ -231,6 +229,10 @@ class LinkableElementSet(SemanticModelDerivation):
         a property in "without_any_of" set are removed. Lastly, any elements with all properties in without_all_of
         are removed.
         """
+        with_any_of = element_filter.with_any_of
+        without_any_of = element_filter.without_any_of
+        without_all_of = element_filter.without_all_of
+
         key_to_linkable_dimensions: Dict[ElementPathKey, Tuple[LinkableDimension, ...]] = {}
         key_to_linkable_entities: Dict[ElementPathKey, Tuple[LinkableEntity, ...]] = {}
         key_to_linkable_metrics: Dict[ElementPathKey, Tuple[LinkableMetric, ...]] = {}

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/candidate_push_down/push_down_visitor.py
@@ -17,6 +17,7 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.mf_logging.pretty_print import mf_pformat, mf_pformat_many
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.query.group_by_item.candidate_push_down.group_by_item_candidate import GroupByItemCandidateSet
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import (
     WhereFilterLocation,
@@ -187,8 +188,10 @@ class _PushDownGroupByItemCandidatesVisitor(GroupByItemResolutionNodeVisitor[Pus
 
             items_available_for_measure = self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_measure(
                 measure_reference=node.measure_reference,
-                with_any_of=self._with_any_property,
-                without_any_of=frozenset(without_any_property),
+                element_filter=LinkableElementFilter(
+                    with_any_of=self._with_any_property or LinkableElementProperty.all_properties(),
+                    without_any_of=frozenset(without_any_property),
+                ),
             )
 
             # The following is needed to handle limitation of cumulative metrics. Filtering could be done at the measure

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_element_set.py
@@ -22,6 +22,7 @@ from dbt_semantic_interfaces.references import (
 )
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element import (
     ElementPathKey,
     LinkableDimension,
@@ -265,7 +266,7 @@ def test_filter_with_any_of() -> None:
     filter_properties = frozenset([LinkableElementProperty.JOINED, LinkableElementProperty.ENTITY])
     linkable_set = _linkable_set_with_uniques_and_duplicates()
 
-    filtered_set = linkable_set.filter(with_any_of=filter_properties)
+    filtered_set = linkable_set.filter(LinkableElementFilter(with_any_of=filter_properties))
 
     filtered_dimensions = [
         dim for dim in itertools.chain.from_iterable(filtered_set.path_key_to_linkable_dimensions.values())
@@ -304,7 +305,9 @@ def test_filter_without_any_of() -> None:
     without_any_of_properties = frozenset([LinkableElementProperty.ENTITY, LinkableElementProperty.METRIC])
     linkable_set = _linkable_set_with_uniques_and_duplicates()
 
-    filtered_set = linkable_set.filter(with_any_of=with_any_of_properties, without_any_of=without_any_of_properties)
+    filtered_set = linkable_set.filter(
+        LinkableElementFilter(with_any_of=with_any_of_properties, without_any_of=without_any_of_properties)
+    )
 
     filtered_dimensions = [
         dim for dim in itertools.chain.from_iterable(filtered_set.path_key_to_linkable_dimensions.values())
@@ -340,7 +343,9 @@ def test_filter_without_all_of() -> None:
     without_all_of_properties = frozenset([LinkableElementProperty.JOINED, LinkableElementProperty.ENTITY])
     linkable_set = _linkable_set_with_uniques_and_duplicates()
 
-    filtered_set = linkable_set.filter(with_any_of=with_any_of_properties, without_all_of=without_all_of_properties)
+    filtered_set = linkable_set.filter(
+        LinkableElementFilter(with_any_of=with_any_of_properties, without_all_of=without_all_of_properties)
+    )
 
     filtered_metrics = [
         metric for metric in itertools.chain.from_iterable(filtered_set.path_key_to_linkable_metrics.values())

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_spec_resolver.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_linkable_spec_resolver.py
@@ -12,6 +12,7 @@ from dbt_semantic_interfaces.references import (
 )
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element import SemanticModelJoinPath, SemanticModelJoinPathElement
 from metricflow_semantics.model.semantics.linkable_spec_resolver import ValidLinkableSpecResolver
 from metricflow_semantics.model.semantics.semantic_model_join_evaluator import MAX_JOIN_HOPS
@@ -58,8 +59,9 @@ def test_all_properties(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
-            with_any_of=LinkableElementProperty.all_properties(),
-            without_any_of=frozenset({}),
+            element_filter=LinkableElementFilter(
+                with_any_of=LinkableElementProperty.all_properties(), without_any_of=frozenset()
+            ),
         ),
     )
 
@@ -75,8 +77,9 @@ def test_one_property(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings"), MetricReference(element_name="views")],
-            with_any_of=frozenset({LinkableElementProperty.LOCAL}),
-            without_any_of=frozenset(),
+            element_filter=LinkableElementFilter(
+                with_any_of=frozenset({LinkableElementProperty.LOCAL}), without_any_of=frozenset()
+            ),
         ),
     )
 
@@ -92,8 +95,9 @@ def test_metric_time_property_for_cumulative_metric(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="trailing_2_months_revenue")],
-            with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}),
-            without_any_of=frozenset(),
+            element_filter=LinkableElementFilter(
+                with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}), without_any_of=frozenset()
+            ),
         ),
     )
 
@@ -109,8 +113,9 @@ def test_metric_time_property_for_derived_metrics(  # noqa: D103
         set_id="result0",
         linkable_element_set=simple_model_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="bookings_per_view")],
-            with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}),
-            without_any_of=frozenset(),
+            element_filter=LinkableElementFilter(
+                with_any_of=frozenset({LinkableElementProperty.METRIC_TIME}), without_any_of=frozenset()
+            ),
         ),
     )
 
@@ -126,8 +131,10 @@ def test_cyclic_join_manifest(  # noqa: D103
         set_id="result0",
         linkable_element_set=cyclic_join_manifest_spec_resolver.get_linkable_elements_for_metrics(
             metric_references=[MetricReference(element_name="listings")],
-            with_any_of=LinkableElementProperty.all_properties(),
-            without_any_of=frozenset(),
+            element_filter=LinkableElementFilter(
+                with_any_of=LinkableElementProperty.all_properties(),
+                without_any_of=frozenset(),
+            ),
         ),
     )
 
@@ -192,8 +199,10 @@ def test_linkable_element_set_as_spec_set(
     linkable_spec_set = InstanceSpecSet.create_from_specs(
         simple_model_spec_resolver.get_linkable_element_set_for_measure(
             MeasureReference(element_name="listings"),
-            with_any_of=LinkableElementProperty.all_properties(),
-            without_any_of=frozenset({}),
+            element_filter=LinkableElementFilter(
+                with_any_of=LinkableElementProperty.all_properties(),
+                without_any_of=frozenset(),
+            ),
         ).specs
     )
     assert_spec_set_snapshot_equal(

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_semantic_model_container.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_semantic_model_container.py
@@ -7,6 +7,7 @@ from _pytest.fixtures import FixtureRequest
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import EntityReference, MeasureReference, MetricReference
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.metric_lookup import MetricLookup
 from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
@@ -103,8 +104,10 @@ def test_local_linked_elements_for_metric(  # noqa: D103
 ) -> None:
     linkable_elements = metric_lookup.linkable_elements_for_metrics(
         (MetricReference(element_name="listings"),),
-        with_any_property=frozenset({LinkableElementProperty.LOCAL_LINKED}),
-        without_any_property=frozenset({LinkableElementProperty.DERIVED_TIME_GRANULARITY}),
+        LinkableElementFilter(
+            with_any_of=frozenset({LinkableElementProperty.LOCAL_LINKED}),
+            without_any_of=frozenset({LinkableElementProperty.DERIVED_TIME_GRANULARITY}),
+        ),
     )
     sorted_specs = sorted(linkable_elements.specs, key=lambda x: x.qualified_name)
     assert_object_snapshot_equal(
@@ -130,11 +133,13 @@ def test_linkable_elements_for_metrics(  # noqa: D103
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_elements_for_metrics(
             (MetricReference(element_name="views"),),
-            without_any_property=frozenset(
-                {
-                    LinkableElementProperty.DERIVED_TIME_GRANULARITY,
-                    LinkableElementProperty.METRIC_TIME,
-                }
+            LinkableElementFilter(
+                without_any_of=frozenset(
+                    {
+                        LinkableElementProperty.DERIVED_TIME_GRANULARITY,
+                        LinkableElementProperty.METRIC_TIME,
+                    }
+                )
             ),
         ),
     )
@@ -179,7 +184,7 @@ def test_linkable_elements_for_no_metrics_query(
 ) -> None:
     """Tests extracting linkable elements for a dimension values query with no metrics."""
     linkable_elements = metric_lookup.linkable_elements_for_no_metrics_query(
-        without_any_of=frozenset({LinkableElementProperty.DERIVED_TIME_GRANULARITY})
+        LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.DERIVED_TIME_GRANULARITY}))
     )
     sorted_specs = sorted(linkable_elements.specs, key=lambda x: x.qualified_name)
     assert_object_snapshot_equal(
@@ -203,10 +208,12 @@ def test_linkable_set_for_common_dimensions_in_different_models(
         set_id="result0",
         linkable_element_set=metric_lookup.linkable_elements_for_metrics(
             (MetricReference(element_name="bookings_per_view"),),
-            without_any_property=frozenset(
-                {
-                    LinkableElementProperty.DERIVED_TIME_GRANULARITY,
-                }
+            LinkableElementFilter(
+                without_any_of=frozenset(
+                    {
+                        LinkableElementProperty.DERIVED_TIME_GRANULARITY,
+                    }
+                ),
             ),
         ),
     )

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -18,6 +18,7 @@ from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.mf_logging.runtime import log_block_runtime
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element import LinkableDimension
 from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
@@ -585,7 +586,9 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         path_key_to_linkable_dimensions = (
             self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
                 metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-                without_any_property=frozenset(without_any_property),
+                element_set_filter=LinkableElementFilter(
+                    without_any_of=frozenset(without_any_property),
+                ),
             )
         ).path_key_to_linkable_dimensions
 
@@ -677,10 +680,12 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
         path_key_to_linkable_entities = (
             self._semantic_manifest_lookup.metric_lookup.linkable_elements_for_metrics(
                 metric_references=tuple(MetricReference(element_name=mname) for mname in metric_names),
-                with_any_property=frozenset(
-                    {
-                        LinkableElementProperty.ENTITY,
-                    }
+                element_set_filter=LinkableElementFilter(
+                    with_any_of=frozenset(
+                        {
+                            LinkableElementProperty.ENTITY,
+                        }
+                    ),
                 ),
             )
         ).path_key_to_linkable_entities


### PR DESCRIPTION
The signature of a few functions in `ValidLinkableSpecResolver` take in a few arguments that describe how to filter the returned items based on properties. To simplify the signatures and enable improved caching in a later PR, this PR groups them into the `LinkableElementFilter` class.