### PR TITLE
Move static methods to `SemanticModelHelper`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/linkable_spec_resolver.py
@@ -39,6 +39,7 @@ from metricflow_semantics.model.semantics.linkable_element import (
     SemanticModelToMetricSubqueryJoinPath,
 )
 from metricflow_semantics.model.semantics.linkable_element_set import LinkableElementSet
+from metricflow_semantics.model.semantics.semantic_model_helper import SemanticModelHelper
 from metricflow_semantics.model.semantics.semantic_model_join_evaluator import SemanticModelJoinEvaluator
 from metricflow_semantics.specs.time_dimension_spec import DEFAULT_TIME_GRANULARITY
 from metricflow_semantics.time.granularity import ExpandedTimeGranularity
@@ -358,7 +359,7 @@ class ValidLinkableSpecResolver:
                     properties=entity_properties,
                 )
             )
-            for entity_link in self._semantic_model_lookup.entity_links_for_local_elements(semantic_model):
+            for entity_link in SemanticModelHelper.entity_links_for_local_elements(semantic_model):
                 # Avoid creating "booking_id__booking_id"
                 if entity_link == entity.reference:
                     continue
@@ -378,7 +379,7 @@ class ValidLinkableSpecResolver:
         if semantic_model_is_scd:
             dimension_properties = dimension_properties.union({LinkableElementProperty.SCD_HOP})
 
-        for entity_link in self._semantic_model_lookup.entity_links_for_local_elements(semantic_model):
+        for entity_link in SemanticModelHelper.entity_links_for_local_elements(semantic_model):
             for dimension in semantic_model.dimensions:
                 dimension_type = dimension.type
                 if dimension_type is DimensionType.CATEGORICAL:

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_helper.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_helper.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from dbt_semantic_interfaces.protocols import Dimension
+from dbt_semantic_interfaces.protocols.entity import Entity
+from dbt_semantic_interfaces.protocols.measure import Measure
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
+from dbt_semantic_interfaces.references import (
+    EntityReference,
+    LinkableElementReference,
+    MeasureReference,
+)
+from dbt_semantic_interfaces.type_enums import EntityType
+
+
+class SemanticModelHelper:
+    """Static helper methods for retrieving items from a semantic model."""
+
+    @staticmethod
+    def get_entity_from_semantic_model(
+        semantic_model: SemanticModel, entity_reference: LinkableElementReference
+    ) -> Entity:
+        """Get entity from semantic model."""
+        for entity in semantic_model.entities:
+            if entity.reference == entity_reference:
+                return entity
+
+        raise ValueError(
+            f"No entity with name ({entity_reference}) in semantic_model with name ({semantic_model.name})"
+        )
+
+    @staticmethod
+    def resolved_primary_entity(semantic_model: SemanticModel) -> Optional[EntityReference]:
+        """Return the primary entity for dimensions in the model."""
+        primary_entity_reference = semantic_model.primary_entity_reference
+
+        entities_with_type_primary = tuple(
+            entity for entity in semantic_model.entities if entity.type == EntityType.PRIMARY
+        )
+
+        # This should be caught by the validation, but adding a sanity check.
+        assert len(entities_with_type_primary) <= 1, f"Found > 1 primary entity in {semantic_model}"
+        if primary_entity_reference is not None:
+            assert len(entities_with_type_primary) == 0, (
+                f"The primary_entity field was set to {primary_entity_reference}, but there are non-zero entities with "
+                f"type {EntityType.PRIMARY} in {semantic_model}"
+            )
+            return primary_entity_reference
+
+        if len(entities_with_type_primary) > 0:
+            return entities_with_type_primary[0].reference
+
+        return None
+
+    @staticmethod
+    def entity_links_for_local_elements(semantic_model: SemanticModel) -> Sequence[EntityReference]:
+        """Return the entity prefix that can be used to access dimensions defined in the semantic model."""
+        primary_entity_reference = semantic_model.primary_entity_reference
+
+        possible_entity_links = set()
+        if primary_entity_reference is not None:
+            possible_entity_links.add(primary_entity_reference)
+
+        for entity in semantic_model.entities:
+            if entity.is_linkable_entity_type:
+                possible_entity_links.add(entity.reference)
+
+        return sorted(possible_entity_links, key=lambda entity_reference: entity_reference.element_name)
+
+    @staticmethod
+    def get_measure_from_semantic_model(semantic_model: SemanticModel, measure_reference: MeasureReference) -> Measure:
+        """Get measure from semantic model."""
+        for measure in semantic_model.measures:
+            if measure.reference == measure_reference:
+                return measure
+
+        raise ValueError(
+            f"No dimension with name ({measure_reference.element_name}) in semantic_model with name ({semantic_model.name})"
+        )
+
+    @staticmethod
+    def get_dimension_from_semantic_model(
+        semantic_model: SemanticModel, dimension_reference: LinkableElementReference
+    ) -> Dimension:
+        """Get dimension from semantic model."""
+        for dim in semantic_model.dimensions:
+            if dim.reference == dimension_reference:
+                return dim
+        raise ValueError(
+            f"No dimension with name ({dimension_reference}) in semantic_model with name ({semantic_model.name})"
+        )

