### PR TITLE
Change `resolved_primary_entity` helper signature

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_helper.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_helper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Sequence
 
 from dbt_semantic_interfaces.protocols import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
@@ -31,8 +31,12 @@ class SemanticModelHelper:
         )
 
     @staticmethod
-    def resolved_primary_entity(semantic_model: SemanticModel) -> Optional[EntityReference]:
-        """Return the primary entity for dimensions in the model."""
+    def resolved_primary_entity(semantic_model: SemanticModel) -> EntityReference:
+        """Return the primary entity for dimensions in the model.
+
+        Semantic models with measures or dimensions should have a primary entity as enforced by semantic manifest
+        validation.
+        """
         primary_entity_reference = semantic_model.primary_entity_reference
 
         entities_with_type_primary = tuple(
@@ -51,7 +55,7 @@ class SemanticModelHelper:
         if len(entities_with_type_primary) > 0:
             return entities_with_type_primary[0].reference
 
-        return None
+        raise ValueError(f"No primary entity found in {semantic_model.reference=}")
 
     @staticmethod
     def entity_links_for_local_elements(semantic_model: SemanticModel) -> Sequence[EntityReference]:

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -674,7 +674,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                         pydantic_dimension=SemanticModelHelper.get_dimension_from_semantic_model(
                             semantic_model=semantic_model, dimension_reference=dimension_reference
                         ),
-                        entity_links=(semantic_model_lookup.get_primary_entity_else_error(semantic_model),),
+                        entity_links=(SemanticModelHelper.resolved_primary_entity(semantic_model),),
                     )
                 )
 


### PR DESCRIPTION
The helper method `resolved_primary_entity` gets the primary entity in a semantic model. Since semantic models with a measure or a dimension should have a primary entity (enforced by validations), this PR changes that method to raise an exception if one does not exist instead of returning `None`. `get_primary_entity_else_error` is also removed since it becomes redundant.