### PR TITLE
Update patterns to use `LinkableElementFilter`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/entity_link_pattern.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, FrozenSet, List, Optional, Sequence, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
@@ -11,6 +11,7 @@ from more_itertools import is_sorted
 from typing_extensions import override
 
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 from metricflow_semantics.specs.spec_set import group_specs_by_type
@@ -152,10 +153,11 @@ class EntityLinkPattern(SpecPattern):
 
     @property
     @override
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
+    def element_pre_filter(self) -> LinkableElementFilter:
         if (
             self.parameter_set.metric_subquery_entity_links is None
             or len(self.parameter_set.metric_subquery_entity_links) == 0
         ):
-            return frozenset({LinkableElementProperty.METRIC})
-        return frozenset()
+            return LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.METRIC}))
+
+        return LinkableElementFilter()

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/no_group_by_metric.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet, List, Sequence
+from typing import List, Sequence
 
 from typing_extensions import override
 
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.spec_pattern import SpecPattern
 from metricflow_semantics.specs.spec_set import group_specs_by_type
@@ -30,5 +31,5 @@ class NoGroupByMetricPattern(SpecPattern):
 
     @property
     @override
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
-        return frozenset({LinkableElementProperty.METRIC})
+    def element_pre_filter(self) -> LinkableElementFilter:
+        return LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.METRIC}))

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/spec_pattern.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/spec_pattern.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, FrozenSet, Sequence
+from typing import TYPE_CHECKING, Sequence
 
-from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 
 if TYPE_CHECKING:
     from metricflow_semantics.specs.instance_spec import InstanceSpec
@@ -25,6 +25,9 @@ class SpecPattern(ABC):
         return len(self.match(candidate_specs)) > 0
 
     @property
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
-        """Returns the set of properties of linkable elements that this won't match."""
-        return frozenset()
+    def element_pre_filter(self) -> LinkableElementFilter:
+        """Returns a filter for a `LinkableElementSet` that can reduce the number of items to match.
+
+        i.e. the filter can produce a superset of the elements that will match.
+        """
+        return LinkableElementFilter()

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import FrozenSet, List, Sequence
+from typing import List, Sequence
 
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
@@ -13,6 +13,7 @@ from dbt_semantic_interfaces.references import EntityReference
 from typing_extensions import override
 
 from metricflow_semantics.model.linkable_element_property import LinkableElementProperty
+from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.specs.instance_spec import InstanceSpec, LinkableInstanceSpec
 from metricflow_semantics.specs.patterns.entity_link_pattern import (
@@ -53,8 +54,8 @@ class DimensionPattern(EntityLinkPattern):
 
     @property
     @override
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
-        return frozenset({LinkableElementProperty.METRIC})
+    def element_pre_filter(self) -> LinkableElementFilter:
+        return LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.METRIC}))
 
 
 @dataclass(frozen=True)
@@ -99,8 +100,8 @@ class TimeDimensionPattern(EntityLinkPattern):
 
     @property
     @override
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
-        return frozenset({LinkableElementProperty.METRIC})
+    def element_pre_filter(self) -> LinkableElementFilter:
+        return LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.METRIC}))
 
 
 @dataclass(frozen=True)
@@ -130,8 +131,8 @@ class EntityPattern(EntityLinkPattern):
 
     @property
     @override
-    def without_linkable_element_properties(self) -> FrozenSet[LinkableElementProperty]:
-        return frozenset({LinkableElementProperty.METRIC})
+    def element_pre_filter(self) -> LinkableElementFilter:
+        return LinkableElementFilter(without_any_of=frozenset({LinkableElementProperty.METRIC}))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Now that `LinkableElementFilter` is available, this PR updates `SpecPattern` to return a filter instead of a set of properties.