--- a/metricflow/dataset/convert_semantic_model.py
+++ b/metricflow/dataset/convert_semantic_model.py
@@ -26,7 +26,7 @@ from metricflow_semantics.instances import (
     MeasureInstance,
     TimeDimensionInstance,
 )
-from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
+from metricflow_semantics.model.semantics.semantic_model_helper import SemanticModelHelper
 from metricflow_semantics.model.spec_converters import MeasureConverter
 from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.dimension_spec import DimensionSpec
@@ -441,7 +441,7 @@ class SemanticModelToDataSetConverter:
             (),
         ]
 
-        for entity_link in SemanticModelLookup.entity_links_for_local_elements(semantic_model):
+        for entity_link in SemanticModelHelper.entity_links_for_local_elements(semantic_model):
             possible_entity_links.append((entity_link,))
 
         # Handle dimensions

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -20,7 +20,7 @@ from metricflow_semantics.model.linkable_element_property import LinkableElement
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
 from metricflow_semantics.model.semantics.element_filter import LinkableElementFilter
 from metricflow_semantics.model.semantics.linkable_element import LinkableDimension
-from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
+from metricflow_semantics.model.semantics.semantic_model_helper import SemanticModelHelper
 from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.protocols.query_parameter import GroupByParameter, MetricQueryParameter, OrderByQueryParameter
 from metricflow_semantics.query.query_exceptions import InvalidQueryException
@@ -653,7 +653,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                     assert semantic_model
                     dimensions.append(
                         Dimension.from_pydantic(
-                            pydantic_dimension=SemanticModelLookup.get_dimension_from_semantic_model(
+                            pydantic_dimension=SemanticModelHelper.get_dimension_from_semantic_model(
                                 semantic_model=semantic_model,
                                 dimension_reference=linkable_dimension.reference,
                             ),
@@ -671,7 +671,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
             for semantic_model in semantic_model_lookup.get_semantic_models_for_dimension(dimension_reference):
                 dimensions.append(
                     Dimension.from_pydantic(
-                        pydantic_dimension=semantic_model_lookup.get_dimension_from_semantic_model(
+                        pydantic_dimension=SemanticModelHelper.get_dimension_from_semantic_model(
                             semantic_model=semantic_model, dimension_reference=dimension_reference
                         ),
                         entity_links=(semantic_model_lookup.get_primary_entity_else_error(semantic_model),),
@@ -706,7 +706,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                 assert semantic_model
                 entities.append(
                     Entity.from_pydantic(
-                        pydantic_entity=SemanticModelLookup.get_entity_from_semantic_model(
+                        pydantic_entity=SemanticModelHelper.get_entity_from_semantic_model(
                             semantic_model=semantic_model,
                             entity_reference=EntityReference(element_name=linkable_entity.element_name),
                         )


### PR DESCRIPTION
`SemanticModelLookup` has gotten large and unwieldy, both in terms of code and state. This has complicated prior performance improvement work. As a first step to breaking up the class, this PR moves the static methods to a separate helper class.