### PR TITLE
Implement `Mergeable` for `SqlBindParameterSet`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_spec.py
@@ -69,7 +69,7 @@ class WhereFilterSpec(Mergeable, SerializableDataclass):
 
         return WhereFilterSpec(
             where_sql=f"({self.where_sql}) AND ({other.where_sql})",
-            bind_parameters=self.bind_parameters.combine(other.bind_parameters),
+            bind_parameters=self.bind_parameters.merge(other.bind_parameters),
             linkable_spec_set=self.linkable_spec_set.merge(other.linkable_spec_set).dedupe(),
             linkable_element_unions=ordered_dedupe(self.linkable_element_unions, other.linkable_element_unions),
         )

--- a/metricflow/sql/render/sql_plan_renderer.py
+++ b/metricflow/sql/render/sql_plan_renderer.py
@@ -93,7 +93,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
         for select_column in select_columns:
             expr_rendered = self.EXPR_RENDERER.render_sql_expr(select_column.expr)
             # Merge all execution parameters together. Similar pattern follows below.
-            params = params.combine(expr_rendered.bind_parameter_set)
+            params = params.merge(expr_rendered.bind_parameter_set)
 
             column_select_str = f"{expr_rendered.sql} AS {select_column.column_alias}"
 
@@ -165,13 +165,13 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
         for join_description in join_descriptions:
             # Render the source for the join
             right_source_rendered = self._render_node(join_description.right_source)
-            params = params.combine(right_source_rendered.bind_parameter_set)
+            params = params.merge(right_source_rendered.bind_parameter_set)
 
             # Render the on condition for the join
             on_condition_rendered: Optional[SqlExpressionRenderResult] = None
             if join_description.on_condition:
                 on_condition_rendered = self.EXPR_RENDERER.render_sql_expr(join_description.on_condition)
-                params = params.combine(on_condition_rendered.bind_parameter_set)
+                params = params.merge(on_condition_rendered.bind_parameter_set)
 
             if join_description.right_source.is_table:
                 join_section_lines.append(join_description.join_type.value)
@@ -210,7 +210,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
         first = True
         for group_by_column in group_by_columns:
             group_by_expr_rendered = self.EXPR_RENDERER.render_group_by_expr(group_by_column)
-            params = params.combine(group_by_expr_rendered.bind_parameter_set)
+            params = params.merge(group_by_expr_rendered.bind_parameter_set)
             if first:
                 first = False
                 group_by_section_lines.append("GROUP BY")
@@ -235,25 +235,25 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
         select_section, select_params = self._render_select_columns_section(
             node.select_columns, len(node.parent_nodes), node.distinct
         )
-        combined_params = combined_params.combine(select_params)
+        combined_params = combined_params.merge(select_params)
 
         # Render "FROM" section
         from_section, from_params = self._render_from_section(node.from_source, node.from_source_alias)
-        combined_params = combined_params.combine(from_params)
+        combined_params = combined_params.merge(from_params)
 
         # Render "JOIN" section
         join_section, join_params = self._render_joins_section(node.join_descs)
-        combined_params = combined_params.combine(join_params)
+        combined_params = combined_params.merge(join_params)
 
         # Render "GROUP BY" section
         group_by_section, group_by_params = self._render_group_by_section(node.group_bys)
-        combined_params = combined_params.combine(group_by_params)
+        combined_params = combined_params.merge(group_by_params)
 
         # Render "WHERE" section
         where_section = None
         if node.where:
             where_render_result = self.EXPR_RENDERER.render_sql_expr(node.where)
-            combined_params = combined_params.combine(where_render_result.bind_parameter_set)
+            combined_params = combined_params.merge(where_render_result.bind_parameter_set)
             where_section = f"WHERE {where_render_result.sql}"
 
         # Render "ORDER BY" section
@@ -263,7 +263,7 @@ class DefaultSqlQueryPlanRenderer(SqlQueryPlanRenderer):
             for order_by in node.order_bys:
                 order_by_render_result = self.EXPR_RENDERER.render_sql_expr(order_by.expr)
                 order_by_items.append(order_by_render_result.sql + (" DESC" if order_by.desc else ""))
-                combined_params = combined_params.combine(order_by_render_result.bind_parameter_set)
+                combined_params = combined_params.merge(order_by_render_result.bind_parameter_set)
 
             order_by_section = "ORDER BY " + ", ".join(order_by_items)
 

--- a/metricflow/sql/render/trino.py
+++ b/metricflow/sql/render/trino.py
@@ -91,9 +91,9 @@ class TrinoSqlExpressionRenderer(DefaultSqlExpressionRenderer):
         rendered_end_expr = self.render_sql_expr(node.end_expr)
 
         bind_parameter_set = SqlBindParameterSet()
-        bind_parameter_set = bind_parameter_set.combine(rendered_column_arg.bind_parameter_set)
-        bind_parameter_set = bind_parameter_set.combine(rendered_start_expr.bind_parameter_set)
-        bind_parameter_set = bind_parameter_set.combine(rendered_end_expr.bind_parameter_set)
+        bind_parameter_set = bind_parameter_set.merge(rendered_column_arg.bind_parameter_set)
+        bind_parameter_set = bind_parameter_set.merge(rendered_start_expr.bind_parameter_set)
+        bind_parameter_set = bind_parameter_set.merge(rendered_end_expr.bind_parameter_set)
 
         # Handle timestamp literals differently.
         if parse(rendered_start_expr.sql):

--- a/tests_metricflow/sql_clients/test_sql_client.py
+++ b/tests_metricflow/sql_clients/test_sql_client.py
@@ -125,7 +125,7 @@ def test_update_params_with_same_item() -> None:  # noqa: D103
     bind_params0 = SqlBindParameterSet.create_from_dict({"key": "value"})
     bind_params1 = SqlBindParameterSet.create_from_dict({"key": "value"})
 
-    bind_params0.combine(bind_params1)
+    bind_params0.merge(bind_params1)
 
 
 def test_update_params_with_same_key_different_values() -> None:  # noqa: D103
@@ -133,4 +133,4 @@ def test_update_params_with_same_key_different_values() -> None:  # noqa: D103
     bind_params1 = SqlBindParameterSet.create_from_dict(({"key": "value1"}))
 
     with pytest.raises(RuntimeError):
-        bind_params0.combine(bind_params1)
+        bind_params0.merge(bind_params1)


### PR DESCRIPTION
`SqlBindParameterSet` implements `combine()`, which is similar to the interface for `Mergeable` objects. This PR updates `SqlBindParameterSet` to be a subclass of `Mergeable` for consistency and the ability to use convenience methods for `Mergeable` objects in later PRs.