### PR TITLE
Update `LinkableSpecName.from_name` to parse custom grains

### DIFF
--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -229,7 +229,9 @@ class SemanticModelLookup:
             semantic_models_for_dimension = self._dimension_index.get(dim.reference, []) + [semantic_model]
             self._dimension_index[dim.reference] = semantic_models_for_dimension
 
-            if not StructuredLinkableSpecName.from_name(dim.name).is_element_name:
+            if not StructuredLinkableSpecName.from_name(
+                qualified_name=dim.name, custom_granularity_names=self.custom_granularity_names
+            ).is_element_name:
                 # TODO: [custom granularity] change this to an assertion once we're sure there aren't exceptions
                 logger.warning(
                     LazyFormat(

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -75,6 +75,11 @@ class SemanticModelLookup:
         self._measure_lookup = MeasureLookup(sorted_semantic_models, custom_granularities)
         self._dimension_lookup = DimensionLookup(sorted_semantic_models)
 
+    @property
+    def custom_granularity_names(self) -> Sequence[str]:
+        """Returns all the custom_granularity names."""
+        return list(self._custom_granularities.keys())
+
     def get_dimension_references(self) -> Sequence[DimensionReference]:
         """Retrieve all dimension references from the collection of semantic models."""
         return tuple(self._dimension_index.keys())

--- a/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
+++ b/metricflow-semantics/metricflow_semantics/model/semantics/semantic_model_lookup.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List, Optional, Sequence, Set
+from functools import cached_property
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
@@ -75,10 +76,10 @@ class SemanticModelLookup:
         self._measure_lookup = MeasureLookup(sorted_semantic_models, custom_granularities)
         self._dimension_lookup = DimensionLookup(sorted_semantic_models)
 
-    @property
-    def custom_granularity_names(self) -> Sequence[str]:
+    @cached_property
+    def custom_granularity_names(self) -> Tuple[str, ...]:
         """Returns all the custom_granularity names."""
-        return list(self._custom_granularities.keys())
+        return tuple(self._custom_granularities.keys())
 
     def get_dimension_references(self) -> Sequence[DimensionReference]:
         """Retrieve all dimension references from the collection of semantic models."""

--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 from typing import Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
@@ -34,6 +35,7 @@ class StructuredLinkableSpecName:
         self.date_part = date_part
 
     @staticmethod
+    @lru_cache
     def from_name(qualified_name: str, custom_granularity_names: Sequence[str]) -> StructuredLinkableSpecName:
         """Construct from a name e.g. listing__ds__month."""
         name_parts = qualified_name.split(DUNDER)
@@ -52,10 +54,13 @@ class StructuredLinkableSpecName:
         for granularity in TimeGranularity:
             if name_parts[-1] == granularity.value:
                 associated_granularity = granularity.value
+                break
 
-        for custom_grain in custom_granularity_names:
-            if name_parts[-1] == custom_grain:
-                associated_granularity = custom_grain
+        if associated_granularity is None:
+            for custom_grain in custom_granularity_names:
+                if name_parts[-1] == custom_grain:
+                    associated_granularity = custom_grain
+                    break
 
         # Has a time granularity
         if associated_granularity:

--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
@@ -34,7 +34,7 @@ class StructuredLinkableSpecName:
         self.date_part = date_part
 
     @staticmethod
-    def from_name(qualified_name: str) -> StructuredLinkableSpecName:
+    def from_name(qualified_name: str, custom_granularity_names: Sequence[str]) -> StructuredLinkableSpecName:
         """Construct from a name e.g. listing__ds__month."""
         name_parts = qualified_name.split(DUNDER)
 
@@ -48,24 +48,27 @@ class StructuredLinkableSpecName:
                     "Dunder syntax not supported for querying date_part. Use `group_by` object syntax instead."
                 )
 
-        associated_granularity = None
-        # TODO: [custom granularity] Update parsing to account for custom granularities
+        associated_granularity: Optional[str] = None
         for granularity in TimeGranularity:
             if name_parts[-1] == granularity.value:
-                associated_granularity = granularity
+                associated_granularity = granularity.value
+
+        for custom_grain in custom_granularity_names:
+            if name_parts[-1] == custom_grain:
+                associated_granularity = custom_grain
 
         # Has a time granularity
         if associated_granularity:
             #  e.g. "ds__month"
             if len(name_parts) == 2:
                 return StructuredLinkableSpecName(
-                    entity_link_names=(), element_name=name_parts[0], time_granularity_name=associated_granularity.value
+                    entity_link_names=(), element_name=name_parts[0], time_granularity_name=associated_granularity
                 )
             # e.g. "messages__ds__month"
             return StructuredLinkableSpecName(
                 entity_link_names=tuple(name_parts[:-2]),
                 element_name=name_parts[-2],
-                time_granularity_name=associated_granularity.value,
+                time_granularity_name=associated_granularity,
             )
 
         # e.g. "messages__ds"

--- a/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
+++ b/metricflow-semantics/metricflow_semantics/specs/patterns/typed_patterns.py
@@ -160,7 +160,10 @@ class GroupByMetricPattern(EntityLinkPattern):
                 "This should have been caught by validations."
             )
         group_by = metric_call_parameter_set.group_by[0]
