### PR TITLE
Remove unneeded group bys from time spine dataset

### DIFF
--- a/.changes/unreleased/Fixes-20241009-174346.yaml
+++ b/.changes/unreleased/Fixes-20241009-174346.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Remove unnecessary group bys that make queries less efficient.
+time: 2024-10-09T17:43:46.011252-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "1453"

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week
               , DATETIME_TRUNC(subq_3.ds, quarter) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              metric_time__day
-              , metric_time__week
-              , metric_time__quarter
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,27 +21,16 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATETIME_TRUNC(subq_12.ds, isoweek) AS metric_time__week
+      , DATETIME_TRUNC(subq_12.ds, quarter) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATETIME_TRUNC(ds, isoweek) AS metric_time__week
-        , DATETIME_TRUNC(ds, quarter) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        metric_time__day
-        , metric_time__week
-        , metric_time__quarter
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_11.metric_time__day
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.ds
       )
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          revenue_instance__ds__month
-          , metric_time__day
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,26 +3,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATETIME_TRUNC(subq_10.ds, month) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATETIME_TRUNC(ds, month) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    revenue_instance__ds__month
-    , metric_time__day
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.metric_time__day
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_10.ds
   ) AND (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 month)
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_10.ds AS DATETIME), INTERVAL 2 month)
   )
 GROUP BY
   revenue_instance__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATETIME_TRUNC(subq_3.ds, month) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          revenue_instance__ds__day
-          , revenue_instance__ds__month
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,26 +3,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATETIME_TRUNC(subq_10.ds, month) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATETIME_TRUNC(ds, month) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    revenue_instance__ds__day
-    , revenue_instance__ds__month
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.revenue_instance__ds__day
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_10.ds
   ) AND (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.revenue_instance__ds__day AS DATETIME), INTERVAL 2 month)
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_10.ds AS DATETIME), INTERVAL 2 month)
   )
 GROUP BY
   revenue_instance__ds__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          metric_time__day
-          , metric_time__month
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,26 +3,17 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATETIME_TRUNC(subq_10.ds, month) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATETIME_TRUNC(ds, month) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    metric_time__day
-    , metric_time__month
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_9.metric_time__day
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_10.ds
   ) AND (
-    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_9.metric_time__day AS DATETIME), INTERVAL 2 month)
+    DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_10.ds AS DATETIME), INTERVAL 2 month)
   )
 GROUP BY
   metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              metric_time__day
-              , metric_time__week
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,24 +17,15 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATETIME_TRUNC(subq_12.ds, isoweek) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATETIME_TRUNC(ds, isoweek) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        metric_time__day
-        , metric_time__week
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_11.metric_time__day
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.ds
       )
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                metric_time__day
-                , metric_time__week
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,26 +18,17 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATETIME_TRUNC(subq_13.ds, isoweek) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATETIME_TRUNC(ds, isoweek) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          metric_time__day
-          , metric_time__week
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.metric_time__day
+          DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_13.ds
         ) AND (
-          DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_12.metric_time__day AS DATETIME), INTERVAL 2 month)
+          DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_13.ds AS DATETIME), INTERVAL 2 month)
         )
       GROUP BY
         metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, month) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              metric_time__day
