### PR TITLE
Add per-measure validation in query validation rules

### DIFF
--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/base_validation_rule.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/base_validation_rule.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import Sequence
 
 from dbt_semantic_interfaces.protocols import WhereFilterIntersection
-from dbt_semantic_interfaces.references import MetricReference
+from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
@@ -28,6 +28,18 @@ class PostResolutionQueryValidationRule(ABC):
         self._manifest_lookup = manifest_lookup
         self._resolver_input_for_query = resolver_input_for_query
         self._resolve_group_by_item_result = resolve_group_by_item_result
+
+    @abstractmethod
+    def validate_measure_in_resolution_dag(
+        self,
+        measure_reference: MeasureReference,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        """Given a measure that exists in a resolution DAG, check that the query is valid.
+
+        This is called for each measure of a base metric as the resolution DAG is traversed.
+        """
+        raise NotImplementedError
 
     @abstractmethod
     def validate_metric_in_resolution_dag(

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/duplicate_metric.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/duplicate_metric.py
@@ -4,7 +4,7 @@ import logging
 from typing import Sequence
 
 from dbt_semantic_interfaces.protocols import WhereFilterIntersection
-from dbt_semantic_interfaces.references import MetricReference
+from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from typing_extensions import override
 
 from metricflow_semantics.query.group_by_item.resolution_path import MetricFlowQueryResolutionPath
@@ -48,4 +48,12 @@ class DuplicateMetricValidationRule(PostResolutionQueryValidationRule):
                 )
             )
 
+        return MetricFlowQueryResolutionIssueSet.empty_instance()
+
+    @override
+    def validate_measure_in_resolution_dag(
+        self,
+        measure_reference: MeasureReference,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
         return MetricFlowQueryResolutionIssueSet.empty_instance()

--- a/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
+++ b/metricflow-semantics/metricflow_semantics/query/validation_rules/metric_time_requirements.py
@@ -8,6 +8,7 @@ from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.protocols import Metric, WhereFilterIntersection
 from dbt_semantic_interfaces.references import (
+    MeasureReference,
     MetricReference,
     TimeDimensionReference,
 )
@@ -224,6 +225,14 @@ class MetricTimeQueryValidationRule(PostResolutionQueryValidationRule):
         self,
         metrics_in_query: Sequence[MetricReference],
         where_filter_intersection: WhereFilterIntersection,
+        resolution_path: MetricFlowQueryResolutionPath,
+    ) -> MetricFlowQueryResolutionIssueSet:
+        return MetricFlowQueryResolutionIssueSet.empty_instance()
+
+    @override
+    def validate_measure_in_resolution_dag(
+        self,
+        measure_reference: MeasureReference,
         resolution_path: MetricFlowQueryResolutionPath,
     ) -> MetricFlowQueryResolutionIssueSet:
         return MetricFlowQueryResolutionIssueSet.empty_instance()


### PR DESCRIPTION
This PR updates the signature of the `PostResolutionQueryValidationRule` to allow for query validation on a per-measure basis. This allows for simpler validation for checks that depend on a measure as used in a later PR.