### PR TITLE
Fix Bug with `get_defined_time_granularity()`

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/metric_lookup.py
@@ -278,7 +278,7 @@ class MetricLookup:
             )
             agg_time_dimension_grains.add(measure_properties.agg_time_granularity)
 
-        return min(agg_time_dimension_grains, key=lambda time_granularity: time_granularity.to_int())
+        return max(agg_time_dimension_grains, key=lambda time_granularity: time_granularity.to_int())
 
     def get_joinable_scd_specs_for_metric(self, metric_reference: MetricReference) -> Sequence[LinkableInstanceSpec]:
         """Get the SCDs that can be joined to a metric."""

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 
-import pytest
 from dbt_semantic_interfaces.references import MetricReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
@@ -10,7 +9,6 @@ from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifest
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip("get_min_queryable_time_granularity has a bug with agg. time dimensions at different grains.")
 def test_min_queryable_time_granularity_for_different_agg_time_grains(  # noqa: D103
     extended_date_semantic_manifest_lookup: SemanticManifestLookup,
 ) -> None:

--- a/metricflow/dataflow/builder/measure_spec_properties.py
+++ b/metricflow/dataflow/builder/measure_spec_properties.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, Sequence
 
 from dbt_semantic_interfaces.references import TimeDimensionReference
+from dbt_semantic_interfaces.type_enums import TimeGranularity
 from metricflow_semantics.specs.measure_spec import MeasureSpec
 from metricflow_semantics.specs.non_additive_dimension_spec import NonAdditiveDimensionSpec
 
@@ -15,4 +16,5 @@ class MeasureSpecProperties:
     measure_specs: Sequence[MeasureSpec]
     semantic_model_name: str
     agg_time_dimension: TimeDimensionReference
+    agg_time_dimension_grain: TimeGranularity
     non_additive_dimension_spec: Optional[NonAdditiveDimensionSpec] = None

--- a/tests_metricflow/integration/test_cases/itest_dimensions.yaml
+++ b/tests_metricflow/integration/test_cases/itest_dimensions.yaml
@@ -157,18 +157,17 @@ integration_test:
     GROUP BY
       v.ds
 ---
-# TODO: Test is currently broken.
-#integration_test:
-#  name: query_non_default_time_dimension_without_granularity
-#  description: Query just a time dimension, no granularity specified. Should assume default granularity for dimension.
-#  model: EXTENDED_DATE_MODEL
-#  group_bys: [ "booking__monthly_ds"]
-#  check_query: |
-#    SELECT
-#      ds AS booking__monthly_ds__month
-#    FROM {{ source_schema }}.fct_bookings_extended_monthly
-#    GROUP BY
-#      ds
+integration_test:
+  name: query_non_default_time_dimension_without_granularity
+  description: Query just a time dimension, no granularity specified. Should assume default granularity for dimension.
+  model: EXTENDED_DATE_MODEL
+  group_bys: [ "booking_monthly__ds"]
+  check_query: |
+    SELECT
+      ds AS booking_monthly__ds__month
+    FROM {{ source_schema }}.fct_bookings_extended_monthly
+    GROUP BY
+      ds
 ---
 integration_test:
   name: query_dimension_with_constraint_from_diff_source


### PR DESCRIPTION
This PR fixes a bug with `get_defined_time_granularity()` as demonstrated in https://github.com/dbt-labs/metricflow/pull/1482.

This also changes the signature of `DataflowPlanBuilder.__get_required_and_extraneous_linkable_specs()` to pass in a more complete object (`measure_spec_properties`) so that a call to `get_defined_time_granularity()` is not required.