-        structured_name = StructuredLinkableSpecName.from_name(group_by.element_name)
+        # custom_granularity_names is empty because we are not parsing any dimensions here with grain
+        structured_name = StructuredLinkableSpecName.from_name(
+            qualified_name=group_by.element_name, custom_granularity_names=()
+        )
         metric_subquery_entity_links = tuple(
             EntityReference(entity_name)
             for entity_name in (structured_name.entity_link_names + (structured_name.element_name,))

--- a/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
+++ b/metricflow-semantics/metricflow_semantics/specs/query_param_implementations.py
@@ -56,8 +56,10 @@ class TimeDimensionParameter(ProtocolHint[TimeDimensionQueryParameter]):
         if self.grain is not None:
             fields_to_compare.append(ParameterSetField.TIME_GRANULARITY)
 
-        # TODO: assert that the name does not include a time granularity marker
-        name_structure = StructuredLinkableSpecName.from_name(self.name.lower())
+        name_structure = StructuredLinkableSpecName.from_name(
+            qualified_name=self.name.lower(),
+            custom_granularity_names=semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
+        )
 
         return ResolverInputForGroupByItem(
             input_obj=self,
@@ -97,7 +99,10 @@ class DimensionOrEntityParameter(ProtocolHint[DimensionOrEntityQueryParameter]):
         TODO: Refine these query input classes so that this kind of thing is either enforced in self-documenting
         ways or removed from the codebase
         """
-        name_structure = StructuredLinkableSpecName.from_name(self.name.lower())
+        name_structure = StructuredLinkableSpecName.from_name(
+            qualified_name=self.name.lower(),
+            custom_granularity_names=semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
+        )
 
         return ResolverInputForGroupByItem(
             input_obj=self,

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_time_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_time_dimension.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.call_parameter_sets import (
     TimeDimensionCallParameterSet,
@@ -69,7 +69,7 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
         spec_resolution_lookup: FilterSpecResolutionLookUp,
         where_filter_location: WhereFilterLocation,
         rendered_spec_tracker: RenderedSpecTracker,
-        custom_granularity_names: Sequence[str],
+        custom_granularity_names: Tuple[str, ...],
     ):
         self._column_association_resolver = column_association_resolver
         self._resolved_spec_lookup = spec_resolution_lookup

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_time_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_time_dimension.py
@@ -69,11 +69,13 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
         spec_resolution_lookup: FilterSpecResolutionLookUp,
         where_filter_location: WhereFilterLocation,
         rendered_spec_tracker: RenderedSpecTracker,
+        custom_granularity_names: Sequence[str],
     ):
         self._column_association_resolver = column_association_resolver
         self._resolved_spec_lookup = spec_resolution_lookup
         self._where_filter_location = where_filter_location
         self._rendered_spec_tracker = rendered_spec_tracker
+        self._custom_granularity_names = custom_granularity_names
 
     def create(
         self,
@@ -90,7 +92,9 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
             )
 
         time_granularity_name = time_granularity_name.lower() if time_granularity_name else None
-        structured_name = StructuredLinkableSpecName.from_name(time_dimension_name.lower())
+        structured_name = StructuredLinkableSpecName.from_name(
+            qualified_name=time_dimension_name.lower(), custom_granularity_names=self._custom_granularity_names
+        )
 
         if (
             structured_name.time_granularity_name

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
@@ -8,6 +8,7 @@ import jinja2
 from dbt_semantic_interfaces.implementations.filters.where_filter import PydanticWhereFilterIntersection
 from dbt_semantic_interfaces.protocols import WhereFilter, WhereFilterIntersection
 
+from metricflow_semantics.model.semantics.semantic_model_lookup import SemanticModelLookup
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
     FilterSpecResolutionLookUp,
@@ -36,9 +37,11 @@ class WhereSpecFactory:
         self,
         column_association_resolver: ColumnAssociationResolver,
         spec_resolution_lookup: FilterSpecResolutionLookUp,
+        semantic_model_lookup: SemanticModelLookup,
     ) -> None:
         self._column_association_resolver = column_association_resolver
         self._spec_resolution_lookup = spec_resolution_lookup
+        self._semantic_model_lookup = semantic_model_lookup
 
     def create_from_where_filter(  # noqa: D102
         self,
@@ -73,6 +76,7 @@ class WhereSpecFactory:
                 spec_resolution_lookup=self._spec_resolution_lookup,
                 where_filter_location=filter_location,
                 rendered_spec_tracker=rendered_spec_tracker,
+                custom_granularity_names=self._semantic_model_lookup.custom_granularity_names,
             )
             entity_factory = WhereFilterEntityFactory(
                 column_association_resolver=self._column_association_resolver,

--- a/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/test_where_filter_spec.py
@@ -136,6 +136,7 @@ def test_dimension_in_filter(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter_intersection(
         filter_location=EXAMPLE_FILTER_LOCATION,
         filter_intersection=create_where_filter_intersection("{{ Dimension('listing__country_latest') }} = 'US'"),
@@ -196,6 +197,7 @@ def test_dimension_in_filter_with_grain(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter_intersection(
         filter_location=EXAMPLE_FILTER_LOCATION,
         filter_intersection=create_where_filter_intersection(
@@ -262,6 +264,7 @@ def test_time_dimension_in_filter(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter_intersection(
         filter_location=EXAMPLE_FILTER_LOCATION,
         filter_intersection=create_where_filter_intersection(
@@ -328,6 +331,7 @@ def test_time_dimension_with_grain_in_name(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter_intersection(
         filter_location=EXAMPLE_FILTER_LOCATION,
         filter_intersection=create_where_filter_intersection(
@@ -395,6 +399,7 @@ def test_date_part_in_filter(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter_intersection(
         filter_location=EXAMPLE_FILTER_LOCATION,
         filter_intersection=create_where_filter_intersection(
@@ -486,6 +491,7 @@ def resolved_spec_lookup(
 def test_date_part_and_grain_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     resolved_spec_lookup: FilterSpecResolutionLookUp,
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
     where_sql: str,
 ) -> None:
     where_filter = PydanticWhereFilter(where_sql_template=where_sql)
@@ -493,6 +499,7 @@ def test_date_part_and_grain_in_filter(  # noqa: D103
     where_filter_spec = WhereSpecFactory(
         column_association_resolver=column_association_resolver,
         spec_resolution_lookup=resolved_spec_lookup,
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter(EXAMPLE_FILTER_LOCATION, where_filter)
 
     assert where_filter_spec.where_sql == "metric_time__extract_year = '2020'"
@@ -523,6 +530,7 @@ def test_date_part_and_grain_in_filter(  # noqa: D103
 def test_date_part_less_than_grain_in_filter(  # noqa: D103
     column_association_resolver: ColumnAssociationResolver,
     resolved_spec_lookup: FilterSpecResolutionLookUp,
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
     where_sql: str,
 ) -> None:
     where_filter = PydanticWhereFilter(where_sql_template=where_sql)
@@ -530,6 +538,7 @@ def test_date_part_less_than_grain_in_filter(  # noqa: D103
     where_filter_spec = WhereSpecFactory(
         column_association_resolver=column_association_resolver,
         spec_resolution_lookup=resolved_spec_lookup,
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter(EXAMPLE_FILTER_LOCATION, where_filter)
 
     assert where_filter_spec.where_sql == "metric_time__extract_day = '2020'"
@@ -587,6 +596,7 @@ def test_entity_in_filter(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter(filter_location=EXAMPLE_FILTER_LOCATION, where_filter=where_filter)
 
     assert where_filter_spec.where_sql == "listing__user == 'example_user_id'"
@@ -646,6 +656,7 @@ def test_metric_in_filter(  # noqa: D103
             ),
             semantic_manifest_lookup=simple_semantic_manifest_lookup,
         ),
+        semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
     ).create_from_where_filter(filter_location=EXAMPLE_FILTER_LOCATION, where_filter=where_filter)
 
     assert where_filter_spec.where_sql == "listing__bookings > 2"
@@ -715,6 +726,7 @@ def test_dimension_time_dimension_parity(  # noqa: D103
                 ),
                 non_parsable_resolutions=(),
             ),
+            semantic_model_lookup=simple_semantic_manifest_lookup.semantic_model_lookup,
         ).create_from_where_filter(filter_location, where_filter)
 
     time_dimension_spec = get_spec("TimeDimension('metric_time', 'week', date_part_name='year')")

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -165,6 +165,7 @@ class DataflowPlanBuilder:
         filter_spec_factory = WhereSpecFactory(
             column_association_resolver=self._column_association_resolver,
             spec_resolution_lookup=query_spec.filter_spec_resolution_lookup,
+            semantic_model_lookup=self._semantic_model_lookup,
         )
 
         query_level_filter_specs = tuple(
@@ -409,7 +410,9 @@ class DataflowPlanBuilder:
             queried_linkable_specs=queried_linkable_specs,
         )
         # TODO: [custom granularity] change this to an assertion once we're sure there aren't exceptions
-        if not StructuredLinkableSpecName.from_name(conversion_type_params.entity).is_element_name:
+        if not StructuredLinkableSpecName.from_name(
+            qualified_name=conversion_type_params.entity, custom_granularity_names=()
+        ).is_element_name:
             logger.warning(
                 LazyFormat(
                     lambda: f"Found additional annotations in type param entity name `{conversion_type_params.entity}`, which "
@@ -806,6 +809,7 @@ class DataflowPlanBuilder:
                 column_association_resolver=self._column_association_resolver,
                 spec_resolution_lookup=query_spec.filter_spec_resolution_lookup
                 or FilterSpecResolutionLookUp.empty_instance(),
+                semantic_model_lookup=self._semantic_model_lookup,
             )
 
             query_level_filter_specs = filter_spec_factory.create_from_where_filter_intersection(

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -629,6 +629,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                                     else None
                                 ),
                             ).qualified_name,
+                            entity_links=(),
                             description="Event time for metrics.",
                             metadata=None,
                             type_params=PydanticDimensionTypeParams(
@@ -658,7 +659,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                                 dimension_reference=linkable_dimension.reference,
                             ),
                             entity_links=path_key.entity_links,
-                            custom_granularity_names=self._semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
                         )
                     )
         return sorted(dimensions, key=lambda dimension: dimension.qualified_name)
@@ -676,7 +676,6 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                             semantic_model=semantic_model, dimension_reference=dimension_reference
                         ),
                         entity_links=(SemanticModelHelper.resolved_primary_entity(semantic_model),),
-                        custom_granularity_names=self._semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
                     )
                 )
 

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -658,6 +658,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                                 dimension_reference=linkable_dimension.reference,
                             ),
                             entity_links=path_key.entity_links,
+                            custom_granularity_names=self._semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
                         )
                     )
         return sorted(dimensions, key=lambda dimension: dimension.qualified_name)
@@ -675,6 +676,7 @@ class MetricFlowEngine(AbstractMetricFlowEngine):
                             semantic_model=semantic_model, dimension_reference=dimension_reference
                         ),
                         entity_links=(SemanticModelHelper.resolved_primary_entity(semantic_model),),
+                        custom_granularity_names=self._semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
                     )
                 )
 

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -84,10 +84,14 @@ class Dimension:
     is_partition: bool = False
     expr: Optional[str] = None
     label: Optional[str] = None
+    _possible_custom_granularity_names: Sequence[str] = ()
 
     @classmethod
     def from_pydantic(
-        cls, pydantic_dimension: SemanticManifestDimension, entity_links: Tuple[EntityReference, ...]
+        cls,
+        pydantic_dimension: SemanticManifestDimension,
+        entity_links: Tuple[EntityReference, ...],
+        custom_granularity_names: Sequence[str],
     ) -> Dimension:
         """Build from pydantic Dimension and entity_key."""
         qualified_name = DimensionSpec(element_name=pydantic_dimension.name, entity_links=entity_links).qualified_name
@@ -107,6 +111,7 @@ class Dimension:
             is_partition=pydantic_dimension.is_partition,
             expr=pydantic_dimension.expr,
             label=pydantic_dimension.label,
+            _possible_custom_granularity_names=custom_granularity_names,
         )
 
     @property
@@ -120,7 +125,9 @@ class Dimension:
         Dimension set has de-duplicated TimeDimensions such that you never have more than one granularity
         in your set for each TimeDimension.
         """
-        return StructuredLinkableSpecName.from_name(qualified_name=self.qualified_name).granularity_free_qualified_name
+        return StructuredLinkableSpecName.from_name(
+            qualified_name=self.qualified_name, custom_granularity_names=self._possible_custom_granularity_names
+        ).granularity_free_qualified_name
 
 
 @dataclass(frozen=True)

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -79,19 +79,18 @@ class Dimension:
     qualified_name: str
     description: Optional[str]
     type: DimensionType
+    entity_links: Tuple[EntityReference, ...]
     type_params: Optional[DimensionTypeParams]
     metadata: Optional[Metadata]
     is_partition: bool = False
     expr: Optional[str] = None
     label: Optional[str] = None
-    _possible_custom_granularity_names: Sequence[str] = ()
 
     @classmethod
     def from_pydantic(
         cls,
         pydantic_dimension: SemanticManifestDimension,
         entity_links: Tuple[EntityReference, ...],
-        custom_granularity_names: Sequence[str],
     ) -> Dimension:
         """Build from pydantic Dimension and entity_key."""
         qualified_name = DimensionSpec(element_name=pydantic_dimension.name, entity_links=entity_links).qualified_name
@@ -111,7 +110,7 @@ class Dimension:
             is_partition=pydantic_dimension.is_partition,
             expr=pydantic_dimension.expr,
             label=pydantic_dimension.label,
-            _possible_custom_granularity_names=custom_granularity_names,
+            entity_links=entity_links,
         )
 
     @property
@@ -125,9 +124,9 @@ class Dimension:
         Dimension set has de-duplicated TimeDimensions such that you never have more than one granularity
         in your set for each TimeDimension.
         """
-        return StructuredLinkableSpecName.from_name(
-            qualified_name=self.qualified_name, custom_granularity_names=self._possible_custom_granularity_names
-        ).granularity_free_qualified_name
+        return StructuredLinkableSpecName(
+            entity_link_names=tuple(e.element_name for e in self.entity_links), element_name=self.name
+        ).qualified_name
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Context

With the addition of custom granularities, when we parse the dundered names via `LinkableSpecName.from_name`, we need to be able to know whether the grain provided is a custom grain. This means we need to pass that information through to this classmethod.

Resolves SL-2971