-              , metric_time__month
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,26 +17,17 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATETIME_TRUNC(subq_12.ds, month) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATETIME_TRUNC(ds, month) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        metric_time__day
-        , metric_time__month
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_11.metric_time__day
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.ds
       ) AND (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) >= DATETIME_TRUNC(subq_11.metric_time__day, month)
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) >= DATETIME_TRUNC(subq_12.ds, month)
       )
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATETIME_TRUNC(subq_3.ds, year) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              revenue_instance__ds__quarter
-              , revenue_instance__ds__year
-              , metric_time__day
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,29 +21,18 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATETIME_TRUNC(subq_12.ds, quarter) AS revenue_instance__ds__quarter
+      , DATETIME_TRUNC(subq_12.ds, year) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATETIME_TRUNC(ds, quarter) AS revenue_instance__ds__quarter
-        , DATETIME_TRUNC(ds, year) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        revenue_instance__ds__quarter
-        , revenue_instance__ds__year
-        , metric_time__day
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_11.metric_time__day
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.ds
       ) AND (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) >= DATETIME_TRUNC(subq_11.metric_time__day, month)
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) >= DATETIME_TRUNC(subq_12.ds, month)
       )
     GROUP BY
       revenue_instance__ds__quarter

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATETIME_TRUNC(subq_3.ds, year) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              metric_time__day
-              , metric_time__year
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,26 +13,17 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATETIME_TRUNC(subq_12.ds, year) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATETIME_TRUNC(ds, year) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        metric_time__day
-        , metric_time__year
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_11.metric_time__day
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) <= subq_12.ds
       ) AND (
-        DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_11.metric_time__day AS DATETIME), INTERVAL 2 month)
+        DATETIME_TRUNC(revenue_src_28000.created_at, day) > DATE_SUB(CAST(subq_12.ds AS DATETIME), INTERVAL 2 month)
       )
     GROUP BY
       metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATETIME_TRUNC(subq_3.ds, isoweek) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                booking__ds__month
