### PR TITLE
Add classes to represent CTEs

### DIFF
--- a/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
+++ b/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
@@ -78,6 +78,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
     SQL_PLAN_TABLE_FROM_CLAUSE_ID_PREFIX = "tfc"
     SQL_PLAN_QUERY_FROM_CLAUSE_ID_PREFIX = "qfc"
     SQL_PLAN_CREATE_TABLE_AS_ID_PREFIX = "cta"
+    SQL_PLAN_COMMON_TABLE_EXPRESSION_ID_PREFIX = "cta"
 
     EXEC_NODE_READ_SQL_QUERY = "rsq"
     EXEC_NODE_NOOP = "noop"

--- a/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
+++ b/metricflow-semantics/metricflow_semantics/dag/id_prefix.py
@@ -78,7 +78,7 @@ class StaticIdPrefix(IdPrefix, Enum, metaclass=EnumMetaClassHelper):
     SQL_PLAN_TABLE_FROM_CLAUSE_ID_PREFIX = "tfc"
     SQL_PLAN_QUERY_FROM_CLAUSE_ID_PREFIX = "qfc"
     SQL_PLAN_CREATE_TABLE_AS_ID_PREFIX = "cta"
-    SQL_PLAN_COMMON_TABLE_EXPRESSION_ID_PREFIX = "cta"
+    SQL_PLAN_COMMON_TABLE_EXPRESSION_ID_PREFIX = "cte"
 
     EXEC_NODE_READ_SQL_QUERY = "rsq"
     EXEC_NODE_NOOP = "noop"

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -4,12 +4,15 @@ import logging
 from collections import defaultdict
 from typing import Dict, List, Set, Tuple
 
+from typing_extensions import override
+
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_exprs import (
     SqlExpressionTreeLineage,
 )
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
+    SqlCteNode,
     SqlJoinDescription,
     SqlQueryPlanNode,
     SqlQueryPlanNodeVisitor,
@@ -110,6 +113,10 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             limit=node.limit,
             distinct=node.distinct,
         )
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         # Remove columns that are not needed from this SELECT statement because the parent SELECT statement doesn't

--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Sequence, Tuple
 
 from metricflow_semantics.mf_logging.formatting import indent
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from typing_extensions import override
 
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_exprs import (
@@ -19,6 +20,7 @@ from metricflow.sql.sql_exprs import (
 )
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
+    SqlCteNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -582,6 +584,10 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             distinct=node.distinct,
         )
 
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
+
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)
 
@@ -726,6 +732,10 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             if select_column.expr == expr:
                 return select_column
         return None
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         new_group_bys = []

--- a/metricflow/sql/optimizer/sub_query_reducer.py
+++ b/metricflow/sql/optimizer/sub_query_reducer.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 from typing import List, Optional
 
+from typing_extensions import override
+
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
+    SqlCteNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -120,6 +123,10 @@ class SqlSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
                 if column_reference_expr:
                     return column_reference_expr.col_ref.table_alias
         return None
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         node_with_reduced_parents = self._reduce_parents(node)

--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 
+from typing_extensions import override
+
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
+    SqlCteNode,
     SqlJoinDescription,
     SqlOrderByDescription,
     SqlQueryPlanNode,
@@ -20,6 +23,10 @@ logger = logging.getLogger(__name__)
 
 class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     """Visits the SQL query plan to see if table aliases can be omitted when rendering column references."""
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         # If there is only a single parent, no table aliases are required since there's no ambiguity.

--- a/tests_metricflow/snapshots/test_render_cte.py/SqlQueryPlan/test_render_cte__plan_0.sql
+++ b/tests_metricflow/snapshots/test_render_cte.py/SqlQueryPlan/test_render_cte__plan_0.sql
@@ -1,0 +1,23 @@
+-- cte_test
+WITH cte_0 AS (
+  -- cte_select_0
+  SELECT
+    cte_source_table_0.col_0
+  FROM demo.cte_source_table_0 cte_source_table_0
+)
+
+, cte_1 AS (
+  -- cte_select_1
+  SELECT
+    cte_source_table_1.col_1
+  FROM demo.cte_source_table_1 cte_source_table_1
+)
+
+SELECT
+  cte_0.col_0 AS col_0
+  , cte_1.col_1 AS col_1
+FROM cte_0 cte_0
+LEFT OUTER JOIN
+  cte_1 cte_1
+ON
+  cte_0.col_0 = cte_1.col_1

--- a/tests_metricflow/sql/test_render_cte.py
+++ b/tests_metricflow/sql/test_render_cte.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.sql.sql_table import SqlTable
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from metricflow.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlComparison,
+    SqlComparisonExpression,
+)
+from metricflow.sql.sql_plan import (
+    SqlCteNode,
+    SqlJoinDescription,
+    SqlSelectColumn,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
+
+logger = logging.getLogger(__name__)
+
+
+def test_render_cte(  # noqa: D103
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+) -> None:
+    assert_default_rendered_sql_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        sql_plan_node=SqlSelectStatementNode.create(
+            description="cte_test",
+            select_columns=(
+                SqlSelectColumn(
+                    expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="cte_0", column_name="col_0")
+                    ),
+                    column_alias="col_0",
+                ),
+                SqlSelectColumn(
+                    expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="cte_1", column_name="col_1")
+                    ),
+                    column_alias="col_1",
+                ),
+            ),
+            from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_0")),
+            from_source_alias="cte_0",
+            join_descs=(
+                SqlJoinDescription(
+                    right_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_1")),
+                    right_source_alias="cte_1",
+                    join_type=SqlJoinType.LEFT_OUTER,
+                    on_condition=SqlComparisonExpression.create(
+                        left_expr=SqlColumnReferenceExpression.create(
+                            col_ref=SqlColumnReference(table_alias="cte_0", column_name="col_0")
+                        ),
+                        comparison=SqlComparison.EQUALS,
+                        right_expr=SqlColumnReferenceExpression.create(
+                            col_ref=SqlColumnReference(table_alias="cte_1", column_name="col_1")
+                        ),
+                    ),
+                ),
+            ),
+            cte_sources=(
+                SqlCteNode.create(
+                    select_statement=SqlSelectStatementNode.create(
+                        description="cte_select_0",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="cte_source_table_0", column_name="col_0")
+                                ),
+                                column_alias="col_0",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name="demo", table_name="cte_source_table_0")
+                        ),
+                        from_source_alias="cte_source_table_0",
+                    ),
+                    cte_alias="cte_0",
+                ),
+                SqlCteNode.create(
+                    select_statement=SqlSelectStatementNode.create(
+                        description="cte_select_1",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="cte_source_table_1", column_name="col_1")
+                                ),
+                                column_alias="col_1",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name="demo", table_name="cte_source_table_1")
+                        ),
+                        from_source_alias="cte_source_table_1",
+                    ),
+                    cte_alias="cte_1",
+                ),
+            ),
+        ),
+        plan_id="plan_0",
+    )


### PR DESCRIPTION
* This PR adds classes to represent CTEs to the SQL object model.
* CTEs will be used in later PRs to simplify generated queries.
* Functionality to render CTEs is included, and existing code should not hit the CTE use cases so many methods were left unimplemented.