### PR TITLE
Fix missing snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ test:
 
 .PHONY: test-slow
 test-include-slow:
+	cd metricflow-semantics && hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW_SEMANTICS)/
 	hatch -v run dev-env:pytest -vv -n $(PARALLELISM) $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_METRICFLOW)/
 
 .PHONY: test-postgresql

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_ambiguous_entity_path_resolves_to_shortest_entity_path_item__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='all_entity_metric'),),
+  metric_specs=(MetricSpec(element_name='all_entity_metric', filter_spec_set=WhereFilterSpecSet()),),
   dimension_specs=(DimensionSpec(element_name='country', entity_links=(EntityReference(element_name='entity_1'),)),),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_ambiguous_entity_path.py/MetricFlowQuerySpec/test_resolvable_ambiguous_entity_path__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='entity_1_metric'),),
+  metric_specs=(MetricSpec(element_name='entity_1_metric', filter_spec_set=WhereFilterSpecSet()),),
   dimension_specs=(
     DimensionSpec(
       element_name='country',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_conversion_metrics.py/ParseQueryResult/test_conversion_rate_with_constant_properties__result.txt
@@ -1,6 +1,11 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='visit_buy_conversion_rate_by_session'),),
+    metric_specs=(
+      MetricSpec(
+        element_name='visit_buy_conversion_rate_by_session',
+        filter_spec_set=WhereFilterSpecSet(),
+      ),
+    ),
     dimension_specs=(
       DimensionSpec(
         element_name='referrer_id',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter__result_0.txt
@@ -1,5 +1,10 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity_and_outer_metric_time_filter'),),
+  metric_specs=(
+    MetricSpec(
+      element_name='derived_metric_with_time_granularity_and_outer_metric_time_filter',
+      filter_spec_set=WhereFilterSpecSet(),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(
     spec_resolutions=(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_defined_metric_time_filter_on_input_metric__result_0.txt
@@ -1,5 +1,10 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity_and_inner_metric_time_filter'),),
+  metric_specs=(
+    MetricSpec(
+      element_name='derived_metric_with_time_granularity_and_inner_metric_time_filter',
+      filter_spec_set=WhereFilterSpecSet(),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(
     spec_resolutions=(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_with_explicit_time_granularity__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity'),),
+  metric_specs=(MetricSpec(element_name='derived_metric_with_time_granularity', filter_spec_set=WhereFilterSpecSet()),),
   time_dimension_specs=(
     TimeDimensionSpec(
       element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_derived_metric_without_explicit_time_granularity__result_0.txt
@@ -1,5 +1,10 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='derived_metric_without_time_granularity'),),
+  metric_specs=(
+    MetricSpec(
+      element_name='derived_metric_without_time_granularity',
+      filter_spec_set=WhereFilterSpecSet(),
+    ),
+  ),
   time_dimension_specs=(
     TimeDimensionSpec(
       element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_non_metric_time_ignores_default_granularity__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='largest_listing'),),
+  metric_specs=(MetricSpec(element_name='largest_listing', filter_spec_set=WhereFilterSpecSet()),),
   time_dimension_specs=(
     TimeDimensionSpec(
       element_name='ds',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_defined_metric_time_filter__result_0.txt
@@ -1,5 +1,10 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='simple_metric_with_default_time_granularity_and_metric_time_filter'),),
+  metric_specs=(
+    MetricSpec(
+      element_name='simple_metric_with_default_time_granularity_and_metric_time_filter',
+      filter_spec_set=WhereFilterSpecSet(),
+    ),
+  ),
   filter_intersection=PydanticWhereFilterIntersection(),
   filter_spec_resolution_lookup=FilterSpecResolutionLookUp(
     spec_resolutions=(

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_with_explicit_time_granularity__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='largest_listing'),),
+  metric_specs=(MetricSpec(element_name='largest_listing', filter_spec_set=WhereFilterSpecSet()),),
   time_dimension_specs=(
     TimeDimensionSpec(
       element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_metric_time_granularity.py/MetricFlowQuerySpec/test_simple_metric_without_explicit_time_granularity__result_0.txt
@@ -1,5 +1,5 @@
 MetricFlowQuerySpec(
-  metric_specs=(MetricSpec(element_name='monthly_metric_0'),),
+  metric_specs=(MetricSpec(element_name='monthly_metric_0', filter_spec_set=WhereFilterSpecSet()),),
   time_dimension_specs=(
     TimeDimensionSpec(
       element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_cumulative_metric_agg_time_dimension_name_validation__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='revenue_cumulative'),),
+    metric_specs=(MetricSpec(element_name='revenue_cumulative', filter_spec_set=WhereFilterSpecSet()),),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='ds',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_derived_metric_with_offset_parsing__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='revenue_growth_2_weeks'),),
+    metric_specs=(MetricSpec(element_name='revenue_growth_2_weeks', filter_spec_set=WhereFilterSpecSet()),),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_conversion__result.txt
@@ -1,6 +1,9 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'), MetricSpec(element_name='revenue')),
+    metric_specs=(
+      MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),
+      MetricSpec(element_name='revenue', filter_spec_set=WhereFilterSpecSet()),
+    ),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_order_by_granularity_no_conversion__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_parse_and_validate_where_constraint_dims__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='metric_time',

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     dimension_specs=(
       DimensionSpec(
         element_name='is_instant',
@@ -25,7 +25,13 @@ ParseQueryResult(
         ),
         descending=False,
       ),
-      OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),
+      OrderBySpec(
+        instance_spec=MetricSpec(
+          element_name='bookings',
+          filter_spec_set=WhereFilterSpecSet(),
+        ),
+        descending=True,
+      ),
     ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_names__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     dimension_specs=(
       DimensionSpec(
         element_name='is_instant',
@@ -25,7 +25,13 @@ ParseQueryResult(
         ),
         descending=False,
       ),
-      OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),
+      OrderBySpec(
+        instance_spec=MetricSpec(
+          element_name='bookings',
+          filter_spec_set=WhereFilterSpecSet(),
+        ),
+        descending=True,
+      ),
     ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_case_insensitivity_with_parameter_objects__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     dimension_specs=(
       DimensionSpec(
         element_name='is_instant',
@@ -25,7 +25,13 @@ ParseQueryResult(
         ),
         descending=False,
       ),
-      OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),
+      OrderBySpec(
+        instance_spec=MetricSpec(
+          element_name='bookings',
+          filter_spec_set=WhereFilterSpecSet(),
+        ),
+        descending=True,
+      ),
     ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_query_parser_with_object_params__result.txt
@@ -1,6 +1,6 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'),),
+    metric_specs=(MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),),
     dimension_specs=(
       DimensionSpec(
         element_name='is_instant',
@@ -25,7 +25,13 @@ ParseQueryResult(
         ),
         descending=False,
       ),
-      OrderBySpec(instance_spec=MetricSpec(element_name='bookings'), descending=True),
+      OrderBySpec(
+        instance_spec=MetricSpec(
+          element_name='bookings',
+          filter_spec_set=WhereFilterSpecSet(),
+        ),
+        descending=True,
+      ),
     ),
     filter_intersection=PydanticWhereFilterIntersection(),
     filter_spec_resolution_lookup=FilterSpecResolutionLookUp(),

--- a/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
+++ b/metricflow-semantics/tests_metricflow_semantics/snapshots/test_query_parser.py/ParseQueryResult/test_time_range_constraint_conversion__result.txt
@@ -1,6 +1,9 @@
 ParseQueryResult(
   query_spec=MetricFlowQuerySpec(
-    metric_specs=(MetricSpec(element_name='bookings'), MetricSpec(element_name='revenue')),
+    metric_specs=(
+      MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()),
+      MetricSpec(element_name='revenue', filter_spec_set=WhereFilterSpecSet()),
+    ),
     time_dimension_specs=(
       TimeDimensionSpec(
         element_name='metric_time',

--- a/tests_metricflow/generate_snapshots.py
+++ b/tests_metricflow/generate_snapshots.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 
 TEST_DIRECTORY = "tests_metricflow"
+MF_SEMANTICS_TEST_DIRECTORY = "metricflow-semantics/tests_metricflow_semantics"
 
 
 class MetricFlowTestCredentialSet(FrozenBaseModel):  # noqa: D101
@@ -142,6 +143,10 @@ def run_tests(test_configuration: MetricFlowTestConfiguration) -> None:  # noqa:
     if test_configuration.engine is SqlEngine.DUCKDB:
         # DuckDB is fast, so generate all snapshots, including the engine-agnostic ones
         run_command(f"pytest -x -vv -n 4 --overwrite-snapshots -k 'not itest' {TEST_DIRECTORY}")
+
+        # Run snapshots changes for metricflow-semantics
+        # these are not dialect specific, so only need to run once
+        run_command(f"pytest -x -vv -n 4 --overwrite-snapshots {MF_SEMANTICS_TEST_DIRECTORY}")
     elif (
         test_configuration.engine is SqlEngine.REDSHIFT
         or test_configuration.engine is SqlEngine.SNOWFLAKE


### PR DESCRIPTION
## Context
After merging https://github.com/dbt-labs/metricflow/pull/1452, seems like snapshots in MF-semantics were missing (CI still passed - odd). But updated those and also updated the script to update snapshots in MF semantics as that seems to be missing.