-                , metric_time__day
-                , metric_time__week
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/BigQuery/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,29 +29,18 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATETIME_TRUNC(subq_15.ds, month) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATETIME_TRUNC(subq_15.ds, isoweek) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATETIME_TRUNC(ds, month) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATETIME_TRUNC(ds, isoweek) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          booking__ds__month
-          , metric_time__day
-          , metric_time__week
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATETIME_TRUNC(bookings_source_src_28000.ds, day) <= subq_14.metric_time__day
+          DATETIME_TRUNC(bookings_source_src_28000.ds, day) <= subq_15.ds
         ) AND (
-          DATETIME_TRUNC(bookings_source_src_28000.ds, day) > DATE_SUB(CAST(subq_14.metric_time__day AS DATETIME), INTERVAL 2 day)
+          DATETIME_TRUNC(bookings_source_src_28000.ds, day) > DATE_SUB(CAST(subq_15.ds AS DATETIME), INTERVAL 2 day)
         )
       GROUP BY
         booking__ds__month

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.metric_time__day)
+          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_13.ds)
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Databricks/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_14.metric_time__day)
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_15.ds)
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.revenue_instance__ds__day - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - INTERVAL 2 month
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - INTERVAL 2 month
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > subq_12.metric_time__day - INTERVAL 2 month
+          DATE_TRUNC('day', revenue_src_28000.created_at) > subq_13.ds - INTERVAL 2 month
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > subq_11.metric_time__day - INTERVAL 2 month
+        DATE_TRUNC('day', revenue_src_28000.created_at) > subq_12.ds - INTERVAL 2 month
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/DuckDB/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_14.metric_time__day - INTERVAL 2 day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_15.ds - INTERVAL 2 day
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - MAKE_INTERVAL(months => 2)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - MAKE_INTERVAL(months => 2)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.revenue_instance__ds__day - MAKE_INTERVAL(months => 2)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - MAKE_INTERVAL(months => 2)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_9.metric_time__day - MAKE_INTERVAL(months => 2)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > subq_10.ds - MAKE_INTERVAL(months => 2)
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > subq_12.metric_time__day - MAKE_INTERVAL(months => 2)
+          DATE_TRUNC('day', revenue_src_28000.created_at) > subq_13.ds - MAKE_INTERVAL(months => 2)
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > subq_11.metric_time__day - MAKE_INTERVAL(months => 2)
+        DATE_TRUNC('day', revenue_src_28000.created_at) > subq_12.ds - MAKE_INTERVAL(months => 2)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Postgres/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_14.metric_time__day - MAKE_INTERVAL(days => 2)
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > subq_15.ds - MAKE_INTERVAL(days => 2)
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.metric_time__day)
+          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_13.ds)
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Redshift/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_14.metric_time__day)
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_15.ds)
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.revenue_instance__ds__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.metric_time__day)
+          DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_13.ds)
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) > DATEADD(month, -2, subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Snowflake/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_14.metric_time__day)
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATEADD(day, -2, subq_15.ds)
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               , DATE_TRUNC('quarter', subq_3.ds) AS metric_time__quarter
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
-              , DATE_TRUNC('quarter', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_all_time_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,32 +21,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
-      , subq_11.metric_time__quarter AS metric_time__quarter
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
+      , DATE_TRUNC('quarter', subq_12.ds) AS metric_time__quarter
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-        , DATE_TRUNC('quarter', ds) AS metric_time__quarter
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-        , DATE_TRUNC('quarter', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
-      , subq_11.metric_time__quarter
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
+      , DATE_TRUNC('quarter', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
           , subq_3.ds AS metric_time__day
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          DATE_TRUNC('month', subq_3.ds)
-          , subq_3.ds
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_agg_time_and_metric_time__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
-  , subq_9.metric_time__day AS metric_time__day
+  DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
+  , subq_10.ds AS metric_time__day
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-    , ds AS metric_time__day
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    DATE_TRUNC('month', ds)
-    , ds
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__month
-  , subq_9.metric_time__day
+  DATE_TRUNC('month', subq_10.ds)
+  , subq_10.ds

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS revenue_instance__ds__day
           , DATE_TRUNC('month', subq_3.ds) AS revenue_instance__ds__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_agg_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.revenue_instance__ds__day AS revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month AS revenue_instance__ds__month
+  subq_10.ds AS revenue_instance__ds__day
+  , DATE_TRUNC('month', subq_10.ds) AS revenue_instance__ds__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS revenue_instance__ds__day
-    , DATE_TRUNC('month', ds) AS revenue_instance__ds__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.revenue_instance__ds__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.revenue_instance__ds__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.revenue_instance__ds__day
-  , subq_9.revenue_instance__ds__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0.sql
@@ -60,9 +60,6 @@ FROM (
           subq_3.ds AS metric_time__day
           , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
         FROM ***************************.mf_time_spine subq_3
-        GROUP BY
-          subq_3.ds
-          , DATE_TRUNC('month', subq_3.ds)
       ) subq_2
       INNER JOIN (
         -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_multiple_metric_time_dimensions__plan0_optimized.sql
@@ -3,27 +3,18 @@
 -- Aggregate Measures
 -- Compute Metrics via Expressions
 SELECT
-  subq_9.metric_time__day AS metric_time__day
-  , subq_9.metric_time__month AS metric_time__month
+  subq_10.ds AS metric_time__day
+  , DATE_TRUNC('month', subq_10.ds) AS metric_time__month
   , SUM(revenue_src_28000.revenue) AS trailing_2_months_revenue
-FROM (
-  -- Time Spine
-  SELECT
-    ds AS metric_time__day
-    , DATE_TRUNC('month', ds) AS metric_time__month
-  FROM ***************************.mf_time_spine subq_10
-  GROUP BY
-    ds
-    , DATE_TRUNC('month', ds)
-) subq_9
+FROM ***************************.mf_time_spine subq_10
 INNER JOIN
   ***************************.fct_revenue revenue_src_28000
 ON
   (
-    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_9.metric_time__day
+    DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_10.ds
   ) AND (
-    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_9.metric_time__day)
+    DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_10.ds)
   )
 GROUP BY
-  subq_9.metric_time__day
-  , subq_9.metric_time__month
+  subq_10.ds
+  , DATE_TRUNC('month', subq_10.ds)

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('week', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,28 +17,19 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__week AS metric_time__week
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('week', subq_12.ds) AS metric_time__week
       , SUM(revenue_src_28000.revenue) AS revenue_all_time
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('week', ds) AS metric_time__week
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('week', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__week
+      subq_12.ds
+      , DATE_TRUNC('week', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0.sql
@@ -75,9 +75,6 @@ FROM (
                 subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_derived_cumulative_metric_with_non_default_grains__plan0_optimized.sql
@@ -18,30 +18,21 @@ FROM (
       -- Pass Only Elements: ['txn_revenue', 'metric_time__week', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_12.metric_time__day AS metric_time__day
-        , subq_12.metric_time__week AS metric_time__week
+        subq_13.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_13.ds) AS metric_time__week
         , SUM(revenue_src_28000.revenue) AS txn_revenue
-      FROM (
-        -- Time Spine
-        SELECT
-          ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_13
-        GROUP BY
-          ds
-          , DATE_TRUNC('week', ds)
-      ) subq_12
+      FROM ***************************.mf_time_spine subq_13
       INNER JOIN
         ***************************.fct_revenue revenue_src_28000
       ON
         (
-          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.metric_time__day
+          DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_13.ds
         ) AND (
-          DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_12.metric_time__day)
+          DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_13.ds)
         )
       GROUP BY
-        subq_12.metric_time__day
-        , subq_12.metric_time__week
+        subq_13.ds
+        , DATE_TRUNC('week', subq_13.ds)
     ) subq_16
   ) subq_18
   GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0.sql
@@ -74,9 +74,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('month', subq_3.ds) AS metric_time__month
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('month', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grain__plan0_optimized.sql
@@ -17,30 +17,21 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__month AS metric_time__month
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('month', subq_12.ds) AS metric_time__month
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('month', ds) AS metric_time__month
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('month', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__month
+      subq_12.ds
+      , DATE_TRUNC('month', subq_12.ds)
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0.sql
@@ -82,10 +82,6 @@ FROM (
               , DATE_TRUNC('year', subq_3.ds) AS revenue_instance__ds__year
               , subq_3.ds AS metric_time__day
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              DATE_TRUNC('quarter', subq_3.ds)
-              , DATE_TRUNC('year', subq_3.ds)
-              , subq_3.ds
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_grain_to_date_metric_with_non_default_grains__plan0_optimized.sql
@@ -21,34 +21,23 @@ FROM (
     -- Aggregate Measures
     -- Compute Metrics via Expressions
     SELECT
-      subq_11.revenue_instance__ds__quarter AS revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year AS revenue_instance__ds__year
-      , subq_11.metric_time__day AS metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds) AS revenue_instance__ds__quarter
+      , DATE_TRUNC('year', subq_12.ds) AS revenue_instance__ds__year
+      , subq_12.ds AS metric_time__day
       , SUM(revenue_src_28000.revenue) AS revenue_mtd
-    FROM (
-      -- Time Spine
-      SELECT
-        DATE_TRUNC('quarter', ds) AS revenue_instance__ds__quarter
-        , DATE_TRUNC('year', ds) AS revenue_instance__ds__year
-        , ds AS metric_time__day
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        DATE_TRUNC('quarter', ds)
-        , DATE_TRUNC('year', ds)
-        , ds
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) >= DATE_TRUNC('month', subq_12.ds)
       )
     GROUP BY
-      subq_11.revenue_instance__ds__quarter
-      , subq_11.revenue_instance__ds__year
-      , subq_11.metric_time__day
+      DATE_TRUNC('quarter', subq_12.ds)
+      , DATE_TRUNC('year', subq_12.ds)
+      , subq_12.ds
   ) subq_16
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0.sql
@@ -70,9 +70,6 @@ FROM (
               subq_3.ds AS metric_time__day
               , DATE_TRUNC('year', subq_3.ds) AS metric_time__year
             FROM ***************************.mf_time_spine subq_3
-            GROUP BY
-              subq_3.ds
-              , DATE_TRUNC('year', subq_3.ds)
           ) subq_2
           INNER JOIN (
             -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grain__plan0_optimized.sql
@@ -13,30 +13,21 @@ FROM (
     -- Pass Only Elements: ['txn_revenue', 'metric_time__year', 'metric_time__day']
     -- Aggregate Measures
     SELECT
-      subq_11.metric_time__day AS metric_time__day
-      , subq_11.metric_time__year AS metric_time__year
+      subq_12.ds AS metric_time__day
+      , DATE_TRUNC('year', subq_12.ds) AS metric_time__year
       , SUM(revenue_src_28000.revenue) AS txn_revenue
-    FROM (
-      -- Time Spine
-      SELECT
-        ds AS metric_time__day
-        , DATE_TRUNC('year', ds) AS metric_time__year
-      FROM ***************************.mf_time_spine subq_12
-      GROUP BY
-        ds
-        , DATE_TRUNC('year', ds)
-    ) subq_11
+    FROM ***************************.mf_time_spine subq_12
     INNER JOIN
       ***************************.fct_revenue revenue_src_28000
     ON
       (
-        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_11.metric_time__day
+        DATE_TRUNC('day', revenue_src_28000.created_at) <= subq_12.ds
       ) AND (
-        DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_11.metric_time__day)
+        DATE_TRUNC('day', revenue_src_28000.created_at) > DATE_ADD('month', -2, subq_12.ds)
       )
     GROUP BY
-      subq_11.metric_time__day
-      , subq_11.metric_time__year
+      subq_12.ds
+      , DATE_TRUNC('year', subq_12.ds)
   ) subq_15
 ) subq_17
 GROUP BY

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0.sql
@@ -157,10 +157,6 @@ FROM (
                 , subq_3.ds AS metric_time__day
                 , DATE_TRUNC('week', subq_3.ds) AS metric_time__week
               FROM ***************************.mf_time_spine subq_3
-              GROUP BY
-                DATE_TRUNC('month', subq_3.ds)
-                , subq_3.ds
-                , DATE_TRUNC('week', subq_3.ds)
             ) subq_2
             INNER JOIN (
               -- Metric Time Dimension 'ds'

--- a/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_cumulative_metric_rendering.py/SqlQueryPlan/Trino/test_window_metric_with_non_default_grains__plan0_optimized.sql
@@ -29,34 +29,23 @@ FROM (
       -- Pass Only Elements: ['bookers', 'metric_time__week', 'booking__ds__month', 'metric_time__day']
       -- Aggregate Measures
       SELECT
-        subq_14.booking__ds__month AS booking__ds__month
-        , subq_14.metric_time__day AS metric_time__day
-        , subq_14.metric_time__week AS metric_time__week
+        DATE_TRUNC('month', subq_15.ds) AS booking__ds__month
+        , subq_15.ds AS metric_time__day
+        , DATE_TRUNC('week', subq_15.ds) AS metric_time__week
         , COUNT(DISTINCT bookings_source_src_28000.guest_id) AS bookers
-      FROM (
-        -- Time Spine
-        SELECT
-          DATE_TRUNC('month', ds) AS booking__ds__month
-          , ds AS metric_time__day
-          , DATE_TRUNC('week', ds) AS metric_time__week
-        FROM ***************************.mf_time_spine subq_15
-        GROUP BY
-          DATE_TRUNC('month', ds)
-          , ds
-          , DATE_TRUNC('week', ds)
-      ) subq_14
+      FROM ***************************.mf_time_spine subq_15
       INNER JOIN
         ***************************.fct_bookings bookings_source_src_28000
       ON
         (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_14.metric_time__day
+          DATE_TRUNC('day', bookings_source_src_28000.ds) <= subq_15.ds
         ) AND (
-          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATE_ADD('day', -2, subq_14.metric_time__day)
+          DATE_TRUNC('day', bookings_source_src_28000.ds) > DATE_ADD('day', -2, subq_15.ds)
         )
       GROUP BY
-        subq_14.booking__ds__month
-        , subq_14.metric_time__day
-        , subq_14.metric_time__week
+        DATE_TRUNC('month', subq_15.ds)
+        , subq_15.ds
+        , DATE_TRUNC('week', subq_15.ds)
     ) subq_18
     ON
       subq_20.ds = subq_18.metric_time__day


### PR DESCRIPTION
We've been applying an unnecessary group by to the time spine dataset. Previously, we were applying group bys whenever a `DATE_TRUNC` column was included in the select statement, _even if_ the base grain was included in the select statement. These group bys are unnecessary, because If there is no `DATE_TRUNC` applied to one select column, then none of the columns will be changed by the group by. For example:
```
SELECT
  ds
  , DATE_TRUNC(ds, month)
FROM time_spine
GROUP BY
  ds, DATE_TRUNC(ds, month)
```
will return the same result as:
```
SELECT
  ds
  , DATE_TRUNC(ds, month)
FROM time_spine
```
The results are the same, but the first query is inefficient because of the unnecessary group by. This PR removes the unnecessary group bys.
Note that if the base grain is not included, the group by is still necessary.

I recommend reviewing by commit because the number of snapshot changes is very large.