### PR TITLE
Update more log calls to be lazy

### DIFF
--- a/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
+++ b/metricflow/dataflow/optimizer/source_scan/cm_branch_combiner.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.specs.metric_spec import MetricSpec
 
 from metricflow.dataflow.dataflow_plan import (
@@ -129,10 +130,9 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
 
     def __init__(self, left_branch_node: DataflowPlanNode) -> None:  # noqa: D107
         self._current_left_node: DataflowPlanNode = left_branch_node
-        self._log_level = logging.DEBUG
 
     def _log_visit_node_type(self, node: DataflowPlanNode) -> None:
-        logger.log(level=self._log_level, msg=f"Visiting {node}")
+        logger.debug(LazyFormat(lambda: f"Visiting {node}"))
 
     def _log_combine_failure(
         self,
@@ -140,10 +140,11 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         right_node: DataflowPlanNode,
         combine_failure_reason: str,
     ) -> None:
-        logger.log(
-            level=self._log_level,
-            msg=f"Because {combine_failure_reason}, unable to combine nodes "
-            f"left_node={left_node} right_node={right_node}",
+        logger.debug(
+            LazyFormat(
+                lambda: f"Because {combine_failure_reason}, unable to combine nodes "
+                f"left_node={left_node} right_node={right_node}",
+            )
         )
 
     def _log_combine_success(
@@ -152,9 +153,8 @@ class ComputeMetricsBranchCombiner(DataflowPlanNodeVisitor[ComputeMetricsBranchC
         right_node: DataflowPlanNode,
         combined_node: DataflowPlanNode,
     ) -> None:
-        logger.log(
-            level=self._log_level,
-            msg=f"Combined left_node={left_node} right_node={right_node} combined_node: {combined_node}",
+        logger.debug(
+            LazyFormat(lambda: f"Combined left_node={left_node} right_node={right_node} combined_node: {combined_node}")
         )
 
     def _combine_parent_branches(self, current_right_node: DataflowPlanNode) -> Optional[Sequence[DataflowPlanNode]]:

--- a/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
+++ b/metricflow/dataflow/optimizer/source_scan/source_scan_optimizer.py
@@ -111,7 +111,7 @@ class SourceScanOptimizer(
     """
 
     def _log_visit_node_type(self, node: DataflowPlanNode) -> None:
-        logger.debug(LazyFormat(lambda: "Visiting {node}"))
+        logger.debug(LazyFormat(lambda: f"Visiting {node}"))
 
     def _default_base_output_handler(
         self,

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -495,7 +495,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 order_by=mf_query_request.order_by,
                 min_max_only=mf_query_request.min_max_only,
             ).query_spec
-        logger.info(LazyFormat("Parsed query", query_spec=query_spec))
+        logger.debug(LazyFormat("Parsed query", query_spec=query_spec))
 
         output_selection_specs: Optional[InstanceSpecSet] = None
         if mf_query_request.query_type == MetricFlowQueryType.DIMENSION_VALUES:

--- a/metricflow/telemetry/handlers/python_log.py
+++ b/metricflow/telemetry/handlers/python_log.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-import textwrap
 
-from metricflow_semantics.mf_logging.pretty_print import mf_pformat
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 
 from metricflow.telemetry.handlers.handlers import PayloadType, TelemetryHandler
 
@@ -17,7 +16,4 @@ class PythonLoggerTelemetryHandler(TelemetryHandler):
         self._logger_level = logger_level
 
     def _write_log(self, client_id: str, payload: PayloadType) -> None:
-        logger.log(
-            level=self._logger_level,
-            msg=f"Logging telemetry payload:\n{textwrap.indent(mf_pformat(payload), prefix='    ')}",
-        )
+        logger.log(level=self._logger_level, msg=LazyFormat("Logging telemetry payload", payload=payload))

--- a/metricflow/telemetry/reporter.py
+++ b/metricflow/telemetry/reporter.py
@@ -62,7 +62,7 @@ class TelemetryReporter:
         return sha256(id_str.encode("utf-8")).hexdigest()
 
     def add_python_log_handler(self) -> None:  # noqa: D102
-        self._handlers.append(PythonLoggerTelemetryHandler(logger_level=logging.INFO))
+        self._handlers.append(PythonLoggerTelemetryHandler(logger_level=logging.DEBUG))
 
     def add_test_handler(self) -> None:
         """See test_handler."""


### PR DESCRIPTION
This PR updates a few more log calls to use `LazyFormat`. These were previously missed due to a different signature used for logging.