### PR TITLE
Make `SqlTable.schema_name` optional

### DIFF
--- a/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
+++ b/metricflow-semantics/metricflow_semantics/time/time_spine_source.py
@@ -24,7 +24,7 @@ class TimeSpineSource:
     Dates should be contiguous. May also contain custom granularity columns.
     """
 
-    schema_name: str
+    schema_name: Optional[str]
     table_name: str = "mf_time_spine"
     # Name of the column in the table that contains date/time values that map to a standard granularity.
     base_column: str = "ds"

--- a/metricflow-semantics/tests_metricflow_semantics/sql/test_sql_table.py
+++ b/metricflow-semantics/tests_metricflow_semantics/sql/test_sql_table.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+from metricflow_semantics.sql.sql_table import SqlTable
+
+
+def test_sql_table() -> None:  # noqa: D103
+    assert SqlTable(schema_name=None, table_name="table", db_name=None).sql == "table"
+    assert SqlTable(schema_name="schema", table_name="table", db_name=None).sql == "schema.table"
+    assert SqlTable(schema_name="schema", table_name="table", db_name="db").sql == "db.schema.table"
+
+    with pytest.raises(ValueError):
+        SqlTable(schema_name=None, table_name="table", db_name="db")

--- a/metricflow/sql/sql_column.py
+++ b/metricflow/sql/sql_column.py
@@ -35,7 +35,7 @@ class SqlColumn:
         return self.table.db_name
 
     @property
-    def schema_name(self) -> str:  # noqa: D102
+    def schema_name(self) -> Optional[str]:  # noqa: D102
         return self.table.schema_name
 
     @property


### PR DESCRIPTION
This PR makes `SqlTable.schema_name` optional as `SqlTable` can later be used to reference a CTE, which does not have a schema name.