### PR TITLE
Rename `SqlBindParameters` to `SqlBindParameterSet`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_spec.py
@@ -11,7 +11,7 @@ from metricflow_semantics.collection_helpers.merger import Mergeable
 from metricflow_semantics.model.semantics.linkable_element import LinkableElement, LinkableElementUnion
 from metricflow_semantics.specs.instance_spec import LinkableInstanceSpec
 from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 
 
 @dataclass(frozen=True)
@@ -26,7 +26,7 @@ class WhereFilterSpec(Mergeable, SerializableDataclass):
 
     WhereFilterSpec(
         where_sql="listing__country == 'US'",
-        bind_parameters: SqlBindParameters(),
+        bind_parameter_set: SqlBindParameters(),
         linkable_specs: (
             DimensionSpec(
                 element_name='country',
@@ -42,10 +42,10 @@ class WhereFilterSpec(Mergeable, SerializableDataclass):
     )
     """
 
-    # Debating whether where_sql / bind_parameters belongs here. where_sql may become dialect specific if we introduce
+    # Debating whether where_sql / bind_parameter_set belongs here. where_sql may become dialect specific if we introduce
     # quoted identifiers later.
     where_sql: str
-    bind_parameters: SqlBindParameters
+    bind_parameters: SqlBindParameterSet
     linkable_element_unions: Tuple[LinkableElementUnion, ...]
     linkable_spec_set: LinkableSpecSet
 
@@ -83,7 +83,7 @@ class WhereFilterSpec(Mergeable, SerializableDataclass):
         # line with other cases of Mergeable.
         return WhereFilterSpec(
             where_sql="TRUE",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_spec_set=LinkableSpecSet(),
             linkable_element_unions=(),
         )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
@@ -20,7 +20,7 @@ from metricflow_semantics.specs.where_filter.where_filter_entity import WhereFil
 from metricflow_semantics.specs.where_filter.where_filter_metric import WhereFilterMetricFactory
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
 from metricflow_semantics.specs.where_filter.where_filter_time_dimension import WhereFilterTimeDimensionFactory
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class WhereSpecFactory:
             filter_specs.append(
                 WhereFilterSpec(
                     where_sql=where_sql,
-                    bind_parameters=SqlBindParameters(),
+                    bind_parameters=SqlBindParameterSet(),
                     linkable_spec_set=LinkableSpecSet.create_from_specs(rendered_specs),
                     linkable_element_unions=tuple(linkable_element.as_union for linkable_element in linkable_elements),
                 )

--- a/metricflow-semantics/metricflow_semantics/sql/sql_bind_parameters.py
+++ b/metricflow-semantics/metricflow_semantics/sql/sql_bind_parameters.py
@@ -74,7 +74,7 @@ class SqlBindParameter(SerializableDataclass):  # noqa: D101
 
 
 @dataclass(frozen=True)
-class SqlBindParameters(SerializableDataclass):
+class SqlBindParameterSet(SerializableDataclass):
     """Helps to build execution parameters during SQL query rendering.
 
     These can be used as per https://docs.sqlalchemy.org/en/14/core/tutorial.html#using-textual-sql
@@ -83,7 +83,7 @@ class SqlBindParameters(SerializableDataclass):
     # Using tuples for immutability as dicts are not.
     param_items: Tuple[SqlBindParameter, ...] = ()
 
-    def combine(self, additional_params: SqlBindParameters) -> SqlBindParameters:
+    def combine(self, additional_params: SqlBindParameterSet) -> SqlBindParameterSet:
         """Create a new set of bind parameters that includes parameters from this and additional_params."""
         if len(self.param_items) == 0:
             return additional_params
@@ -108,7 +108,7 @@ class SqlBindParameters(SerializableDataclass):
             new_items.append(item)
             included_keys.add(item.key)
 
-        return SqlBindParameters(param_items=tuple(new_items))
+        return SqlBindParameterSet(param_items=tuple(new_items))
 
     @property
     def param_dict(self) -> OrderedDict[str, SqlColumnType]:
@@ -119,8 +119,8 @@ class SqlBindParameters(SerializableDataclass):
         return param_dict
 
     @staticmethod
-    def create_from_dict(param_dict: Mapping[str, SqlColumnType]) -> SqlBindParameters:  # noqa: D102
-        return SqlBindParameters(
+    def create_from_dict(param_dict: Mapping[str, SqlColumnType]) -> SqlBindParameterSet:  # noqa: D102
+        return SqlBindParameterSet(
             tuple(
                 SqlBindParameter(key=key, value=SqlBindParameterValue.create_from_sql_column_type(value))
                 for key, value in param_dict.items()
@@ -128,4 +128,4 @@ class SqlBindParameters(SerializableDataclass):
         )
 
     def __eq__(self, other: Any) -> bool:  # type: ignore  # noqa: D105
-        return isinstance(other, SqlBindParameters) and self.param_dict == other.param_dict
+        return isinstance(other, SqlBindParameterSet) and self.param_dict == other.param_dict

--- a/metricflow-semantics/tests_metricflow_semantics/specs/test_spec_serialization.py
+++ b/metricflow-semantics/tests_metricflow_semantics/specs/test_spec_serialization.py
@@ -16,14 +16,14 @@ from metricflow_semantics.specs.group_by_metric_spec import GroupByMetricSpec
 from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameter, SqlBindParameters, SqlBindParameterValue
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameter, SqlBindParameterSet, SqlBindParameterValue
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
 def test_where_filter_spec_serialization() -> None:  # noqa: D103
     where_filter_spec = WhereFilterSpec(
         where_sql="where_sql",
-        bind_parameters=SqlBindParameters(
+        bind_parameters=SqlBindParameterSet(
             param_items=(SqlBindParameter(key="key", value=SqlBindParameterValue(str_value="str_value")),)
         ),
         linkable_element_unions=(

--- a/metricflow-semantics/tests_metricflow_semantics/sql/test_bind_parameter_serialization.py
+++ b/metricflow-semantics/tests_metricflow_semantics/sql/test_bind_parameter_serialization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 from dbt_semantic_interfaces.dataclass_serialization import DataClassDeserializer, DataclassSerializer
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameter, SqlBindParameters, SqlBindParameterValue
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameter, SqlBindParameterSet, SqlBindParameterValue
 
 
 @pytest.fixture
@@ -19,14 +19,14 @@ def test_serialization(  # noqa: D103
     serializer: DataclassSerializer,
     deserializer: DataClassDeserializer,
 ) -> None:
-    bind_parameters = SqlBindParameters(
+    bind_parameter_set = SqlBindParameterSet(
         param_items=(
             SqlBindParameter("key0", SqlBindParameterValue.create_from_sql_column_type("value0")),
             SqlBindParameter("key1", SqlBindParameterValue.create_from_sql_column_type("value1")),
         )
     )
-    serialized_obj = serializer.pydantic_serialize(bind_parameters)
+    serialized_obj = serializer.pydantic_serialize(bind_parameter_set)
     deserialized_obj = deserializer.pydantic_deserialize(
-        dataclass_type=SqlBindParameters, serialized_obj=serialized_obj
+        dataclass_type=SqlBindParameterSet, serialized_obj=serialized_obj
     )
-    assert bind_parameters == deserialized_obj
+    assert bind_parameter_set == deserialized_obj

--- a/metricflow-semantics/tests_metricflow_semantics/test_specs.py
+++ b/metricflow-semantics/tests_metricflow_semantics/test_specs.py
@@ -16,7 +16,7 @@ from metricflow_semantics.specs.spec_set import InstanceSpecSet
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
 from metricflow_semantics.specs.where_filter.where_filter_spec_set import WhereFilterSpecSet
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
 
 
@@ -224,7 +224,7 @@ def where_filter_spec_set() -> WhereFilterSpecSet:  # noqa: D103
         measure_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="measure is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -232,7 +232,7 @@ def where_filter_spec_set() -> WhereFilterSpecSet:  # noqa: D103
         metric_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="metric is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -240,7 +240,7 @@ def where_filter_spec_set() -> WhereFilterSpecSet:  # noqa: D103
         query_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="query is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -252,19 +252,19 @@ def test_where_filter_spec_set_all_specs(where_filter_spec_set: WhereFilterSpecS
     assert set(where_filter_spec_set.all_filter_specs) == {
         WhereFilterSpec(
             where_sql="measure is true",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_element_unions=(),
             linkable_spec_set=LinkableSpecSet(),
         ),
         WhereFilterSpec(
             where_sql="metric is true",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_element_unions=(),
             linkable_spec_set=LinkableSpecSet(),
         ),
         WhereFilterSpec(
             where_sql="query is true",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_element_unions=(),
             linkable_spec_set=LinkableSpecSet(),
         ),
@@ -275,13 +275,13 @@ def test_where_filter_spec_set_post_aggregation_specs(where_filter_spec_set: Whe
     assert set(where_filter_spec_set.after_measure_aggregation_filter_specs) == {
         WhereFilterSpec(
             where_sql="metric is true",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_element_unions=(),
             linkable_spec_set=LinkableSpecSet(),
         ),
         WhereFilterSpec(
             where_sql="query is true",
-            bind_parameters=SqlBindParameters(),
+            bind_parameters=SqlBindParameterSet(),
             linkable_element_unions=(),
             linkable_spec_set=LinkableSpecSet(),
         ),
@@ -293,7 +293,7 @@ def test_where_filter_spec_set_merge(where_filter_spec_set: WhereFilterSpecSet) 
         measure_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="measure is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -303,7 +303,7 @@ def test_where_filter_spec_set_merge(where_filter_spec_set: WhereFilterSpecSet) 
         metric_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="metric is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -314,7 +314,7 @@ def test_where_filter_spec_set_merge(where_filter_spec_set: WhereFilterSpecSet) 
         measure_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="measure is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -322,7 +322,7 @@ def test_where_filter_spec_set_merge(where_filter_spec_set: WhereFilterSpecSet) 
         metric_level_filter_specs=(
             WhereFilterSpec(
                 where_sql="metric is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -204,7 +204,7 @@ class MetricFlowExplainResult:
                     sql_query.sql_query.split("\n"),
                 )
             ),
-            bind_parameters=sql_query.bind_parameters,
+            bind_parameter_set=sql_query.bind_parameter_set,
         )
 
     @property

--- a/metricflow/execution/dataflow_to_execution.py
+++ b/metricflow/execution/dataflow_to_execution.py
@@ -85,7 +85,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
             leaf_tasks=(
                 SelectSqlQueryToDataTableTask.create(
                     sql_client=self._sql_client,
-                    sql_query=SqlQuery(render_sql_result.sql, render_sql_result.bind_parameters),
+                    sql_query=SqlQuery(render_sql_result.sql, render_sql_result.bind_parameter_set),
                 ),
             )
         )
@@ -105,7 +105,7 @@ class DataflowToExecutionPlanConverter(DataflowPlanNodeVisitor[ConvertToExecutio
                     sql_client=self._sql_client,
                     sql_query=SqlQuery(
                         sql_query=render_sql_result.sql,
-                        bind_parameters=render_sql_result.bind_parameters,
+                        bind_parameter_set=render_sql_result.bind_parameter_set,
                     ),
                     output_table=node.output_sql_table,
                 ),

--- a/metricflow/execution/execution_plan.py
+++ b/metricflow/execution/execution_plan.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Sequence, Tuple
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagId, DagNode, DisplayedProperty, MetricFlowDag, NodeId
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.visitor import Visitable
 
@@ -49,7 +49,7 @@ class SqlQuery:
 
     # This field will be renamed as it is confusing given the class name.
     sql_query: str
-    bind_parameters: SqlBindParameters
+    bind_parameter_set: SqlBindParameterSet
 
 
 @dataclass(frozen=True)
@@ -69,7 +69,7 @@ class TaskExecutionResult:
 
     # If the task was an SQL query, it's stored here
     sql: Optional[str] = None
-    bind_params: Optional[SqlBindParameters] = None
+    bind_params: Optional[SqlBindParameterSet] = None
     # If the task produces a data_table as a result, it's stored here.
     df: Optional[MetricFlowDataTable] = None
 
@@ -120,7 +120,7 @@ class SelectSqlQueryToDataTableTask(ExecutionPlanTask):
 
         df = self.sql_client.query(
             sql_query.sql_query,
-            sql_bind_parameters=sql_query.bind_parameters,
+            sql_bind_parameter_set=sql_query.bind_parameter_set,
         )
 
         end_time = time.time()
@@ -128,7 +128,7 @@ class SelectSqlQueryToDataTableTask(ExecutionPlanTask):
             start_time=start_time,
             end_time=end_time,
             sql=sql_query.sql_query,
-            bind_params=sql_query.bind_parameters,
+            bind_params=sql_query.bind_parameter_set,
             df=df,
         )
 
@@ -180,7 +180,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
         return tuple(super().displayed_properties) + (
             DisplayedProperty(key="sql_query", value=sql_query.sql_query),
             DisplayedProperty(key="output_table", value=self.output_table),
-            DisplayedProperty(key="bind_parameters", value=sql_query.bind_parameters),
+            DisplayedProperty(key="bind_parameter_set", value=sql_query.bind_parameter_set),
         )
 
     def execute(self) -> TaskExecutionResult:  # noqa: D102
@@ -192,7 +192,7 @@ class SelectSqlQueryToTableTask(ExecutionPlanTask):
         logger.debug(LazyFormat(lambda: f"Creating table {self.output_table} using a query"))
         self.sql_client.execute(
             sql_query.sql_query,
-            sql_bind_parameters=sql_query.bind_parameters,
+            sql_bind_parameter_set=sql_query.bind_parameter_set,
         )
 
         end_time = time.time()

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -855,7 +855,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                     used_columns=tuple(
                         column_association.column_name for column_association in column_associations_in_where_sql
                     ),
-                    bind_parameters=node.where.bind_parameters,
+                    bind_parameter_set=node.where.bind_parameters,
                 ),
             ),
         )

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -6,7 +6,7 @@ from typing import Protocol, Set
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 
 from metricflow.data_table.mf_table import MetricFlowDataTable
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
@@ -79,7 +79,7 @@ class SqlClient(Protocol):
     def query(
         self,
         stmt: str,
-        sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+        sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet(),
     ) -> MetricFlowDataTable:
         """Base query method, upon execution will run a query that returns a pandas DataTable."""
         raise NotImplementedError
@@ -88,7 +88,7 @@ class SqlClient(Protocol):
     def execute(
         self,
         stmt: str,
-        sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+        sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet(),
     ) -> None:
         """Base execute method."""
         raise NotImplementedError
@@ -97,7 +97,7 @@ class SqlClient(Protocol):
     def dry_run(
         self,
         stmt: str,
-        sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+        sql_bind_parameter_set: SqlBindParameterSet = SqlBindParameterSet(),
     ) -> None:
         """Base dry_run method."""
         raise NotImplementedError

--- a/metricflow/sql/render/databricks.py
+++ b/metricflow/sql/render/databricks.py
@@ -38,7 +38,7 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Databricks."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
-        params = arg_rendered.bind_parameters
+        params = arg_rendered.bind_parameter_set
         percentile = node.percentile_args.percentile
 
         if node.percentile_args.function_type is SqlPercentileFunctionType.CONTINUOUS:
@@ -57,14 +57,14 @@ class DatabricksSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_DISCRETE:
             return SqlExpressionRenderResult(
                 sql=f"APPROX_PERCENTILE({arg_rendered.sql}, {percentile})",
-                bind_parameters=params,
+                bind_parameter_set=params,
             )
         else:
             assert_values_exhausted(node.percentile_args.function_type)
 
         return SqlExpressionRenderResult(
             sql=f"{function_str}({percentile}) WITHIN GROUP (ORDER BY ({arg_rendered.sql}))",
-            bind_parameters=params,
+            bind_parameter_set=params,
         )
 
 

--- a/metricflow/sql/render/duckdb_renderer.py
+++ b/metricflow/sql/render/duckdb_renderer.py
@@ -4,7 +4,7 @@ from typing import Collection
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from typing_extensions import override
 
 from metricflow.protocols.sql_client import SqlEngine
@@ -49,21 +49,21 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=f"{arg_rendered.sql} - INTERVAL {count} {granularity.value}",
-            bind_parameters=arg_rendered.bind_parameters,
+            bind_parameter_set=arg_rendered.bind_parameter_set,
         )
 
     @override
     def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         return SqlExpressionRenderResult(
             sql="GEN_RANDOM_UUID()",
-            bind_parameters=SqlBindParameters(),
+            bind_parameter_set=SqlBindParameterSet(),
         )
 
     @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for DuckDB."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
-        params = arg_rendered.bind_parameters
+        params = arg_rendered.bind_parameter_set
         percentile = node.percentile_args.percentile
 
         if node.percentile_args.function_type is SqlPercentileFunctionType.CONTINUOUS:
@@ -73,7 +73,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS:
             return SqlExpressionRenderResult(
                 sql=f"approx_quantile({arg_rendered.sql}, {percentile})",
-                bind_parameters=params,
+                bind_parameter_set=params,
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_DISCRETE:
             raise RuntimeError(
@@ -85,7 +85,7 @@ class DuckDbSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=f"{function_str}({percentile}) WITHIN GROUP (ORDER BY ({arg_rendered.sql}))",
-            bind_parameters=params,
+            bind_parameter_set=params,
         )
 
 

--- a/metricflow/sql/render/redshift.py
+++ b/metricflow/sql/render/redshift.py
@@ -5,7 +5,7 @@ from typing import Collection
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from metricflow_semantics.errors.error_classes import UnsupportedEngineFeatureError
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from typing_extensions import override
 
 from metricflow.protocols.sql_client import SqlEngine
@@ -43,7 +43,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Redshift."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
-        params = arg_rendered.bind_parameters
+        params = arg_rendered.bind_parameter_set
         percentile = node.percentile_args.percentile
 
         if node.percentile_args.function_type is SqlPercentileFunctionType.CONTINUOUS:
@@ -65,7 +65,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=f"{function_str}({percentile}) WITHIN GROUP (ORDER BY ({arg_rendered.sql}))",
-            bind_parameters=params,
+            bind_parameter_set=params,
         )
 
     @override
@@ -90,7 +90,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=case_expr,
-            bind_parameters=extract_rendering_result.bind_parameters,
+            bind_parameter_set=extract_rendering_result.bind_parameter_set,
         )
 
     @override
@@ -104,7 +104,7 @@ class RedshiftSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         """
         return SqlExpressionRenderResult(
             sql="CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR)",
-            bind_parameters=SqlBindParameters(),
+            bind_parameter_set=SqlBindParameterSet(),
         )
 
 

--- a/metricflow/sql/render/snowflake.py
+++ b/metricflow/sql/render/snowflake.py
@@ -5,7 +5,7 @@ from typing import Collection
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from metricflow_semantics.errors.error_classes import UnsupportedEngineFeatureError
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from typing_extensions import override
 
 from metricflow.protocols.sql_client import SqlEngine
@@ -47,14 +47,14 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
     def visit_generate_uuid_expr(self, node: SqlGenerateUuidExpression) -> SqlExpressionRenderResult:
         return SqlExpressionRenderResult(
             sql="UUID_STRING()",
-            bind_parameters=SqlBindParameters(),
+            bind_parameter_set=SqlBindParameterSet(),
         )
 
     @override
     def visit_percentile_expr(self, node: SqlPercentileExpression) -> SqlExpressionRenderResult:
         """Render a percentile expression for Snowflake."""
         arg_rendered = self.render_sql_expr(node.order_by_arg)
-        params = arg_rendered.bind_parameters
+        params = arg_rendered.bind_parameter_set
         percentile = node.percentile_args.percentile
 
         if node.percentile_args.function_type is SqlPercentileFunctionType.CONTINUOUS:
@@ -64,7 +64,7 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_CONTINUOUS:
             return SqlExpressionRenderResult(
                 sql=f"APPROX_PERCENTILE({arg_rendered.sql}, {percentile})",
-                bind_parameters=params,
+                bind_parameter_set=params,
             )
         elif node.percentile_args.function_type is SqlPercentileFunctionType.APPROXIMATE_DISCRETE:
             raise UnsupportedEngineFeatureError(
@@ -76,7 +76,7 @@ class SnowflakeSqlExpressionRenderer(DefaultSqlExpressionRenderer):
 
         return SqlExpressionRenderResult(
             sql=f"{function_str}({percentile}) WITHIN GROUP (ORDER BY ({arg_rendered.sql}))",
-            bind_parameters=params,
+            bind_parameter_set=params,
         )
 
 

--- a/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
+++ b/tests_metricflow/dataflow/optimizer/test_predicate_pushdown_optimizer.py
@@ -10,7 +10,7 @@ from metricflow_semantics.query.query_parser import MetricFlowQueryParser
 from metricflow_semantics.specs.linkable_spec_set import LinkableSpecSet
 from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.snapshot_helpers import assert_plan_snapshot_text_equal
 
@@ -78,7 +78,7 @@ def test_branch_state_propagation(branch_state_tracker: PredicatePushdownBranchS
         where_filter_specs=(
             WhereFilterSpec(
                 where_sql="x is true",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_element_unions=(),
                 linkable_spec_set=LinkableSpecSet(),
             ),
@@ -115,13 +115,13 @@ def test_applied_filter_back_propagation(branch_state_tracker: PredicatePushdown
     base_state = branch_state_tracker.last_pushdown_state
     where_spec_x_is_true = WhereFilterSpec(
         where_sql="x is true",
-        bind_parameters=SqlBindParameters(),
+        bind_parameters=SqlBindParameterSet(),
         linkable_element_unions=(),
         linkable_spec_set=LinkableSpecSet(),
     )
     where_spec_y_is_null = WhereFilterSpec(
         where_sql="y is null",
-        bind_parameters=SqlBindParameters(),
+        bind_parameters=SqlBindParameterSet(),
         linkable_element_unions=(),
         linkable_spec_set=LinkableSpecSet(),
     )

--- a/tests_metricflow/execution/test_tasks.py
+++ b/tests_metricflow/execution/test_tasks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from metricflow_semantics.dag.mf_dag import DagId
 from metricflow_semantics.random_id import random_id
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
@@ -19,7 +19,7 @@ from tests_metricflow.sql.compare_data_table import assert_data_tables_equal
 
 
 def test_read_sql_task(sql_client: SqlClient) -> None:  # noqa: D103
-    task = SelectSqlQueryToDataTableTask.create(sql_client, SqlQuery("SELECT 1 AS foo", SqlBindParameters()))
+    task = SelectSqlQueryToDataTableTask.create(sql_client, SqlQuery("SELECT 1 AS foo", SqlBindParameterSet()))
     execution_plan = ExecutionPlan(leaf_tasks=[task], dag_id=DagId.from_str("plan0"))
 
     results = SequentialPlanExecutor().execute_plan(execution_plan)
@@ -46,7 +46,7 @@ def test_write_table_task(  # noqa: D103
         sql_client=sql_client,
         sql_query=SqlQuery(
             sql_query=f"CREATE TABLE {output_table.sql} AS SELECT 1 AS foo",
-            bind_parameters=SqlBindParameters(),
+            bind_parameter_set=SqlBindParameterSet(),
         ),
         output_table=output_table,
     )

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -26,7 +26,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.specs.spec_set import InstanceSpecSet
 from metricflow_semantics.specs.time_dimension_spec import TimeDimensionSpec
 from metricflow_semantics.specs.where_filter.where_filter_spec import WhereFilterSpec
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.sql.sql_join_type import SqlJoinType
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 from metricflow_semantics.test_helpers.metric_time_dimension import MTD_SPEC_DAY
@@ -196,7 +196,7 @@ def test_filter_with_where_constraint_node(
         where_specs=(
             WhereFilterSpec(
                 where_sql="booking__ds__day = '2020-01-01'",
-                bind_parameters=SqlBindParameters(),
+                bind_parameters=SqlBindParameterSet(),
                 linkable_spec_set=LinkableSpecSet(
                     time_dimension_specs=(
                         TimeDimensionSpec(

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan__dfp_0.xml
@@ -29,7 +29,7 @@
                     <!-- where_condition =                                                 -->
                     <!--   WhereFilterSpec(                                                -->
                     <!--     where_sql="listing__country_latest = 'us'",                   -->
-                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                     <!--     linkable_element_unions=(                                     -->
                     <!--       LinkableElementUnion(                                       -->
                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -34,7 +34,7 @@
                     <!-- where_condition =                                                 -->
                     <!--   WhereFilterSpec(                                                -->
                     <!--     where_sql="listing__country_latest = 'us'",                   -->
-                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                     <!--     linkable_element_unions=(                                     -->
                     <!--       LinkableElementUnion(                                       -->
                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_with_filters__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -62,7 +62,7 @@
                     <!-- where_condition =                                                 -->
                     <!--   WhereFilterSpec(                                                -->
                     <!--     where_sql="metric_time__day = '2020-01-01'",                  -->
-                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                     <!--     linkable_element_unions=(                                     -->
                     <!--       LinkableElementUnion(                                       -->
                     <!--         linkable_dimension=LinkableDimension(                     -->
@@ -125,7 +125,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                  -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_plan__dfp_0.xml
@@ -20,7 +20,7 @@
                     <!--       metric_level_filter_specs=(                                       -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='listing__is_lux_latest',                           -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -90,7 +90,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='listing__is_lux_latest',                           -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->
@@ -224,7 +224,7 @@
                     <!--       metric_level_filter_specs=(                                       -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='listing__is_lux_latest',                           -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -294,7 +294,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='listing__is_lux_latest',                           -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_measure_constraint_with_reused_measure_plan__dfp_0.xml
@@ -20,7 +20,7 @@
                     <!--       metric_level_filter_specs=(                                       -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -81,7 +81,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='booking__is_instant',                              -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_metric_where_filter__dfp_0.xml
@@ -17,28 +17,28 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                        -->
-                        <!--   WhereFilterSpec(                       -->
-                        <!--     where_sql='listing__bookings > 2',   -->
-                        <!--     bind_parameters=SqlBindParameters(), -->
-                        <!--     linkable_spec_set=LinkableSpecSet(   -->
-                        <!--       group_by_metric_specs=(            -->
-                        <!--         GroupByMetricSpec(               -->
-                        <!--           element_name='bookings',       -->
-                        <!--           entity_links=(                 -->
-                        <!--             EntityReference(             -->
-                        <!--               element_name='listing',    -->
-                        <!--             ),                           -->
-                        <!--           ),                             -->
-                        <!--           metric_subquery_entity_links=( -->
-                        <!--             EntityReference(             -->
-                        <!--               element_name='listing',    -->
-                        <!--             ),                           -->
-                        <!--           ),                             -->
-                        <!--         ),                               -->
-                        <!--       ),                                 -->
-                        <!--     ),                                   -->
-                        <!--   )                                      -->
+                        <!-- where_condition =                          -->
+                        <!--   WhereFilterSpec(                         -->
+                        <!--     where_sql='listing__bookings > 2',     -->
+                        <!--     bind_parameters=SqlBindParameterSet(), -->
+                        <!--     linkable_spec_set=LinkableSpecSet(     -->
+                        <!--       group_by_metric_specs=(              -->
+                        <!--         GroupByMetricSpec(                 -->
+                        <!--           element_name='bookings',         -->
+                        <!--           entity_links=(                   -->
+                        <!--             EntityReference(               -->
+                        <!--               element_name='listing',      -->
+                        <!--             ),                             -->
+                        <!--           ),                               -->
+                        <!--           metric_subquery_entity_links=(   -->
+                        <!--             EntityReference(               -->
+                        <!--               element_name='listing',      -->
+                        <!--             ),                             -->
+                        <!--           ),                               -->
+                        <!--         ),                                 -->
+                        <!--       ),                                   -->
+                        <!--     ),                                     -->
+                        <!--   )                                        -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['listings', 'listing__bookings']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_in_query_where_filter__dfp_0.xml
@@ -5,35 +5,35 @@
         <ComputeMetricsNode>
             <!-- description = 'Compute Metrics via Expressions' -->
             <!-- node_id = NodeId(id_str='cm_1') -->
-            <!-- metric_spec =                                  -->
-            <!--   MetricSpec(                                  -->
-            <!--     element_name='listings',                   -->
-            <!--     filter_spec_set=WhereFilterSpecSet(        -->
-            <!--       query_level_filter_specs=(               -->
-            <!--         WhereFilterSpec(                       -->
-            <!--           where_sql='listing__bookings > 2',   -->
-            <!--           bind_parameters=SqlBindParameters(), -->
-            <!--           linkable_spec_set=LinkableSpecSet(   -->
-            <!--             group_by_metric_specs=(            -->
-            <!--               GroupByMetricSpec(               -->
-            <!--                 element_name='bookings',       -->
-            <!--                 entity_links=(                 -->
-            <!--                   EntityReference(             -->
-            <!--                     element_name='listing',    -->
-            <!--                   ),                           -->
-            <!--                 ),                             -->
-            <!--                 metric_subquery_entity_links=( -->
-            <!--                   EntityReference(             -->
-            <!--                     element_name='listing',    -->
-            <!--                   ),                           -->
-            <!--                 ),                             -->
-            <!--               ),                               -->
-            <!--             ),                                 -->
-            <!--           ),                                   -->
-            <!--         ),                                     -->
-            <!--       ),                                       -->
-            <!--     ),                                         -->
-            <!--   )                                            -->
+            <!-- metric_spec =                                    -->
+            <!--   MetricSpec(                                    -->
+            <!--     element_name='listings',                     -->
+            <!--     filter_spec_set=WhereFilterSpecSet(          -->
+            <!--       query_level_filter_specs=(                 -->
+            <!--         WhereFilterSpec(                         -->
+            <!--           where_sql='listing__bookings > 2',     -->
+            <!--           bind_parameters=SqlBindParameterSet(), -->
+            <!--           linkable_spec_set=LinkableSpecSet(     -->
+            <!--             group_by_metric_specs=(              -->
+            <!--               GroupByMetricSpec(                 -->
+            <!--                 element_name='bookings',         -->
+            <!--                 entity_links=(                   -->
+            <!--                   EntityReference(               -->
+            <!--                     element_name='listing',      -->
+            <!--                   ),                             -->
+            <!--                 ),                               -->
+            <!--                 metric_subquery_entity_links=(   -->
+            <!--                   EntityReference(               -->
+            <!--                     element_name='listing',      -->
+            <!--                   ),                             -->
+            <!--                 ),                               -->
+            <!--               ),                                 -->
+            <!--             ),                                   -->
+            <!--           ),                                     -->
+            <!--         ),                                       -->
+            <!--       ),                                         -->
+            <!--     ),                                           -->
+            <!--   )                                              -->
             <AggregateMeasuresNode>
                 <!-- description = 'Aggregate Measures' -->
                 <!-- node_id = NodeId(id_str='am_1') -->
@@ -45,28 +45,28 @@
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_0') -->
-                        <!-- where_condition =                        -->
-                        <!--   WhereFilterSpec(                       -->
-                        <!--     where_sql='listing__bookings > 2',   -->
-                        <!--     bind_parameters=SqlBindParameters(), -->
-                        <!--     linkable_spec_set=LinkableSpecSet(   -->
-                        <!--       group_by_metric_specs=(            -->
-                        <!--         GroupByMetricSpec(               -->
-                        <!--           element_name='bookings',       -->
-                        <!--           entity_links=(                 -->
-                        <!--             EntityReference(             -->
-                        <!--               element_name='listing',    -->
-                        <!--             ),                           -->
-                        <!--           ),                             -->
-                        <!--           metric_subquery_entity_links=( -->
-                        <!--             EntityReference(             -->
-                        <!--               element_name='listing',    -->
-                        <!--             ),                           -->
-                        <!--           ),                             -->
-                        <!--         ),                               -->
-                        <!--       ),                                 -->
-                        <!--     ),                                   -->
-                        <!--   )                                      -->
+                        <!-- where_condition =                          -->
+                        <!--   WhereFilterSpec(                         -->
+                        <!--     where_sql='listing__bookings > 2',     -->
+                        <!--     bind_parameters=SqlBindParameterSet(), -->
+                        <!--     linkable_spec_set=LinkableSpecSet(     -->
+                        <!--       group_by_metric_specs=(              -->
+                        <!--         GroupByMetricSpec(                 -->
+                        <!--           element_name='bookings',         -->
+                        <!--           entity_links=(                   -->
+                        <!--             EntityReference(               -->
+                        <!--               element_name='listing',      -->
+                        <!--             ),                             -->
+                        <!--           ),                               -->
+                        <!--           metric_subquery_entity_links=(   -->
+                        <!--             EntityReference(               -->
+                        <!--               element_name='listing',      -->
+                        <!--             ),                             -->
+                        <!--           ),                               -->
+                        <!--         ),                                 -->
+                        <!--       ),                                   -->
+                        <!--     ),                                     -->
+                        <!--   )                                        -->
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['listings', 'listing__bookings']" -->
                             <!-- node_id = NodeId(id_str='pfe_3') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_to_grain_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -61,7 +61,7 @@
                 <!--       query_level_filter_specs=(                                        -->
                 <!--         WhereFilterSpec(                                                -->
                 <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-                <!--           bind_parameters=SqlBindParameters(),                          -->
+                <!--           bind_parameters=SqlBindParameterSet(),                        -->
                 <!--           linkable_element_unions=(                                     -->
                 <!--             LinkableElementUnion(                                       -->
                 <!--               linkable_dimension=LinkableDimension(                     -->
@@ -121,7 +121,7 @@
                             <!-- where_condition =                                                 -->
                             <!--   WhereFilterSpec(                                                -->
                             <!--     where_sql="metric_time__day = '2020-01-01'",                  -->
-                            <!--     bind_parameters=SqlBindParameters(),                          -->
+                            <!--     bind_parameters=SqlBindParameterSet(),                        -->
                             <!--     linkable_element_unions=(                                     -->
                             <!--       LinkableElementUnion(                                       -->
                             <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -64,7 +64,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -123,7 +123,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                  -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->
@@ -221,7 +221,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -279,7 +279,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql="metric_time__day = '2020-01-01'",                  -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="listing__country_latest = 'us'",                   -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -82,7 +82,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql="listing__country_latest = 'us'",                   -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_plan_time_dimension__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day >= '2020-01-01'",                 -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -70,7 +70,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql="metric_time__day >= '2020-01-01'",                 -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_where_constrained_with_common_linkable_plan__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="listing__country_latest = 'us'",                   -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -72,7 +72,7 @@
                     <!-- where_condition =                                                 -->
                     <!--   WhereFilterSpec(                                                -->
                     <!--     where_sql="listing__country_latest = 'us'",                   -->
-                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                     <!--     linkable_element_unions=(                                     -->
                     <!--       LinkableElementUnion(                                       -->
                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="visit__referrer_id = '123456'",                    -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -81,7 +81,7 @@
                             <!-- where_condition =                                                 -->
                             <!--   WhereFilterSpec(                                                -->
                             <!--     where_sql="visit__referrer_id = '123456'",                    -->
-                            <!--     bind_parameters=SqlBindParameters(),                          -->
+                            <!--     bind_parameters=SqlBindParameterSet(),                        -->
                             <!--     linkable_element_unions=(                                     -->
                             <!--       LinkableElementUnion(                                       -->
                             <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="visit__referrer_id = '123456'",                    -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -130,7 +130,7 @@
                                         <!-- where_condition =                                                 -->
                                         <!--   WhereFilterSpec(                                                -->
                                         <!--     where_sql="visit__referrer_id = '123456'",                    -->
-                                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                         <!--     linkable_element_unions=(                                     -->
                                         <!--       LinkableElementUnion(                                       -->
                                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -77,7 +77,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -137,7 +137,7 @@
                                         <!-- where_condition =                                                 -->
                                         <!--   WhereFilterSpec(                                                -->
                                         <!--     where_sql='booking__is_instant',                              -->
-                                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                         <!--     linkable_element_unions=(                                     -->
                                         <!--       LinkableElementUnion(                                       -->
                                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -147,7 +147,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->
@@ -285,7 +285,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -368,7 +368,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -199,7 +199,7 @@
                                                 <!-- where_condition =                                                 -->
                                                 <!--   WhereFilterSpec(                                                -->
                                                 <!--     where_sql='booking__is_instant',                              -->
-                                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                                 <!--     linkable_element_unions=(                                     -->
                                                 <!--       LinkableElementUnion(                                       -->
                                                 <!--         linkable_dimension=LinkableDimension(                     -->
@@ -284,7 +284,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -367,7 +367,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -113,7 +113,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->
@@ -174,7 +174,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->
@@ -312,7 +312,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -361,7 +361,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->
@@ -422,7 +422,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -113,7 +113,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->
@@ -226,7 +226,7 @@
                                                 <!-- where_condition =                                                 -->
                                                 <!--   WhereFilterSpec(                                                -->
                                                 <!--     where_sql='booking__is_instant',                              -->
-                                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                                 <!--     linkable_element_unions=(                                     -->
                                                 <!--       LinkableElementUnion(                                       -->
                                                 <!--         linkable_dimension=LinkableDimension(                     -->
@@ -311,7 +311,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -360,7 +360,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->
@@ -421,7 +421,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -132,7 +132,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='booking__is_instant',                              -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->
@@ -266,7 +266,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -334,7 +334,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='booking__is_instant',                              -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -66,7 +66,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -184,7 +184,7 @@
                                             <!-- where_condition =                                                 -->
                                             <!--   WhereFilterSpec(                                                -->
                                             <!--     where_sql='booking__is_instant',                              -->
-                                            <!--     bind_parameters=SqlBindParameters(),                          -->
+                                            <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                             <!--     linkable_element_unions=(                                     -->
                                             <!--       LinkableElementUnion(                                       -->
                                             <!--         linkable_dimension=LinkableDimension(                     -->
@@ -265,7 +265,7 @@
                     <!--       query_level_filter_specs=(                                        -->
                     <!--         WhereFilterSpec(                                                -->
                     <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameters(),                          -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
                     <!--           linkable_element_unions=(                                     -->
                     <!--             LinkableElementUnion(                                       -->
                     <!--               linkable_dimension=LinkableDimension(                     -->
@@ -333,7 +333,7 @@
                                 <!-- where_condition =                                                 -->
                                 <!--   WhereFilterSpec(                                                -->
                                 <!--     where_sql='booking__is_instant',                              -->
-                                <!--     bind_parameters=SqlBindParameters(),                          -->
+                                <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                 <!--     linkable_element_unions=(                                     -->
                                 <!--       LinkableElementUnion(                                       -->
                                 <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -72,7 +72,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql='booking__is_instant',                              -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_categorical_pushdown__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql='booking__is_instant',                              -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -108,7 +108,7 @@
                                     <!-- where_condition =                                                 -->
                                     <!--   WhereFilterSpec(                                                -->
                                     <!--     where_sql='booking__is_instant',                              -->
-                                    <!--     bind_parameters=SqlBindParameters(),                          -->
+                                    <!--     bind_parameters=SqlBindParameterSet(),                        -->
                                     <!--     linkable_element_unions=(                                     -->
                                     <!--       LinkableElementUnion(                                       -->
                                     <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfp_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day = '2024-01-01'",                  -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -70,7 +70,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql="metric_time__day = '2024-01-01'",                  -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_simple_join_metric_time_pushdown_with_two_targets__dfpo_0.xml
@@ -12,7 +12,7 @@
             <!--       query_level_filter_specs=(                                        -->
             <!--         WhereFilterSpec(                                                -->
             <!--           where_sql="metric_time__day = '2024-01-01'",                  -->
-            <!--           bind_parameters=SqlBindParameters(),                          -->
+            <!--           bind_parameters=SqlBindParameterSet(),                        -->
             <!--           linkable_element_unions=(                                     -->
             <!--             LinkableElementUnion(                                       -->
             <!--               linkable_dimension=LinkableDimension(                     -->
@@ -70,7 +70,7 @@
                         <!-- where_condition =                                                 -->
                         <!--   WhereFilterSpec(                                                -->
                         <!--     where_sql="metric_time__day = '2024-01-01'",                  -->
-                        <!--     bind_parameters=SqlBindParameters(),                          -->
+                        <!--     bind_parameters=SqlBindParameterSet(),                        -->
                         <!--     linkable_element_unions=(                                     -->
                         <!--       LinkableElementUnion(                                       -->
                         <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfp_0.xml
@@ -59,7 +59,7 @@
                             <!-- where_condition =                                                 -->
                             <!--   WhereFilterSpec(                                                -->
                             <!--     where_sql='booking__is_instant',                              -->
-                            <!--     bind_parameters=SqlBindParameters(),                          -->
+                            <!--     bind_parameters=SqlBindParameterSet(),                        -->
                             <!--     linkable_element_unions=(                                     -->
                             <!--       LinkableElementUnion(                                       -->
                             <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_source_scan_optimizer.py/DataflowPlan/test_constrained_metric_not_combined__dfpo_0.xml
@@ -59,7 +59,7 @@
                             <!-- where_condition =                                                 -->
                             <!--   WhereFilterSpec(                                                -->
                             <!--     where_sql='booking__is_instant',                              -->
-                            <!--     bind_parameters=SqlBindParameters(),                          -->
+                            <!--     bind_parameters=SqlBindParameterSet(),                        -->
                             <!--     linkable_element_unions=(                                     -->
                             <!--       LinkableElementUnion(                                       -->
                             <!--         linkable_dimension=LinkableDimension(                     -->

--- a/tests_metricflow/sql_clients/test_sql_client.py
+++ b/tests_metricflow/sql_clients/test_sql_client.py
@@ -6,7 +6,7 @@ from typing import Optional, Set, Union
 import pytest
 from dbt_semantic_interfaces.test_utils import as_datetime
 from metricflow_semantics.random_id import random_id
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
@@ -122,15 +122,15 @@ def test_dry_run_of_bad_query_raises_exception(sql_client: SqlClient) -> None:  
 
 
 def test_update_params_with_same_item() -> None:  # noqa: D103
-    bind_params0 = SqlBindParameters.create_from_dict({"key": "value"})
-    bind_params1 = SqlBindParameters.create_from_dict({"key": "value"})
+    bind_params0 = SqlBindParameterSet.create_from_dict({"key": "value"})
+    bind_params1 = SqlBindParameterSet.create_from_dict({"key": "value"})
 
     bind_params0.combine(bind_params1)
 
 
 def test_update_params_with_same_key_different_values() -> None:  # noqa: D103
-    bind_params0 = SqlBindParameters.create_from_dict(({"key": "value0"}))
-    bind_params1 = SqlBindParameters.create_from_dict(({"key": "value1"}))
+    bind_params0 = SqlBindParameterSet.create_from_dict(({"key": "value0"}))
+    bind_params1 = SqlBindParameterSet.create_from_dict(({"key": "value1"}))
 
     with pytest.raises(RuntimeError):
         bind_params0.combine(bind_params1)

--- a/tests_metricflow/validation/test_data_warehouse_tasks.py
+++ b/tests_metricflow/validation/test_data_warehouse_tasks.py
@@ -14,7 +14,7 @@ from dbt_semantic_interfaces.protocols.entity import EntityType
 from dbt_semantic_interfaces.test_utils import semantic_model_with_guaranteed_meta
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import PydanticSemanticManifestTransformer
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
-from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameters
+from metricflow_semantics.sql.sql_bind_parameters import SqlBindParameterSet
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.protocols.sql_client import SqlClient
@@ -59,8 +59,8 @@ def test_build_semantic_model_tasks(  # noqa: D103
 def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTestConfiguration) -> None:  # noqa: D103
     dw_validator = DataWarehouseModelValidator(sql_client=sql_client)
 
-    def good_query() -> Tuple[str, SqlBindParameters]:
-        return ("SELECT 'foo' AS foo", SqlBindParameters())
+    def good_query() -> Tuple[str, SqlBindParameterSet]:
+        return ("SELECT 'foo' AS foo", SqlBindParameterSet())
 
     tasks = [
         DataWarehouseValidationTask(
@@ -71,8 +71,8 @@ def test_task_runner(sql_client: SqlClient, mf_test_configuration: MetricFlowTes
     issues = dw_validator.run_tasks(tasks=tasks)
     assert len(issues.all_issues) == 0
 
-    def bad_query() -> Tuple[str, SqlBindParameters]:
-        return ("SELECT (true) AS col1 FROM doesnt_exist", SqlBindParameters())
+    def bad_query() -> Tuple[str, SqlBindParameterSet]:
+        return ("SELECT (true) AS col1 FROM doesnt_exist", SqlBindParameterSet())
 
     err_msg_bad = "Could not access table 'doesnt_exist' in data warehouse"
     bad_task = DataWarehouseValidationTask(


### PR DESCRIPTION
This PR renames `SqlBindParameters` to `SqlBindParameterSet` as plural nouns make it confusing to name variables that contain a list of those objects. e.g. is `sql_bind_parameters: List[SqlBindParameters]` could also seem like a list of `SqlBindParameter`.