### PR TITLE
Bug fix: Generate correct instances for `JoinOnEntitiesNode`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,11 @@ populate-persistent-source-schemas:
 .PHONY: test-snap
 test-snap:
 	make test ADDITIONAL_PYTEST_OPTIONS=--overwrite-snapshots
+
+.PHONY: testx
+testx:
+	make test ADDITIONAL_PYTEST_OPTIONS=-x
+
+.PHONY: testx-snap
+testx-snap:
+	make test ADDITIONAL_PYTEST_OPTIONS='-x --overwrite-snapshots'

--- a/metricflow-semantics/metricflow_semantics/specs/dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/dimension_spec.py
@@ -43,3 +43,6 @@ class DimensionSpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
         return ElementPathKey(
             element_name=self.element_name, element_type=LinkableElementType.DIMENSION, entity_links=self.entity_links
         )
+
+    def with_entity_prefix(self, entity_prefix: EntityReference) -> DimensionSpec:  # noqa: D102
+        return DimensionSpec(element_name=self.element_name, entity_links=(entity_prefix,) + self.entity_links)

--- a/metricflow-semantics/metricflow_semantics/specs/entity_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/entity_spec.py
@@ -53,6 +53,9 @@ class EntitySpec(LinkableInstanceSpec, SerializableDataclass):  # noqa: D101
             element_name=self.element_name, element_type=LinkableElementType.ENTITY, entity_links=self.entity_links
         )
 
+    def with_entity_prefix(self, entity_prefix: EntityReference) -> EntitySpec:  # noqa: D102
+        return EntitySpec(element_name=self.element_name, entity_links=(entity_prefix,) + self.entity_links)
+
 
 @dataclass(frozen=True)
 class LinklessEntitySpec(EntitySpec, SerializableDataclass):

--- a/metricflow-semantics/metricflow_semantics/specs/group_by_metric_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/group_by_metric_spec.py
@@ -111,3 +111,10 @@ class GroupByMetricSpec(LinkableInstanceSpec, SerializableDataclass):
         return ElementPathKey(
             element_name=self.element_name, element_type=LinkableElementType.METRIC, entity_links=self.entity_links
         )
+
+    def with_entity_prefix(self, entity_prefix: EntityReference) -> GroupByMetricSpec:  # noqa: D102
+        return GroupByMetricSpec(
+            element_name=self.element_name,
+            entity_links=(entity_prefix,) + self.entity_links,
+            metric_subquery_entity_links=self.metric_subquery_entity_links,
+        )

--- a/metricflow-semantics/metricflow_semantics/specs/instance_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/instance_spec.py
@@ -136,5 +136,10 @@ class LinkableInstanceSpec(InstanceSpec, ABC):
         """Return the ElementPathKey representation of the LinkableInstanceSpec subtype."""
         raise NotImplementedError()
 
+    @abstractmethod
+    def with_entity_prefix(self, entity_prefix: EntityReference) -> LinkableInstanceSpec:
+        """Add the selected entity prefix to the start of the entity links."""
+        raise NotImplementedError()
+
 
 SelfTypeT = TypeVar("SelfTypeT", bound="LinkableInstanceSpec")

--- a/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
+++ b/metricflow-semantics/metricflow_semantics/specs/time_dimension_spec.py
@@ -235,3 +235,12 @@ class TimeDimensionSpec(DimensionSpec):  # noqa: D101
     @property
     def is_metric_time(self) -> bool:  # noqa: D102
         return self.element_name == METRIC_TIME_ELEMENT_NAME
+
+    def with_entity_prefix(self, entity_prefix: EntityReference) -> TimeDimensionSpec:  # noqa: D102
+        return TimeDimensionSpec(
+            element_name=self.element_name,
+            entity_links=(entity_prefix,) + self.entity_links,
+            time_granularity=self.time_granularity,
+            date_part=self.date_part,
+            aggregation_state=self.aggregation_state,
+        )

--- a/metricflow/dataflow/builder/dataflow_plan_builder.py
+++ b/metricflow/dataflow/builder/dataflow_plan_builder.py
@@ -221,12 +221,12 @@ class DataflowPlanBuilder:
     def _optimize_plan(self, plan: DataflowPlan, optimizations: FrozenSet[DataflowPlanOptimization]) -> DataflowPlan:
         optimizer_factory = DataflowPlanOptimizerFactory(self._node_data_set_resolver)
         for optimizer in optimizer_factory.get_optimizers(optimizations):
-            logger.debug(LazyFormat(lambda: f"Applying {optimizer.__class__.__name__}"))
+            logger.debug(LazyFormat(lambda: f"Applying optimizer: {optimizer.__class__.__name__}"))
             try:
                 plan = optimizer.optimize(plan)
                 logger.debug(
                     LazyFormat(
-                        lambda: f"After applying {optimizer.__class__.__name__}, the dataflow plan is:\n"
+                        lambda: f"After applying optimizer {optimizer.__class__.__name__}, the dataflow plan is:\n"
                         f"{indent(plan.structure_text())}"
                     )
                 )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -25,13 +25,12 @@ from metricflow_semantics.instances import (
     MetadataInstance,
     MetricInstance,
     TimeDimensionInstance,
+    group_instances_by_type,
 )
 from metricflow_semantics.mf_logging.formatting import indent
 from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
-from metricflow_semantics.specs.column_assoc import (
-    ColumnAssociationResolver,
-)
+from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
 from metricflow_semantics.specs.group_by_metric_spec import GroupByMetricSpec
 from metricflow_semantics.specs.instance_spec import InstanceSpec
 from metricflow_semantics.specs.measure_spec import MeasureSpec
@@ -72,7 +71,6 @@ from metricflow.dataset.sql_dataset import SqlDataSet
 from metricflow.plan_conversion.convert_to_sql_plan import ConvertToSqlPlanResult
 from metricflow.plan_conversion.instance_converters import (
     AddGroupByMetric,
-    AddLinkToLinkableElements,
     AddMetadata,
     AddMetrics,
     AliasAggregatedMeasures,
@@ -229,7 +227,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             sql_node = optimizer.optimize(sql_node)
             logger.debug(
                 LazyFormat(
-                    lambda: f"After applying {optimizer.__class__.__name__}, the SQL query plan is:\n"
+                    lambda: f"After applying optimizer {optimizer.__class__.__name__}, the SQL query plan is:\n"
                     f"{indent(sql_node.structure_text())}"
                 )
             )
@@ -456,69 +454,17 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
         )
 
     def visit_join_on_entities_node(self, node: JoinOnEntitiesNode) -> SqlDataSet:
-        """Generates the query that realizes the behavior of the JoinToStandardOutputNode."""
-        # Keep a mapping between the table aliases that would be used in the query and the MDO instances in that source.
-        # e.g. when building "FROM from_table a JOIN right_table b", the value for key "a" would be the instances in
-        # "from_table"
-        table_alias_to_instance_set: OrderedDict[str, InstanceSet] = OrderedDict()
-
-        # Convert the dataflow from the left node to a DataSet and add context for it to table_alias_to_instance_set
-        # A DataSet is a bundle of the SQL query (in object form) and the MDO instances that the SQL query contains.
+        """Generates the query that realizes the behavior of the JoinOnEntitiesNode."""
         from_data_set = node.left_node.accept(self)
         from_data_set_alias = self._next_unique_table_alias()
-        table_alias_to_instance_set[from_data_set_alias] = from_data_set.instance_set
-
-        # Build the join descriptions for the SqlQueryPlan - different from node.join_descriptions which are the join
-        # descriptions from the dataflow plan.
-        sql_join_descs: List[SqlJoinDescription] = []
-
-        # The dataflow plan describes how the data sets coming from the parent nodes should be joined together. Use
-        # those descriptions to convert them to join descriptions for the SQL query plan.
-        for join_description in node.join_targets:
-            join_on_entity = join_description.join_on_entity
-
-            right_node_to_join: DataflowPlanNode = join_description.join_node
-            right_data_set: SqlDataSet = right_node_to_join.accept(self)
-            right_data_set_alias = self._next_unique_table_alias()
-
-            sql_join_desc = SqlQueryPlanJoinBuilder.make_base_output_join_description(
-                left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
-                right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
-                join_description=join_description,
-            )
-            sql_join_descs.append(sql_join_desc)
-
-            if join_on_entity:
-                # Remove the linkable instances with the join_on_entity as the leading link as the next step adds the
-                # link. This is to avoid cases where there is a primary entity and a dimension in the data set, and we
-                # create an instance in the next step that has the same entity link.
-                # e.g. a data set has the dimension "listing__country_latest" and "listing" is a primary entity in the
-                # data set. The next step would create an instance like "listing__listing__country_latest" without this
-                # filter.
-                right_data_set_instance_set_filtered = FilterLinkableInstancesWithLeadingLink(
-                    entity_link=join_on_entity,
-                ).transform(right_data_set.instance_set)
-
-                # After the right data set is joined to the "from" data set, we need to change the links for some of the
-                # instances that represent the right data set. For example, if the "from" data set contains the "bookings"
-                # measure instance and the right dataset contains the "country" dimension instance, then after the join,
-                # the output data set should have the "country" dimension instance with the "user_id" entity link
-                # (if "user_id" equality was the join condition). "country" -> "user_id__country"
-                right_data_set_instance_set_after_join = right_data_set_instance_set_filtered.transform(
-                    AddLinkToLinkableElements(join_on_entity=join_on_entity)
-                )
-            else:
-                right_data_set_instance_set_after_join = right_data_set.instance_set
-            table_alias_to_instance_set[right_data_set_alias] = right_data_set_instance_set_after_join
-
-        from_data_set_output_instance_set = from_data_set.instance_set.transform(
-            FilterElements(include_specs=from_data_set.instance_set.spec_set)
-        )
 
         # Change the aggregation state for the measures to be partially aggregated if it was previously aggregated
         # since we removed the entities and added the dimensions. The dimensions could have the same value for
         # multiple rows, so we'll need to re-aggregate.
-        from_data_set_output_instance_set = from_data_set_output_instance_set.transform(
+        from_data_set_output_instance_set = from_data_set.instance_set.transform(
+            # TODO: is this filter doing anything? seems like no?
+            FilterElements(include_specs=from_data_set.instance_set.spec_set)
+        ).transform(
             ChangeMeasureAggregationState(
                 {
                     AggregationState.NON_AGGREGATED: AggregationState.NON_AGGREGATED,
@@ -527,18 +473,71 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
                 }
             )
         )
+        instances_to_build_simple_select_columns_for = OrderedDict(
+            {from_data_set_alias: from_data_set_output_instance_set}
+        )
 
-        table_alias_to_instance_set[from_data_set_alias] = from_data_set_output_instance_set
+        # Build SQL join description, instance set, and select columns for each join target.
+        output_instance_set = from_data_set_output_instance_set
+        select_columns: Tuple[SqlSelectColumn, ...] = ()
+        sql_join_descs: List[SqlJoinDescription] = []
+        for join_description in node.join_targets:
+            join_on_entity = join_description.join_on_entity
+            right_node_to_join = join_description.join_node
+            right_data_set: SqlDataSet = right_node_to_join.accept(self)
+            right_data_set_alias = self._next_unique_table_alias()
 
-        # Construct the data set that contains the updated instances and the SQL nodes that should go in the various
-        # clauses.
+            # Build join description.
+            sql_join_desc = SqlQueryPlanJoinBuilder.make_base_output_join_description(
+                left_data_set=AnnotatedSqlDataSet(data_set=from_data_set, alias=from_data_set_alias),
+                right_data_set=AnnotatedSqlDataSet(data_set=right_data_set, alias=right_data_set_alias),
+                join_description=join_description,
+            )
+            sql_join_descs.append(sql_join_desc)
+
+            if join_on_entity:
+                # Remove any instances that already have the join_on_entity as the leading link. This will prevent a duplicate
+                # entity link when we add it in the next step.
+                right_instance_set_filtered = FilterLinkableInstancesWithLeadingLink(join_on_entity).transform(
+                    right_data_set.instance_set
+                )
+
+                # After the right data set is joined, update the entity links to indicate that joining on the entity was
+                # required to reach the spec. If the "country" dimension was joined and "user_id" is the join_on_entity,
+                # then the joined data set should have the "user__country" dimension.
+                new_instances: Tuple[MdoInstance, ...] = ()
+                for original_instance in right_instance_set_filtered.linkable_instances:
+                    if original_instance.spec == join_on_entity:
+                        continue
+                    new_instance = original_instance.with_entity_prefix(
+                        join_on_entity.reference, column_association_resolver=self._column_association_resolver
+                    )
+                    # Build new select column using the old column name as the expr and the new column name as the alias.
+                    select_column = SqlSelectColumn(
+                        expr=SqlColumnReferenceExpression.from_table_and_column_names(
+                            table_alias=right_data_set_alias,
+                            column_name=original_instance.associated_column.column_name,
+                        ),
+                        column_alias=new_instance.associated_column.column_name,
+                    )
+                    new_instances += (new_instance,)
+                    select_columns += (select_column,)
+                right_instance_set_after_join = group_instances_by_type(new_instances)
+            else:
+                right_instance_set_after_join = right_data_set.instance_set
+                instances_to_build_simple_select_columns_for[right_data_set_alias] = right_instance_set_after_join
+
+            output_instance_set = InstanceSet.merge([output_instance_set, right_instance_set_after_join])
+
+        select_columns += create_select_columns_for_instance_sets(
+            column_resolver=self._column_association_resolver,
+            table_alias_to_instance_set=instances_to_build_simple_select_columns_for,
+        )
         return SqlDataSet(
-            instance_set=InstanceSet.merge(list(table_alias_to_instance_set.values())),
+            instance_set=output_instance_set,
             sql_select_node=SqlSelectStatementNode.create(
                 description=node.description,
-                select_columns=create_select_columns_for_instance_sets(
-                    self._column_association_resolver, table_alias_to_instance_set
-                ),
+                select_columns=select_columns,
                 from_source=from_data_set.checked_sql_select_node,
                 from_source_alias=from_data_set_alias,
                 join_descs=tuple(sql_join_descs),

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -498,17 +498,15 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             if join_on_entity:
                 # Remove any instances that already have the join_on_entity as the leading link. This will prevent a duplicate
                 # entity link when we add it in the next step.
-                right_instance_set_filtered = FilterLinkableInstancesWithLeadingLink(join_on_entity).transform(
-                    right_data_set.instance_set
-                )
+                right_instance_set_filtered = FilterLinkableInstancesWithLeadingLink(
+                    join_on_entity.reference
+                ).transform(right_data_set.instance_set)
 
                 # After the right data set is joined, update the entity links to indicate that joining on the entity was
                 # required to reach the spec. If the "country" dimension was joined and "user_id" is the join_on_entity,
                 # then the joined data set should have the "user__country" dimension.
                 new_instances: Tuple[MdoInstance, ...] = ()
                 for original_instance in right_instance_set_filtered.linkable_instances:
-                    if original_instance.spec == join_on_entity:
-                        continue
                     new_instance = original_instance.with_entity_prefix(
                         join_on_entity.reference, column_association_resolver=self._column_association_resolver
                     )

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -87,7 +87,7 @@ from metricflow.plan_conversion.instance_converters import (
     RemoveMeasures,
     RemoveMetrics,
     UpdateMeasureFillNullsWith,
-    create_select_columns_for_instance_sets,
+    create_simple_select_columns_for_instance_sets,
 )
 from metricflow.plan_conversion.select_column_gen import (
     SelectColumnSet,
@@ -345,7 +345,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             complete_outer_where_filter = where_constraint_exprs[0]
 
         outer_query_output_instance_set = InstanceSet(time_dimension_instances=agg_time_dimension_instances)
-        outer_query_select_columns = create_select_columns_for_instance_sets(
+        outer_query_select_columns = create_simple_select_columns_for_instance_sets(
             column_resolver=self._column_association_resolver,
             table_alias_to_instance_set=OrderedDict({inner_query_alias: outer_query_output_instance_set}),
         )
@@ -444,7 +444,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             instance_set=output_instance_set,
             sql_select_node=SqlSelectStatementNode.create(
                 description=node.description,
-                select_columns=create_select_columns_for_instance_sets(
+                select_columns=create_simple_select_columns_for_instance_sets(
                     self._column_association_resolver, table_alias_to_instance_set
                 ),
                 from_source=time_spine_data_set.checked_sql_select_node,
@@ -529,7 +529,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
 
             output_instance_set = InstanceSet.merge([output_instance_set, right_instance_set_after_join])
 
-        select_columns += create_select_columns_for_instance_sets(
+        select_columns += create_simple_select_columns_for_instance_sets(
             column_resolver=self._column_association_resolver,
             table_alias_to_instance_set=instances_to_build_simple_select_columns_for,
         )
@@ -1384,7 +1384,7 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
             metric_instances=parent_data_set.instance_set.metric_instances,
             metadata_instances=parent_data_set.instance_set.metadata_instances,
         )
-        parent_select_columns = create_select_columns_for_instance_sets(
+        parent_select_columns = create_simple_select_columns_for_instance_sets(
             self._column_association_resolver, OrderedDict({parent_alias: parent_instance_set})
         )
 

--- a/metricflow/plan_conversion/instance_converters.py
+++ b/metricflow/plan_conversion/instance_converters.py
@@ -935,7 +935,7 @@ class ConvertToMetadata(InstanceSetTransform[InstanceSet]):
         )
 
 
-def create_select_columns_for_instance_sets(
+def create_simple_select_columns_for_instance_sets(
     column_resolver: ColumnAssociationResolver,
     table_alias_to_instance_set: OrderedDict[str, InstanceSet],
 ) -> Tuple[SqlSelectColumn, ...]:

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -133,7 +133,13 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         # SqlExpressionNode.
 
         if len(pruned_select_columns) == 0:
-            raise RuntimeError("All columns have been pruned - this indicates an bug in the pruner or in the inputs.")
+            raise RuntimeError(
+                "All columns have been removed - this indicates an bug in the pruner or in the inputs.\n"
+                f"Original column aliases: {[col.column_alias for col in node.select_columns]}\n"
+                f"Required column aliases: {self._required_column_aliases}\n"
+                f"Group bys: {node.group_bys}\n"
+                f"Distinct: {node.distinct}"
+            )
 
         # Based on the expressions in this select statement, figure out what column aliases are needed in the sources of
         # this query (i.e. tables or sub-queries in the FROM or JOIN clauses).

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/BigQuery/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Databricks/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/DuckDB/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Postgres/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Redshift/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Snowflake/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
+++ b/tests_metricflow/snapshots/test_custom_granularity.py/SqlQueryPlan/Trino/test_simple_metric_with_multi_hop_custom_granularity__plan0.sql
@@ -22,9 +22,9 @@ FROM (
       FROM (
         -- Join Standard Outputs
         SELECT
-          subq_2.ds_partitioned__day AS ds_partitioned__day
-          , subq_9.user__ds__day AS listing__user__ds__day
+          subq_9.user__ds__day AS listing__user__ds__day
           , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+          , subq_2.ds_partitioned__day AS ds_partitioned__day
           , subq_2.listing AS listing
           , subq_2.bookings AS bookings
         FROM (
@@ -238,61 +238,7 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_4.ds__day AS ds__day
-              , subq_4.ds__week AS ds__week
-              , subq_4.ds__month AS ds__month
-              , subq_4.ds__quarter AS ds__quarter
-              , subq_4.ds__year AS ds__year
-              , subq_4.ds__extract_year AS ds__extract_year
-              , subq_4.ds__extract_quarter AS ds__extract_quarter
-              , subq_4.ds__extract_month AS ds__extract_month
-              , subq_4.ds__extract_day AS ds__extract_day
-              , subq_4.ds__extract_dow AS ds__extract_dow
-              , subq_4.ds__extract_doy AS ds__extract_doy
-              , subq_4.created_at__day AS created_at__day
-              , subq_4.created_at__week AS created_at__week
-              , subq_4.created_at__month AS created_at__month
-              , subq_4.created_at__quarter AS created_at__quarter
-              , subq_4.created_at__year AS created_at__year
-              , subq_4.created_at__extract_year AS created_at__extract_year
-              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-              , subq_4.created_at__extract_month AS created_at__extract_month
-              , subq_4.created_at__extract_day AS created_at__extract_day
-              , subq_4.created_at__extract_dow AS created_at__extract_dow
-              , subq_4.created_at__extract_doy AS created_at__extract_doy
-              , subq_4.listing__ds__day AS listing__ds__day
-              , subq_4.listing__ds__week AS listing__ds__week
-              , subq_4.listing__ds__month AS listing__ds__month
-              , subq_4.listing__ds__quarter AS listing__ds__quarter
-              , subq_4.listing__ds__year AS listing__ds__year
-              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-              , subq_4.listing__created_at__day AS listing__created_at__day
-              , subq_4.listing__created_at__week AS listing__created_at__week
-              , subq_4.listing__created_at__month AS listing__created_at__month
-              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-              , subq_4.listing__created_at__year AS listing__created_at__year
-              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-              , subq_4.metric_time__day AS metric_time__day
-              , subq_4.metric_time__week AS metric_time__week
-              , subq_4.metric_time__month AS metric_time__month
-              , subq_4.metric_time__quarter AS metric_time__quarter
-              , subq_4.metric_time__year AS metric_time__year
-              , subq_4.metric_time__extract_year AS metric_time__extract_year
-              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-              , subq_4.metric_time__extract_month AS metric_time__extract_month
-              , subq_4.metric_time__extract_day AS metric_time__extract_day
-              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+              subq_7.home_state AS user__home_state
               , subq_7.ds__day AS user__ds__day
               , subq_7.ds__week AS user__ds__week
               , subq_7.ds__month AS user__ds__month
@@ -391,6 +337,61 @@ FROM (
               , subq_7.metric_time__extract_day AS user__metric_time__extract_day
               , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
               , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+              , subq_4.ds__day AS ds__day
+              , subq_4.ds__week AS ds__week
+              , subq_4.ds__month AS ds__month
+              , subq_4.ds__quarter AS ds__quarter
+              , subq_4.ds__year AS ds__year
+              , subq_4.ds__extract_year AS ds__extract_year
+              , subq_4.ds__extract_quarter AS ds__extract_quarter
+              , subq_4.ds__extract_month AS ds__extract_month
+              , subq_4.ds__extract_day AS ds__extract_day
+              , subq_4.ds__extract_dow AS ds__extract_dow
+              , subq_4.ds__extract_doy AS ds__extract_doy
+              , subq_4.created_at__day AS created_at__day
+              , subq_4.created_at__week AS created_at__week
+              , subq_4.created_at__month AS created_at__month
+              , subq_4.created_at__quarter AS created_at__quarter
+              , subq_4.created_at__year AS created_at__year
+              , subq_4.created_at__extract_year AS created_at__extract_year
+              , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+              , subq_4.created_at__extract_month AS created_at__extract_month
+              , subq_4.created_at__extract_day AS created_at__extract_day
+              , subq_4.created_at__extract_dow AS created_at__extract_dow
+              , subq_4.created_at__extract_doy AS created_at__extract_doy
+              , subq_4.listing__ds__day AS listing__ds__day
+              , subq_4.listing__ds__week AS listing__ds__week
+              , subq_4.listing__ds__month AS listing__ds__month
+              , subq_4.listing__ds__quarter AS listing__ds__quarter
+              , subq_4.listing__ds__year AS listing__ds__year
+              , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+              , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+              , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+              , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+              , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+              , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+              , subq_4.listing__created_at__day AS listing__created_at__day
+              , subq_4.listing__created_at__week AS listing__created_at__week
+              , subq_4.listing__created_at__month AS listing__created_at__month
+              , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+              , subq_4.listing__created_at__year AS listing__created_at__year
+              , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+              , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+              , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+              , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+              , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+              , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+              , subq_4.metric_time__day AS metric_time__day
+              , subq_4.metric_time__week AS metric_time__week
+              , subq_4.metric_time__month AS metric_time__month
+              , subq_4.metric_time__quarter AS metric_time__quarter
+              , subq_4.metric_time__year AS metric_time__year
+              , subq_4.metric_time__extract_year AS metric_time__extract_year
+              , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+              , subq_4.metric_time__extract_month AS metric_time__extract_month
+              , subq_4.metric_time__extract_day AS metric_time__extract_day
+              , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+              , subq_4.metric_time__extract_doy AS metric_time__extract_doy
               , subq_4.listing AS listing
               , subq_4.user AS user
               , subq_4.listing__user AS listing__user
@@ -400,7 +401,6 @@ FROM (
               , subq_4.listing__country_latest AS listing__country_latest
               , subq_4.listing__is_lux_latest AS listing__is_lux_latest
               , subq_4.listing__capacity_latest AS listing__capacity_latest
-              , subq_7.home_state AS user__home_state
               , subq_4.listings AS listings
               , subq_4.largest_listing AS largest_listing
               , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
     FROM (
       -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.sql
@@ -31,9 +31,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.ds__day AS ds__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.ds__day AS ds__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'ds__day', 'listing']
@@ -405,9 +405,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_12.ds__day AS ds__day
+            subq_15.country_latest AS listing__country_latest
+            , subq_12.ds__day AS ds__day
             , subq_12.listing AS listing
-            , subq_15.country_latest AS listing__country_latest
             , subq_12.views AS views
           FROM (
             -- Pass Only Elements: ['views', 'ds__day', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.sql
@@ -13,8 +13,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.bookings AS bookings
       , subq_1.bookers AS bookers
     FROM (

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_simple_expr__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_simple_expr__plan0.sql
@@ -12,8 +12,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_1.listing AS listing
-      , subq_3.country_latest AS listing__country_latest
+      subq_3.country_latest AS listing__country_latest
+      , subq_1.listing AS listing
       , subq_1.booking_value AS booking_value
     FROM (
       -- Pass Only Elements: ['booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimension_with_joined_where_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimension_with_joined_where_constraint__plan0.sql
@@ -64,7 +64,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -117,7 +118,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimension_with_joined_where_constraint__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimension_with_joined_where_constraint__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.country AS listing__country_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.country AS listing__country_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_1.listing AS listing
-  , subq_3.country_latest AS listing__country_latest
+  subq_3.country_latest AS listing__country_latest
   , subq_5.country_latest AS listing__country_latest
+  , subq_1.listing AS listing
   , subq_1.bookings AS bookings
 FROM (
   -- Pass Only Elements: ['bookings', 'listing']

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0_optimized.sql
@@ -1,8 +1,8 @@
 -- Join Standard Outputs
 SELECT
-  subq_7.listing AS listing
-  , subq_9.country_latest AS listing__country_latest
+  subq_9.country_latest AS listing__country_latest
   , subq_11.country_latest AS listing__country_latest
+  , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
   -- Read Elements From Semantic Model 'bookings_source'

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -35,13 +35,13 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='listing') -->
-                <!-- col1 =                                               -->
+                <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_8), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
                 <!--     column_alias='listing__country_latest',          -->
                 <!--   )                                                  -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='bookings') -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='bookings') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -110,22 +110,22 @@
                             <!-- node_id = NodeId(id_str='ss_4') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_173), -->
-                            <!--     column_alias='ds__day',                            -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_172), -->
+                            <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_174), -->
-                            <!--     column_alias='listing',                            -->
+                            <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_175), -->
-                            <!--     column_alias='listing__country_latest',            -->
+                            <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_172), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_173), -->
                             <!--     column_alias='bookings',                           -->
                             <!--   )                                                    -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
@@ -1823,22 +1823,22 @@
                             <!-- node_id = NodeId(id_str='ss_12') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_320), -->
-                            <!--     column_alias='ds__day',                            -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_319), -->
+                            <!--     column_alias='listing__country_latest',            -->
                             <!--   )                                                    -->
                             <!-- col1 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_321), -->
-                            <!--     column_alias='listing',                            -->
+                            <!--     column_alias='ds__day',                            -->
                             <!--   )                                                    -->
                             <!-- col2 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_322), -->
-                            <!--     column_alias='listing__country_latest',            -->
+                            <!--     column_alias='listing',                            -->
                             <!--   )                                                    -->
                             <!-- col3 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
-                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_319), -->
+                            <!--     expr=SqlColumnReferenceExpression(node_id=cr_320), -->
                             <!--     column_alias='views',                              -->
                             <!--   )                                                    -->
                             <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -41,14 +41,14 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='listing') -->
-                <!-- col1 =                                                -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
-                <!--     column_alias='listing__country_latest',           -->
-                <!--   )                                                   -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='bookings') -->
-                <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookers') -->
+                <!-- col0 =                                               -->
+                <!--   SqlSelectColumn(                                   -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
+                <!--     column_alias='listing__country_latest',          -->
+                <!--   )                                                  -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='listing') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookings') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='bookers') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -39,14 +39,14 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_2') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='listing') -->
-                <!-- col1 =                                               -->
+                <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_8), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
                 <!--     column_alias='listing__country_latest',          -->
                 <!--   )                                                  -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
                 <!-- col2 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='booking_value') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='booking_value') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -204,206 +204,206 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
-                <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
-                <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
-                <!-- col6 =                                                -->
+                <!-- col0 =                                               -->
+                <!--   SqlSelectColumn(                                   -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                <!--     column_alias='user__home_state_latest',          -->
+                <!--   )                                                  -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+                <!-- col4 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
+                <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+                <!-- col6 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+                <!-- col7 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
-                <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
-                <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
+                <!-- col8 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
-                <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
-                <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
-                <!-- col14 =                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+                <!-- col12 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+                <!-- col13 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+                <!-- col14 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+                <!-- col15 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
-                <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
-                <!-- col16 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
-                <!--     column_alias='created_at__extract_year',          -->
-                <!--   )                                                   -->
+                <!-- col16 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
-                <!--     column_alias='created_at__extract_quarter',       -->
+                <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
-                <!--     column_alias='created_at__extract_month',         -->
+                <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
-                <!--     column_alias='created_at__extract_day',           -->
+                <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
-                <!--     column_alias='created_at__extract_dow',           -->
+                <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     column_alias='created_at__extract_dow',           -->
+                <!--   )                                                   -->
+                <!-- col22 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
-                <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
-                <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
-                <!-- col24 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
-                <!--     column_alias='listing__ds__month',                -->
-                <!--   )                                                   -->
+                <!-- col23 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+                <!-- col24 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                <!--     column_alias='listing__ds__month',                -->
+                <!--   )                                                   -->
+                <!-- col26 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
-                <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
-                <!-- col27 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
-                <!--     column_alias='listing__ds__extract_year',         -->
-                <!--   )                                                   -->
+                <!-- col27 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
-                <!--     column_alias='listing__ds__extract_quarter',      -->
+                <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
-                <!--     column_alias='listing__ds__extract_month',        -->
+                <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
-                <!--     column_alias='listing__ds__extract_day',          -->
+                <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
-                <!--     column_alias='listing__ds__extract_dow',          -->
+                <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
-                <!--     column_alias='listing__ds__extract_doy',          -->
+                <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
-                <!--     column_alias='listing__created_at__day',          -->
+                <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
-                <!--     column_alias='listing__created_at__week',         -->
+                <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
-                <!--     column_alias='listing__created_at__month',        -->
+                <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
-                <!--     column_alias='listing__created_at__quarter',      -->
+                <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
-                <!--     column_alias='listing__created_at__year',         -->
+                <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     column_alias='listing__created_at__year',         -->
+                <!--   )                                                   -->
+                <!-- col39 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
-                <!-- col39 =                                                  -->
+                <!-- col40 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
-                <!-- col40 =                                                -->
+                <!-- col41 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
-                <!-- col41 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-                <!--     column_alias='listing__created_at__extract_day',  -->
-                <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--   )                                                   -->
+                <!-- col44 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
-                <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
+                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
                 <!-- col47 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
-                <!-- col48 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
-                <!-- col49 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
-                <!-- col50 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
-                <!--     column_alias='listing__country_latest',           -->
-                <!--   )                                                   -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
+                <!-- col48 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
+                <!-- col49 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+                <!-- col50 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
-                <!--     column_alias='listing__is_lux_latest',            -->
+                <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
-                <!--     column_alias='listing__capacity_latest',          -->
+                <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
-                <!--     column_alias='user__home_state_latest',           -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
                 <!-- col55 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -16,190 +16,190 @@
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
             <!-- node_id = NodeId(id_str='ss_1') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
-            <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
-            <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
+            <!-- col0 =                                               -->
+            <!--   SqlSelectColumn(                                   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+            <!--     column_alias='user__home_state_latest',          -->
+            <!--   )                                                  -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
+            <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+            <!-- col6 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+            <!-- col7 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_quarter') -->
+            <!-- col8 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
-            <!-- col16 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
-            <!--     column_alias='created_at__extract_year',          -->
-            <!--   )                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+            <!-- col12 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+            <!-- col13 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+            <!-- col14 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+            <!-- col15 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__quarter') -->
+            <!-- col16 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
-            <!--     column_alias='created_at__extract_quarter',       -->
+            <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
-            <!--     column_alias='created_at__extract_month',         -->
+            <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
-            <!--     column_alias='created_at__extract_day',           -->
+            <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
-            <!--     column_alias='created_at__extract_dow',           -->
+            <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     column_alias='created_at__extract_dow',           -->
+            <!--   )                                                   -->
+            <!-- col22 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
-            <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
-            <!-- col27 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
-            <!--     column_alias='listing__ds__extract_year',         -->
-            <!--   )                                                   -->
+            <!-- col23 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+            <!-- col24 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+            <!-- col25 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__month') -->
+            <!-- col26 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__quarter') -->
+            <!-- col27 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
-            <!--     column_alias='listing__ds__extract_quarter',      -->
+            <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
-            <!--     column_alias='listing__ds__extract_month',        -->
+            <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
-            <!--     column_alias='listing__ds__extract_day',          -->
+            <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
-            <!--     column_alias='listing__ds__extract_dow',          -->
+            <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
-            <!--     column_alias='listing__ds__extract_doy',          -->
+            <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
-            <!--     column_alias='listing__created_at__day',          -->
+            <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
-            <!--     column_alias='listing__created_at__week',         -->
+            <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
-            <!--     column_alias='listing__created_at__month',        -->
+            <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
-            <!--     column_alias='listing__created_at__quarter',      -->
+            <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
-            <!--     column_alias='listing__created_at__year',         -->
+            <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     column_alias='listing__created_at__year',         -->
+            <!--   )                                                   -->
+            <!-- col39 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
-            <!-- col39 =                                                  -->
+            <!-- col40 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
-            <!-- col40 =                                                -->
+            <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
-            <!-- col41 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-            <!--     column_alias='listing__created_at__extract_day',  -->
-            <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--   )                                                   -->
+            <!-- col44 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
-            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
-            <!-- col49 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
-            <!-- col50 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
-            <!--     column_alias='listing__country_latest',           -->
-            <!--   )                                                   -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
+            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+            <!-- col50 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
-            <!--     column_alias='listing__is_lux_latest',            -->
+            <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
-            <!--     column_alias='listing__capacity_latest',          -->
+            <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
-            <!--     column_alias='user__home_state_latest',           -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+            <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
             <!-- col55 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -2,12 +2,12 @@
     <SqlSelectStatementNode>
         <!-- description = 'Join Standard Outputs' -->
         <!-- node_id = NodeId(id_str='ss_3') -->
-        <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
+        <!-- col0 =                                                                                                     -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='listing__country_latest') -->
         <!-- col1 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='listing__country_latest') -->
-        <!-- col2 =                                                                                                      -->
-        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing__country_latest') -->
-        <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='bookings') -->
+        <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing__country_latest') -->
+        <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
+        <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='bookings') -->
         <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
@@ -580,8 +580,8 @@
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
             <!-- node_id = NodeId(id_str='ss_2') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='listing') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='country_latest') -->
+            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- where = None -->
             <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/BigQuery/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Databricks/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/DuckDB/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Postgres/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Redshift/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Snowflake/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_derived_metric_rendering.py/SqlQueryPlan/Trino/test_nested_filters__plan0.sql
@@ -38,9 +38,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.listing AS listing
+                  subq_5.is_lux_latest AS listing__is_lux_latest
+                  , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.is_lux_latest AS listing__is_lux_latest
                   , subq_2.average_booking_value AS average_booking_value
                 FROM (
                   -- Pass Only Elements: ['average_booking_value', 'booking__is_instant', 'listing']
@@ -418,9 +418,9 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_14.listing AS listing
+                  subq_17.is_lux_latest AS listing__is_lux_latest
+                  , subq_14.listing AS listing
                   , subq_14.booking__is_instant AS booking__is_instant
-                  , subq_17.is_lux_latest AS listing__is_lux_latest
                   , subq_14.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/BigQuery/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Databricks/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/DuckDB/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Postgres/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Redshift/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Snowflake/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimension_values_with_a_join_and_a_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimension_values_with_a_join_and_a_filter__plan0.sql
@@ -65,7 +65,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_2.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -118,7 +119,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_2.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimension_values_with_a_join_and_a_filter__plan0_optimized.sql
@@ -6,8 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    listings_latest_src_28000.is_lux AS listing__is_lux_latest
-    , users_latest_src_28000.home_state_latest AS user__home_state_latest
+    users_latest_src_28000.home_state_latest AS user__home_state_latest
+    , listings_latest_src_28000.is_lux AS listing__is_lux_latest
   FROM ***************************.dim_listings_latest listings_latest_src_28000
   FULL OUTER JOIN
     ***************************.dim_users_latest users_latest_src_28000

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimensions_requiring_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/Trino/test_dimensions_requiring_join__plan0.sql
@@ -5,7 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_2.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -58,7 +59,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_2.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -208,206 +208,206 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_1') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
-                <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
-                <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
-                <!-- col6 =                                                -->
+                <!-- col0 =                                               -->
+                <!--   SqlSelectColumn(                                   -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+                <!--     column_alias='user__home_state_latest',          -->
+                <!--   )                                                  -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+                <!-- col4 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
+                <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+                <!-- col6 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+                <!-- col7 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_19), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_20), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
-                <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
-                <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
+                <!-- col8 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
-                <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
-                <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
-                <!-- col14 =                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+                <!-- col12 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+                <!-- col13 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+                <!-- col14 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+                <!-- col15 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_27), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_28), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
-                <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
-                <!-- col16 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
-                <!--     column_alias='created_at__extract_year',          -->
-                <!--   )                                                   -->
+                <!-- col16 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
-                <!--     column_alias='created_at__extract_quarter',       -->
+                <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
-                <!--     column_alias='created_at__extract_month',         -->
+                <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
-                <!--     column_alias='created_at__extract_day',           -->
+                <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
-                <!--     column_alias='created_at__extract_dow',           -->
+                <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+                <!--     column_alias='created_at__extract_dow',           -->
+                <!--   )                                                   -->
+                <!-- col22 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
-                <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
-                <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
-                <!-- col24 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
-                <!--     column_alias='listing__ds__month',                -->
-                <!--   )                                                   -->
+                <!-- col23 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+                <!-- col24 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                <!--     column_alias='listing__ds__month',                -->
+                <!--   )                                                   -->
+                <!-- col26 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_39), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
-                <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
-                <!-- col27 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
-                <!--     column_alias='listing__ds__extract_year',         -->
-                <!--   )                                                   -->
+                <!-- col27 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
-                <!--     column_alias='listing__ds__extract_quarter',      -->
+                <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
-                <!--     column_alias='listing__ds__extract_month',        -->
+                <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
-                <!--     column_alias='listing__ds__extract_day',          -->
+                <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
-                <!--     column_alias='listing__ds__extract_dow',          -->
+                <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
-                <!--     column_alias='listing__ds__extract_doy',          -->
+                <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
-                <!--     column_alias='listing__created_at__day',          -->
+                <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
-                <!--     column_alias='listing__created_at__week',         -->
+                <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
-                <!--     column_alias='listing__created_at__month',        -->
+                <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
-                <!--     column_alias='listing__created_at__quarter',      -->
+                <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
-                <!--     column_alias='listing__created_at__year',         -->
+                <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+                <!--     column_alias='listing__created_at__year',         -->
+                <!--   )                                                   -->
+                <!-- col39 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
-                <!-- col39 =                                                  -->
+                <!-- col40 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
-                <!-- col40 =                                                -->
+                <!-- col41 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
-                <!-- col41 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-                <!--     column_alias='listing__created_at__extract_day',  -->
-                <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--   )                                                   -->
+                <!-- col44 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
-                <!-- col46 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
+                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
+                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
                 <!-- col47 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
-                <!-- col48 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
-                <!-- col49 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
-                <!-- col50 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
-                <!--     column_alias='listing__country_latest',           -->
-                <!--   )                                                   -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
+                <!-- col48 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
+                <!-- col49 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+                <!-- col50 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
                 <!-- col51 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
-                <!--     column_alias='listing__is_lux_latest',            -->
+                <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
-                <!--     column_alias='listing__capacity_latest',          -->
+                <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
-                <!--     column_alias='user__home_state_latest',           -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+                <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
-                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+                <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
                 <!-- col55 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -16,190 +16,190 @@
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
             <!-- node_id = NodeId(id_str='ss_1') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__year') -->
-            <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__extract_year') -->
-            <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_day') -->
+            <!-- col0 =                                               -->
+            <!--   SqlSelectColumn(                                   -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
+            <!--     column_alias='user__home_state_latest',          -->
+            <!--   )                                                  -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__day') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__week') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__month') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__quarter') -->
+            <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_18), column_alias='ds__year') -->
+            <!-- col6 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_19), column_alias='ds__extract_year') -->
+            <!-- col7 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_20), column_alias='ds__extract_quarter') -->
+            <!-- col8 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_21), column_alias='ds__extract_month') -->
             <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_dow') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_22), column_alias='ds__extract_day') -->
             <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_doy') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_23), column_alias='ds__extract_dow') -->
             <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__year') -->
-            <!-- col16 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
-            <!--     column_alias='created_at__extract_year',          -->
-            <!--   )                                                   -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='ds__extract_doy') -->
+            <!-- col12 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='created_at__day') -->
+            <!-- col13 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='created_at__week') -->
+            <!-- col14 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_27), column_alias='created_at__month') -->
+            <!-- col15 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28), column_alias='created_at__quarter') -->
+            <!-- col16 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='created_at__year') -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_30), -->
-            <!--     column_alias='created_at__extract_quarter',       -->
+            <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_31), -->
-            <!--     column_alias='created_at__extract_month',         -->
+            <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_32), -->
-            <!--     column_alias='created_at__extract_day',           -->
+            <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_33), -->
-            <!--     column_alias='created_at__extract_dow',           -->
+            <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_34), -->
+            <!--     column_alias='created_at__extract_dow',           -->
+            <!--   )                                                   -->
+            <!-- col22 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
-            <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__year') -->
-            <!-- col27 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_40), -->
-            <!--     column_alias='listing__ds__extract_year',         -->
-            <!--   )                                                   -->
+            <!-- col23 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_36), column_alias='listing__ds__day') -->
+            <!-- col24 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_37), column_alias='listing__ds__week') -->
+            <!-- col25 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='listing__ds__month') -->
+            <!-- col26 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='listing__ds__quarter') -->
+            <!-- col27 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='listing__ds__year') -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_41), -->
-            <!--     column_alias='listing__ds__extract_quarter',      -->
+            <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
-            <!--     column_alias='listing__ds__extract_month',        -->
+            <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
-            <!--     column_alias='listing__ds__extract_day',          -->
+            <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
-            <!--     column_alias='listing__ds__extract_dow',          -->
+            <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
-            <!--     column_alias='listing__ds__extract_doy',          -->
+            <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
-            <!--     column_alias='listing__created_at__day',          -->
+            <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
-            <!--     column_alias='listing__created_at__week',         -->
+            <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
-            <!--     column_alias='listing__created_at__month',        -->
+            <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
-            <!--     column_alias='listing__created_at__quarter',      -->
+            <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_50), -->
-            <!--     column_alias='listing__created_at__year',         -->
+            <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
+            <!--     column_alias='listing__created_at__year',         -->
+            <!--   )                                                   -->
+            <!-- col39 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
-            <!-- col39 =                                                  -->
+            <!-- col40 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_52),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
-            <!-- col40 =                                                -->
+            <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_53),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
-            <!-- col41 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-            <!--     column_alias='listing__created_at__extract_day',  -->
-            <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
+            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--   )                                                   -->
+            <!-- col44 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_57), column_alias='listing') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='user') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='listing__user') -->
-            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
-            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='is_lux_latest') -->
-            <!-- col49 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='capacity_latest') -->
-            <!-- col50 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_10), -->
-            <!--     column_alias='listing__country_latest',           -->
-            <!--   )                                                   -->
+            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_58), column_alias='listing') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_59), column_alias='user') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__user') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='country_latest') -->
+            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_lux_latest') -->
+            <!-- col50 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='capacity_latest') -->
             <!-- col51 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_11), -->
-            <!--     column_alias='listing__is_lux_latest',            -->
+            <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_12), -->
-            <!--     column_alias='listing__capacity_latest',          -->
+            <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
-            <!--     column_alias='user__home_state_latest',           -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_13), -->
+            <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
-            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listings') -->
+            <!-- col54 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='listings') -->
             <!-- col55 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/BigQuery/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Databricks/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/DuckDB/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Postgres/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Redshift/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Snowflake/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_granularity_date_part_rendering.py/SqlQueryPlan/Trino/test_simple_metric_with_joined_sub_daily_dimension__plan0.sql
@@ -15,9 +15,9 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
-        , subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
+        subq_9.user__ds_partitioned__day AS listing__user__ds_partitioned__day
         , subq_9.user__bio_added_ts__minute AS listing__user__bio_added_ts__minute
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.listing AS listing
         , subq_2.bookings AS bookings
       FROM (
@@ -231,61 +231,7 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds__day AS ds__day
-            , subq_4.ds__week AS ds__week
-            , subq_4.ds__month AS ds__month
-            , subq_4.ds__quarter AS ds__quarter
-            , subq_4.ds__year AS ds__year
-            , subq_4.ds__extract_year AS ds__extract_year
-            , subq_4.ds__extract_quarter AS ds__extract_quarter
-            , subq_4.ds__extract_month AS ds__extract_month
-            , subq_4.ds__extract_day AS ds__extract_day
-            , subq_4.ds__extract_dow AS ds__extract_dow
-            , subq_4.ds__extract_doy AS ds__extract_doy
-            , subq_4.created_at__day AS created_at__day
-            , subq_4.created_at__week AS created_at__week
-            , subq_4.created_at__month AS created_at__month
-            , subq_4.created_at__quarter AS created_at__quarter
-            , subq_4.created_at__year AS created_at__year
-            , subq_4.created_at__extract_year AS created_at__extract_year
-            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
-            , subq_4.created_at__extract_month AS created_at__extract_month
-            , subq_4.created_at__extract_day AS created_at__extract_day
-            , subq_4.created_at__extract_dow AS created_at__extract_dow
-            , subq_4.created_at__extract_doy AS created_at__extract_doy
-            , subq_4.listing__ds__day AS listing__ds__day
-            , subq_4.listing__ds__week AS listing__ds__week
-            , subq_4.listing__ds__month AS listing__ds__month
-            , subq_4.listing__ds__quarter AS listing__ds__quarter
-            , subq_4.listing__ds__year AS listing__ds__year
-            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
-            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
-            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
-            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
-            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
-            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
-            , subq_4.listing__created_at__day AS listing__created_at__day
-            , subq_4.listing__created_at__week AS listing__created_at__week
-            , subq_4.listing__created_at__month AS listing__created_at__month
-            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
-            , subq_4.listing__created_at__year AS listing__created_at__year
-            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
-            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
-            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
-            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
-            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
-            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
-            , subq_4.metric_time__day AS metric_time__day
-            , subq_4.metric_time__week AS metric_time__week
-            , subq_4.metric_time__month AS metric_time__month
-            , subq_4.metric_time__quarter AS metric_time__quarter
-            , subq_4.metric_time__year AS metric_time__year
-            , subq_4.metric_time__extract_year AS metric_time__extract_year
-            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
-            , subq_4.metric_time__extract_month AS metric_time__extract_month
-            , subq_4.metric_time__extract_day AS metric_time__extract_day
-            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
-            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
+            subq_7.home_state AS user__home_state
             , subq_7.ds__day AS user__ds__day
             , subq_7.ds__week AS user__ds__week
             , subq_7.ds__month AS user__ds__month
@@ -384,6 +330,61 @@ FROM (
             , subq_7.metric_time__extract_day AS user__metric_time__extract_day
             , subq_7.metric_time__extract_dow AS user__metric_time__extract_dow
             , subq_7.metric_time__extract_doy AS user__metric_time__extract_doy
+            , subq_4.ds__day AS ds__day
+            , subq_4.ds__week AS ds__week
+            , subq_4.ds__month AS ds__month
+            , subq_4.ds__quarter AS ds__quarter
+            , subq_4.ds__year AS ds__year
+            , subq_4.ds__extract_year AS ds__extract_year
+            , subq_4.ds__extract_quarter AS ds__extract_quarter
+            , subq_4.ds__extract_month AS ds__extract_month
+            , subq_4.ds__extract_day AS ds__extract_day
+            , subq_4.ds__extract_dow AS ds__extract_dow
+            , subq_4.ds__extract_doy AS ds__extract_doy
+            , subq_4.created_at__day AS created_at__day
+            , subq_4.created_at__week AS created_at__week
+            , subq_4.created_at__month AS created_at__month
+            , subq_4.created_at__quarter AS created_at__quarter
+            , subq_4.created_at__year AS created_at__year
+            , subq_4.created_at__extract_year AS created_at__extract_year
+            , subq_4.created_at__extract_quarter AS created_at__extract_quarter
+            , subq_4.created_at__extract_month AS created_at__extract_month
+            , subq_4.created_at__extract_day AS created_at__extract_day
+            , subq_4.created_at__extract_dow AS created_at__extract_dow
+            , subq_4.created_at__extract_doy AS created_at__extract_doy
+            , subq_4.listing__ds__day AS listing__ds__day
+            , subq_4.listing__ds__week AS listing__ds__week
+            , subq_4.listing__ds__month AS listing__ds__month
+            , subq_4.listing__ds__quarter AS listing__ds__quarter
+            , subq_4.listing__ds__year AS listing__ds__year
+            , subq_4.listing__ds__extract_year AS listing__ds__extract_year
+            , subq_4.listing__ds__extract_quarter AS listing__ds__extract_quarter
+            , subq_4.listing__ds__extract_month AS listing__ds__extract_month
+            , subq_4.listing__ds__extract_day AS listing__ds__extract_day
+            , subq_4.listing__ds__extract_dow AS listing__ds__extract_dow
+            , subq_4.listing__ds__extract_doy AS listing__ds__extract_doy
+            , subq_4.listing__created_at__day AS listing__created_at__day
+            , subq_4.listing__created_at__week AS listing__created_at__week
+            , subq_4.listing__created_at__month AS listing__created_at__month
+            , subq_4.listing__created_at__quarter AS listing__created_at__quarter
+            , subq_4.listing__created_at__year AS listing__created_at__year
+            , subq_4.listing__created_at__extract_year AS listing__created_at__extract_year
+            , subq_4.listing__created_at__extract_quarter AS listing__created_at__extract_quarter
+            , subq_4.listing__created_at__extract_month AS listing__created_at__extract_month
+            , subq_4.listing__created_at__extract_day AS listing__created_at__extract_day
+            , subq_4.listing__created_at__extract_dow AS listing__created_at__extract_dow
+            , subq_4.listing__created_at__extract_doy AS listing__created_at__extract_doy
+            , subq_4.metric_time__day AS metric_time__day
+            , subq_4.metric_time__week AS metric_time__week
+            , subq_4.metric_time__month AS metric_time__month
+            , subq_4.metric_time__quarter AS metric_time__quarter
+            , subq_4.metric_time__year AS metric_time__year
+            , subq_4.metric_time__extract_year AS metric_time__extract_year
+            , subq_4.metric_time__extract_quarter AS metric_time__extract_quarter
+            , subq_4.metric_time__extract_month AS metric_time__extract_month
+            , subq_4.metric_time__extract_day AS metric_time__extract_day
+            , subq_4.metric_time__extract_dow AS metric_time__extract_dow
+            , subq_4.metric_time__extract_doy AS metric_time__extract_doy
             , subq_4.listing AS listing
             , subq_4.user AS user
             , subq_4.listing__user AS listing__user
@@ -393,7 +394,6 @@ FROM (
             , subq_4.listing__country_latest AS listing__country_latest
             , subq_4.listing__is_lux_latest AS listing__is_lux_latest
             , subq_4.listing__capacity_latest AS listing__capacity_latest
-            , subq_7.home_state AS user__home_state
             , subq_4.listings AS listings
             , subq_4.largest_listing AS largest_listing
             , subq_4.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/BigQuery/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Databricks/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/DuckDB/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Postgres/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Redshift/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Snowflake/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0.sql
@@ -11,10 +11,10 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.listing AS listing
+      subq_6.listing__bookings AS listing__bookings
+      , subq_0.listing AS listing
       , subq_0.lux_listing AS lux_listing
       , subq_0.listing__lux_listing AS listing__lux_listing
-      , subq_6.listing__bookings AS listing__bookings
     FROM (
       -- Read Elements From Semantic Model 'lux_listing_mapping'
       SELECT

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_distinct_values_query_with_metric_filter__plan0_optimized.sql
@@ -5,8 +5,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    lux_listing_mapping_src_28000.listing_id AS listing
-    , subq_15.listing__bookings AS listing__bookings
+    subq_15.listing__bookings AS listing__bookings
+    , lux_listing_mapping_src_28000.listing_id AS listing
   FROM ***************************.dim_lux_listing_id_mapping lux_listing_mapping_src_28000
   FULL OUTER JOIN (
     -- Aggregate Measures

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_by_metric_in_same_semantic_model_as_queried_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.guest AS guest
-            , subq_8.guest__booking_value AS guest__booking_value
+            subq_8.guest__booking_value AS guest__booking_value
+            , subq_2.guest AS guest
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'guest']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_filter_with_conversion_metric__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            subq_19.user__visit_buy_conversion_rate AS user__visit_buy_conversion_rate
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_group_by_has_local_entity_prefix__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_13.listing__user AS user__listing__user
+            subq_13.listing__user AS user__listing__user
             , subq_13.listing__user__average_booking_value AS user__listing__user__average_booking_value
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']
@@ -187,8 +187,8 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.listing AS listing
-                      , subq_8.user AS listing__user
+                      subq_8.user AS listing__user
+                      , subq_5.listing AS listing
                       , subq_5.average_booking_value AS average_booking_value
                     FROM (
                       -- Pass Only Elements: ['average_booking_value', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_multi_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
+            subq_17.account_id__customer_id__customer_third_hop_id AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id
             , subq_17.account_id__customer_id__customer_third_hop_id__txn_count AS customer_third_hop_id__account_id__customer_id__customer_third_hop_id__txn_count
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']
@@ -127,10 +127,10 @@ FROM (
                   FROM (
                     -- Join Standard Outputs
                     SELECT
-                      subq_5.ds_partitioned__day AS ds_partitioned__day
-                      , subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
-                      , subq_5.account_id AS account_id
+                      subq_12.ds_partitioned__day AS account_id__ds_partitioned__day
                       , subq_12.customer_id__customer_third_hop_id AS account_id__customer_id__customer_third_hop_id
+                      , subq_5.ds_partitioned__day AS ds_partitioned__day
+                      , subq_5.account_id AS account_id
                       , subq_5.txn_count AS txn_count
                     FROM (
                       -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -264,7 +264,44 @@ FROM (
                       FROM (
                         -- Join Standard Outputs
                         SELECT
-                          subq_7.ds_partitioned__day AS ds_partitioned__day
+                          subq_10.country AS customer_id__country
+                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
+                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
+                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
+                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
+                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
+                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
+                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
+                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
+                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
+                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
+                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
+                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
+                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
+                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
+                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
+                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
+                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
+                          , subq_10.metric_time__day AS customer_id__metric_time__day
+                          , subq_10.metric_time__week AS customer_id__metric_time__week
+                          , subq_10.metric_time__month AS customer_id__metric_time__month
+                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
+                          , subq_10.metric_time__year AS customer_id__metric_time__year
+                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
+                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
+                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
+                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
+                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
+                          , subq_7.ds_partitioned__day AS ds_partitioned__day
                           , subq_7.ds_partitioned__week AS ds_partitioned__week
                           , subq_7.ds_partitioned__month AS ds_partitioned__month
                           , subq_7.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -308,51 +345,14 @@ FROM (
                           , subq_7.metric_time__extract_day AS metric_time__extract_day
                           , subq_7.metric_time__extract_dow AS metric_time__extract_dow
                           , subq_7.metric_time__extract_doy AS metric_time__extract_doy
-                          , subq_10.acquired_ds__day AS customer_id__acquired_ds__day
-                          , subq_10.acquired_ds__week AS customer_id__acquired_ds__week
-                          , subq_10.acquired_ds__month AS customer_id__acquired_ds__month
-                          , subq_10.acquired_ds__quarter AS customer_id__acquired_ds__quarter
-                          , subq_10.acquired_ds__year AS customer_id__acquired_ds__year
-                          , subq_10.acquired_ds__extract_year AS customer_id__acquired_ds__extract_year
-                          , subq_10.acquired_ds__extract_quarter AS customer_id__acquired_ds__extract_quarter
-                          , subq_10.acquired_ds__extract_month AS customer_id__acquired_ds__extract_month
-                          , subq_10.acquired_ds__extract_day AS customer_id__acquired_ds__extract_day
-                          , subq_10.acquired_ds__extract_dow AS customer_id__acquired_ds__extract_dow
-                          , subq_10.acquired_ds__extract_doy AS customer_id__acquired_ds__extract_doy
-                          , subq_10.customer_third_hop_id__acquired_ds__day AS customer_id__customer_third_hop_id__acquired_ds__day
-                          , subq_10.customer_third_hop_id__acquired_ds__week AS customer_id__customer_third_hop_id__acquired_ds__week
-                          , subq_10.customer_third_hop_id__acquired_ds__month AS customer_id__customer_third_hop_id__acquired_ds__month
-                          , subq_10.customer_third_hop_id__acquired_ds__quarter AS customer_id__customer_third_hop_id__acquired_ds__quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__year AS customer_id__customer_third_hop_id__acquired_ds__year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_year AS customer_id__customer_third_hop_id__acquired_ds__extract_year
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_quarter AS customer_id__customer_third_hop_id__acquired_ds__extract_quarter
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_month AS customer_id__customer_third_hop_id__acquired_ds__extract_month
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_day AS customer_id__customer_third_hop_id__acquired_ds__extract_day
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_dow AS customer_id__customer_third_hop_id__acquired_ds__extract_dow
-                          , subq_10.customer_third_hop_id__acquired_ds__extract_doy AS customer_id__customer_third_hop_id__acquired_ds__extract_doy
-                          , subq_10.metric_time__day AS customer_id__metric_time__day
-                          , subq_10.metric_time__week AS customer_id__metric_time__week
-                          , subq_10.metric_time__month AS customer_id__metric_time__month
-                          , subq_10.metric_time__quarter AS customer_id__metric_time__quarter
-                          , subq_10.metric_time__year AS customer_id__metric_time__year
-                          , subq_10.metric_time__extract_year AS customer_id__metric_time__extract_year
-                          , subq_10.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-                          , subq_10.metric_time__extract_month AS customer_id__metric_time__extract_month
-                          , subq_10.metric_time__extract_day AS customer_id__metric_time__extract_day
-                          , subq_10.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-                          , subq_10.metric_time__extract_doy AS customer_id__metric_time__extract_doy
                           , subq_7.account_id AS account_id
                           , subq_7.customer_id AS customer_id
                           , subq_7.account_id__customer_id AS account_id__customer_id
                           , subq_7.bridge_account__account_id AS bridge_account__account_id
                           , subq_7.bridge_account__customer_id AS bridge_account__customer_id
-                          , subq_10.customer_third_hop_id AS customer_id__customer_third_hop_id
-                          , subq_10.customer_third_hop_id__customer_id AS customer_id__customer_third_hop_id__customer_id
                           , subq_7.extra_dim AS extra_dim
                           , subq_7.account_id__extra_dim AS account_id__extra_dim
                           , subq_7.bridge_account__extra_dim AS bridge_account__extra_dim
-                          , subq_10.country AS customer_id__country
-                          , subq_10.customer_third_hop_id__country AS customer_id__customer_third_hop_id__country
                           , subq_7.account_customer_combos AS account_customer_combos
                         FROM (
                           -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_inner_query_single_hop__plan0.sql
@@ -22,9 +22,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.customer_third_hop_id AS customer_third_hop_id
-            , subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
+            subq_10.customer_id__customer_third_hop_id AS customer_third_hop_id__customer_id__customer_third_hop_id
             , subq_10.customer_id__customer_third_hop_id__paraguayan_customers AS customer_third_hop_id__customer_id__customer_third_hop_id__paraguayan_customers
+            , subq_2.customer_third_hop_id AS customer_third_hop_id
             , subq_2.third_hop_count AS third_hop_count
           FROM (
             -- Pass Only Elements: ['third_hop_count', 'customer_third_hop_id']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_filtered_by_itself__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookers AS listing__bookers
+            subq_8.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_metric_with_metric_in_where_filter__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_cumulative_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
-            , subq_8.user__revenue_all_time AS user__revenue_all_time
+            subq_8.user__revenue_all_time AS user__revenue_all_time
+            , subq_2.user AS user
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'user']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_derived_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            subq_15.listing__views_times_booking_value AS listing__views_times_booking_value
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_multiple_metrics_in_filter__plan0.sql
@@ -24,9 +24,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
             , subq_14.listing__bookers AS listing__bookers
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_ratio_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            subq_15.listing__bookings_per_booker AS listing__bookings_per_booker
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_filter_rendering.py/SqlQueryPlan/Trino/test_query_with_simple_metric_in_where_filter__plan0.sql
@@ -22,8 +22,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_8.listing__bookings AS listing__bookings
+            subq_8.listing__bookings AS listing__bookings
+            , subq_2.listing AS listing
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing']

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/BigQuery/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Databricks/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/DuckDB/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Postgres/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Redshift/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Snowflake/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_dimensions_with_time_constraint__plan0.sql
@@ -67,7 +67,8 @@ FROM (
   FROM (
     -- Join Standard Outputs
     SELECT
-      subq_0.ds__day AS ds__day
+      subq_5.home_state_latest AS user__home_state_latest
+      , subq_0.ds__day AS ds__day
       , subq_0.ds__week AS ds__week
       , subq_0.ds__month AS ds__month
       , subq_0.ds__quarter AS ds__quarter
@@ -121,7 +122,6 @@ FROM (
       , subq_0.listing__country_latest AS listing__country_latest
       , subq_0.listing__is_lux_latest AS listing__is_lux_latest
       , subq_0.listing__capacity_latest AS listing__capacity_latest
-      , subq_5.home_state_latest AS user__home_state_latest
       , subq_0.listings AS listings
       , subq_0.largest_listing AS largest_listing
       , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/Trino/test_metric_time_with_other_dimensions__plan0.sql
@@ -6,7 +6,8 @@ SELECT
 FROM (
   -- Join Standard Outputs
   SELECT
-    subq_0.ds__day AS ds__day
+    subq_5.home_state_latest AS user__home_state_latest
+    , subq_0.ds__day AS ds__day
     , subq_0.ds__week AS ds__week
     , subq_0.ds__month AS ds__month
     , subq_0.ds__quarter AS ds__quarter
@@ -60,7 +61,6 @@ FROM (
     , subq_0.listing__country_latest AS listing__country_latest
     , subq_0.listing__is_lux_latest AS listing__is_lux_latest
     , subq_0.listing__capacity_latest AS listing__capacity_latest
-    , subq_5.home_state_latest AS user__home_state_latest
     , subq_0.listings AS listings
     , subq_0.largest_listing AS largest_listing
     , subq_0.smallest_listing AS smallest_listing

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -214,208 +214,208 @@
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='ss_3') -->
-                <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__day') -->
-                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__week') -->
-                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__month') -->
-                <!-- col3 =                                                                                          -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__quarter') -->
-                <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__year') -->
-                <!-- col5 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_year') -->
-                <!-- col6 =                                                -->
+                <!-- col0 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+                <!--     column_alias='user__home_state_latest',           -->
+                <!--   )                                                   -->
+                <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__day') -->
+                <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__week') -->
+                <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__month') -->
+                <!-- col4 =                                                                                          -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__quarter') -->
+                <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__year') -->
+                <!-- col6 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_year') -->
+                <!-- col7 =                                                -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
                 <!--     column_alias='ds__extract_quarter',               -->
                 <!--   )                                                   -->
-                <!-- col7 =                                                                                                -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_month') -->
-                <!-- col8 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__extract_day') -->
+                <!-- col8 =                                                                                                -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__extract_month') -->
                 <!-- col9 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='ds__extract_dow') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='ds__extract_day') -->
                 <!-- col10 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='ds__extract_doy') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='ds__extract_dow') -->
                 <!-- col11 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__day') -->
-                <!-- col12 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__week') -->
-                <!-- col13 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='created_at__month') -->
-                <!-- col14 =                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='ds__extract_doy') -->
+                <!-- col12 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__day') -->
+                <!-- col13 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='created_at__week') -->
+                <!-- col14 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='created_at__month') -->
+                <!-- col15 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_52), -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_53), -->
                 <!--     column_alias='created_at__quarter',               -->
                 <!--   )                                                   -->
-                <!-- col15 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='created_at__year') -->
-                <!-- col16 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-                <!--     column_alias='created_at__extract_year',          -->
-                <!--   )                                                   -->
+                <!-- col16 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_54), column_alias='created_at__year') -->
                 <!-- col17 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-                <!--     column_alias='created_at__extract_quarter',       -->
+                <!--     column_alias='created_at__extract_year',          -->
                 <!--   )                                                   -->
                 <!-- col18 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
-                <!--     column_alias='created_at__extract_month',         -->
+                <!--     column_alias='created_at__extract_quarter',       -->
                 <!--   )                                                   -->
                 <!-- col19 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
-                <!--     column_alias='created_at__extract_day',           -->
+                <!--     column_alias='created_at__extract_month',         -->
                 <!--   )                                                   -->
                 <!-- col20 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
-                <!--     column_alias='created_at__extract_dow',           -->
+                <!--     column_alias='created_at__extract_day',           -->
                 <!--   )                                                   -->
                 <!-- col21 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+                <!--     column_alias='created_at__extract_dow',           -->
+                <!--   )                                                   -->
+                <!-- col22 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
                 <!--     column_alias='created_at__extract_doy',           -->
                 <!--   )                                                   -->
-                <!-- col22 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__day') -->
-                <!-- col23 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__week') -->
-                <!-- col24 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_62), -->
-                <!--     column_alias='listing__ds__month',                -->
-                <!--   )                                                   -->
+                <!-- col23 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__day') -->
+                <!-- col24 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__ds__week') -->
                 <!-- col25 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_63), -->
+                <!--     column_alias='listing__ds__month',                -->
+                <!--   )                                                   -->
+                <!-- col26 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_64), -->
                 <!--     column_alias='listing__ds__quarter',              -->
                 <!--   )                                                   -->
-                <!-- col26 =                                                                                               -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='listing__ds__year') -->
-                <!-- col27 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
-                <!--     column_alias='listing__ds__extract_year',         -->
-                <!--   )                                                   -->
+                <!-- col27 =                                                                                               -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='listing__ds__year') -->
                 <!-- col28 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
-                <!--     column_alias='listing__ds__extract_quarter',      -->
+                <!--     column_alias='listing__ds__extract_year',         -->
                 <!--   )                                                   -->
                 <!-- col29 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
-                <!--     column_alias='listing__ds__extract_month',        -->
+                <!--     column_alias='listing__ds__extract_quarter',      -->
                 <!--   )                                                   -->
                 <!-- col30 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
-                <!--     column_alias='listing__ds__extract_day',          -->
+                <!--     column_alias='listing__ds__extract_month',        -->
                 <!--   )                                                   -->
                 <!-- col31 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
-                <!--     column_alias='listing__ds__extract_dow',          -->
+                <!--     column_alias='listing__ds__extract_day',          -->
                 <!--   )                                                   -->
                 <!-- col32 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
-                <!--     column_alias='listing__ds__extract_doy',          -->
+                <!--     column_alias='listing__ds__extract_dow',          -->
                 <!--   )                                                   -->
                 <!-- col33 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
-                <!--     column_alias='listing__created_at__day',          -->
+                <!--     column_alias='listing__ds__extract_doy',          -->
                 <!--   )                                                   -->
                 <!-- col34 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
-                <!--     column_alias='listing__created_at__week',         -->
+                <!--     column_alias='listing__created_at__day',          -->
                 <!--   )                                                   -->
                 <!-- col35 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
-                <!--     column_alias='listing__created_at__month',        -->
+                <!--     column_alias='listing__created_at__week',         -->
                 <!--   )                                                   -->
                 <!-- col36 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
-                <!--     column_alias='listing__created_at__quarter',      -->
+                <!--     column_alias='listing__created_at__month',        -->
                 <!--   )                                                   -->
                 <!-- col37 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
-                <!--     column_alias='listing__created_at__year',         -->
+                <!--     column_alias='listing__created_at__quarter',      -->
                 <!--   )                                                   -->
                 <!-- col38 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+                <!--     column_alias='listing__created_at__year',         -->
+                <!--   )                                                   -->
+                <!-- col39 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
                 <!--     column_alias='listing__created_at__extract_year', -->
                 <!--   )                                                   -->
-                <!-- col39 =                                                  -->
+                <!-- col40 =                                                  -->
                 <!--   SqlSelectColumn(                                       -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_77),    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78),    -->
                 <!--     column_alias='listing__created_at__extract_quarter', -->
                 <!--   )                                                      -->
-                <!-- col40 =                                                -->
+                <!-- col41 =                                                -->
                 <!--   SqlSelectColumn(                                     -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_78),  -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_79),  -->
                 <!--     column_alias='listing__created_at__extract_month', -->
                 <!--   )                                                    -->
-                <!-- col41 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
-                <!--     column_alias='listing__created_at__extract_day',  -->
-                <!--   )                                                   -->
                 <!-- col42 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
-                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--     column_alias='listing__created_at__extract_day',  -->
                 <!--   )                                                   -->
                 <!-- col43 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+                <!--     column_alias='listing__created_at__extract_dow',  -->
+                <!--   )                                                   -->
+                <!-- col44 =                                               -->
+                <!--   SqlSelectColumn(                                    -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
                 <!--     column_alias='listing__created_at__extract_doy',  -->
                 <!--   )                                                   -->
-                <!-- col44 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='metric_time__day') -->
-                <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing') -->
-                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='user') -->
-                <!-- col47 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='listing__user') -->
-                <!-- col48 =                                                                                            -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='country_latest') -->
-                <!-- col49 =                                                                                           -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='is_lux_latest') -->
-                <!-- col50 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='capacity_latest') -->
-                <!-- col51 =                                               -->
-                <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
-                <!--     column_alias='listing__country_latest',           -->
-                <!--   )                                                   -->
+                <!-- col45 =                                                                                              -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='metric_time__day') -->
+                <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing') -->
+                <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user') -->
+                <!-- col48 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='listing__user') -->
+                <!-- col49 =                                                                                            -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='country_latest') -->
+                <!-- col50 =                                                                                           -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='is_lux_latest') -->
+                <!-- col51 =                                                                                             -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='capacity_latest') -->
                 <!-- col52 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
-                <!--     column_alias='listing__is_lux_latest',            -->
+                <!--     column_alias='listing__country_latest',           -->
                 <!--   )                                                   -->
                 <!-- col53 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
-                <!--     column_alias='listing__capacity_latest',          -->
+                <!--     column_alias='listing__is_lux_latest',            -->
                 <!--   )                                                   -->
                 <!-- col54 =                                               -->
                 <!--   SqlSelectColumn(                                    -->
-                <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
-                <!--     column_alias='user__home_state_latest',           -->
+                <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+                <!--     column_alias='listing__capacity_latest',          -->
                 <!--   )                                                   -->
-                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='listings') -->
+                <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='listings') -->
                 <!-- col56 =                                                                                             -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='largest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
                 <!-- col57 =                                                                                              -->
-                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='smallest_listing') -->
+                <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
                 <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
                 <!-- join_0 =                                               -->
                 <!--   SqlJoinDescription(                                  -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -20,193 +20,193 @@
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
             <!-- node_id = NodeId(id_str='ss_3') -->
-            <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_38), column_alias='ds__day') -->
-            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__week') -->
-            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__month') -->
-            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__quarter') -->
-            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__year') -->
-            <!-- col5 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__extract_year') -->
-            <!-- col6 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_quarter') -->
-            <!-- col7 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_month') -->
-            <!-- col8 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__extract_day') -->
-            <!-- col9 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='ds__extract_dow') -->
-            <!-- col10 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='ds__extract_doy') -->
-            <!-- col11 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='created_at__day') -->
-            <!-- col12 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__week') -->
-            <!-- col13 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='created_at__month') -->
-            <!-- col14 =                                                                                                 -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='created_at__quarter') -->
-            <!-- col15 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='created_at__year') -->
-            <!-- col16 =                                               -->
+            <!-- col0 =                                                -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
-            <!--     column_alias='created_at__extract_year',          -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
+            <!--     column_alias='user__home_state_latest',           -->
             <!--   )                                                   -->
+            <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_39), column_alias='ds__day') -->
+            <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_40), column_alias='ds__week') -->
+            <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='ds__month') -->
+            <!-- col4 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_42), column_alias='ds__quarter') -->
+            <!-- col5 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_43), column_alias='ds__year') -->
+            <!-- col6 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_44), column_alias='ds__extract_year') -->
+            <!-- col7 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_45), column_alias='ds__extract_quarter') -->
+            <!-- col8 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='ds__extract_month') -->
+            <!-- col9 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_47), column_alias='ds__extract_day') -->
+            <!-- col10 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='ds__extract_dow') -->
+            <!-- col11 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='ds__extract_doy') -->
+            <!-- col12 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_50), column_alias='created_at__day') -->
+            <!-- col13 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_51), column_alias='created_at__week') -->
+            <!-- col14 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_52), column_alias='created_at__month') -->
+            <!-- col15 =                                                                                                 -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_53), column_alias='created_at__quarter') -->
+            <!-- col16 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_54), column_alias='created_at__year') -->
             <!-- col17 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_55), -->
-            <!--     column_alias='created_at__extract_quarter',       -->
+            <!--     column_alias='created_at__extract_year',          -->
             <!--   )                                                   -->
             <!-- col18 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_56), -->
-            <!--     column_alias='created_at__extract_month',         -->
+            <!--     column_alias='created_at__extract_quarter',       -->
             <!--   )                                                   -->
             <!-- col19 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_57), -->
-            <!--     column_alias='created_at__extract_day',           -->
+            <!--     column_alias='created_at__extract_month',         -->
             <!--   )                                                   -->
             <!-- col20 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_58), -->
-            <!--     column_alias='created_at__extract_dow',           -->
+            <!--     column_alias='created_at__extract_day',           -->
             <!--   )                                                   -->
             <!-- col21 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_59), -->
+            <!--     column_alias='created_at__extract_dow',           -->
+            <!--   )                                                   -->
+            <!-- col22 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_60), -->
             <!--     column_alias='created_at__extract_doy',           -->
             <!--   )                                                   -->
-            <!-- col22 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_60), column_alias='listing__ds__day') -->
-            <!-- col23 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__week') -->
-            <!-- col24 =                                                                                                -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__ds__month') -->
-            <!-- col25 =                                                                                                  -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='listing__ds__quarter') -->
-            <!-- col26 =                                                                                               -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='listing__ds__year') -->
-            <!-- col27 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_65), -->
-            <!--     column_alias='listing__ds__extract_year',         -->
-            <!--   )                                                   -->
+            <!-- col23 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__ds__day') -->
+            <!-- col24 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='listing__ds__week') -->
+            <!-- col25 =                                                                                                -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='listing__ds__month') -->
+            <!-- col26 =                                                                                                  -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_64), column_alias='listing__ds__quarter') -->
+            <!-- col27 =                                                                                               -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_65), column_alias='listing__ds__year') -->
             <!-- col28 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_66), -->
-            <!--     column_alias='listing__ds__extract_quarter',      -->
+            <!--     column_alias='listing__ds__extract_year',         -->
             <!--   )                                                   -->
             <!-- col29 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_67), -->
-            <!--     column_alias='listing__ds__extract_month',        -->
+            <!--     column_alias='listing__ds__extract_quarter',      -->
             <!--   )                                                   -->
             <!-- col30 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_68), -->
-            <!--     column_alias='listing__ds__extract_day',          -->
+            <!--     column_alias='listing__ds__extract_month',        -->
             <!--   )                                                   -->
             <!-- col31 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_69), -->
-            <!--     column_alias='listing__ds__extract_dow',          -->
+            <!--     column_alias='listing__ds__extract_day',          -->
             <!--   )                                                   -->
             <!-- col32 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_70), -->
-            <!--     column_alias='listing__ds__extract_doy',          -->
+            <!--     column_alias='listing__ds__extract_dow',          -->
             <!--   )                                                   -->
             <!-- col33 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_71), -->
-            <!--     column_alias='listing__created_at__day',          -->
+            <!--     column_alias='listing__ds__extract_doy',          -->
             <!--   )                                                   -->
             <!-- col34 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_72), -->
-            <!--     column_alias='listing__created_at__week',         -->
+            <!--     column_alias='listing__created_at__day',          -->
             <!--   )                                                   -->
             <!-- col35 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_73), -->
-            <!--     column_alias='listing__created_at__month',        -->
+            <!--     column_alias='listing__created_at__week',         -->
             <!--   )                                                   -->
             <!-- col36 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_74), -->
-            <!--     column_alias='listing__created_at__quarter',      -->
+            <!--     column_alias='listing__created_at__month',        -->
             <!--   )                                                   -->
             <!-- col37 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_75), -->
-            <!--     column_alias='listing__created_at__year',         -->
+            <!--     column_alias='listing__created_at__quarter',      -->
             <!--   )                                                   -->
             <!-- col38 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_76), -->
+            <!--     column_alias='listing__created_at__year',         -->
+            <!--   )                                                   -->
+            <!-- col39 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77), -->
             <!--     column_alias='listing__created_at__extract_year', -->
             <!--   )                                                   -->
-            <!-- col39 =                                                  -->
+            <!-- col40 =                                                  -->
             <!--   SqlSelectColumn(                                       -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_77),    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78),    -->
             <!--     column_alias='listing__created_at__extract_quarter', -->
             <!--   )                                                      -->
-            <!-- col40 =                                                -->
+            <!-- col41 =                                                -->
             <!--   SqlSelectColumn(                                     -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_78),  -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79),  -->
             <!--     column_alias='listing__created_at__extract_month', -->
             <!--   )                                                    -->
-            <!-- col41 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_79), -->
-            <!--     column_alias='listing__created_at__extract_day',  -->
-            <!--   )                                                   -->
             <!-- col42 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_80), -->
-            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--     column_alias='listing__created_at__extract_day',  -->
             <!--   )                                                   -->
             <!-- col43 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_81), -->
+            <!--     column_alias='listing__created_at__extract_dow',  -->
+            <!--   )                                                   -->
+            <!-- col44 =                                               -->
+            <!--   SqlSelectColumn(                                    -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_82), -->
             <!--     column_alias='listing__created_at__extract_doy',  -->
             <!--   )                                                   -->
-            <!-- col44 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='metric_time__day') -->
-            <!-- col45 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_82), column_alias='listing') -->
-            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='user') -->
-            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='listing__user') -->
-            <!-- col48 =                                                                                            -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='country_latest') -->
-            <!-- col49 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='is_lux_latest') -->
-            <!-- col50 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='capacity_latest') -->
-            <!-- col51 =                                               -->
-            <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_35), -->
-            <!--     column_alias='listing__country_latest',           -->
-            <!--   )                                                   -->
+            <!-- col45 =                                                                                              -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_86), column_alias='metric_time__day') -->
+            <!-- col46 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_83), column_alias='listing') -->
+            <!-- col47 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_84), column_alias='user') -->
+            <!-- col48 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_85), column_alias='listing__user') -->
+            <!-- col49 =                                                                                            -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_33), column_alias='country_latest') -->
+            <!-- col50 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_34), column_alias='is_lux_latest') -->
+            <!-- col51 =                                                                                             -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_35), column_alias='capacity_latest') -->
             <!-- col52 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_36), -->
-            <!--     column_alias='listing__is_lux_latest',            -->
+            <!--     column_alias='listing__country_latest',           -->
             <!--   )                                                   -->
             <!-- col53 =                                               -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_37), -->
-            <!--     column_alias='listing__capacity_latest',          -->
+            <!--     column_alias='listing__is_lux_latest',            -->
             <!--   )                                                   -->
             <!-- col54 =                                               -->
             <!--   SqlSelectColumn(                                    -->
-            <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
-            <!--     column_alias='user__home_state_latest',           -->
+            <!--     expr=SqlColumnReferenceExpression(node_id=cr_38), -->
+            <!--     column_alias='listing__capacity_latest',          -->
             <!--   )                                                   -->
-            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_29), column_alias='listings') -->
+            <!-- col55 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='listings') -->
             <!-- col56 =                                                                                             -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_30), column_alias='largest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
-            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='smallest_listing') -->
+            <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
             <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
             <!-- join_0 =                                               -->
             <!--   SqlJoinDescription(                                  -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/BigQuery/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Databricks/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/DuckDB/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Postgres/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Redshift/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Snowflake/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0.sql
@@ -39,10 +39,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
+              subq_4.home_state_latest AS user__home_state_latest
+              , subq_2.metric_time__day AS metric_time__day
               , subq_2.user AS user
               , subq_2.visit__referrer_id AS visit__referrer_id
-              , subq_4.home_state_latest AS user__home_state_latest
               , subq_2.visits AS visits
             FROM (
               -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
@@ -301,7 +301,8 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_11.ds__day AS ds__day
+                  subq_13.home_state_latest AS user__home_state_latest
+                  , subq_11.ds__day AS ds__day
                   , subq_11.ds__week AS ds__week
                   , subq_11.ds__month AS ds__month
                   , subq_11.ds__quarter AS ds__quarter
@@ -340,7 +341,6 @@ FROM (
                   , subq_11.visit__session AS visit__session
                   , subq_11.referrer_id AS referrer_id
                   , subq_11.visit__referrer_id AS visit__referrer_id
-                  , subq_13.home_state_latest AS user__home_state_latest
                   , subq_11.visits AS visits
                   , subq_11.visitors AS visitors
                 FROM (

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_conversion_metric_query_filters__plan0_optimized.sql
@@ -112,10 +112,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_36.metric_time__day AS metric_time__day
+            users_latest_src_28000.home_state_latest AS user__home_state_latest
+            , subq_36.metric_time__day AS metric_time__day
             , subq_36.user AS user
             , subq_36.visit__referrer_id AS visit__referrer_id
-            , users_latest_src_28000.home_state_latest AS user__home_state_latest
             , subq_36.visits AS visits
           FROM (
             -- Read Elements From Semantic Model 'visits_source'

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_cumulative_metric_with_query_time_filters__plan0.sql
@@ -32,10 +32,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.metric_time__day AS metric_time__day
+            subq_8.country_latest AS listing__country_latest
+            , subq_5.metric_time__day AS metric_time__day
             , subq_5.listing AS listing
             , subq_5.booking__is_instant AS booking__is_instant
-            , subq_8.country_latest AS listing__country_latest
             , subq_5.bookers AS bookers
           FROM (
             -- Pass Only Elements: ['bookers', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_fill_nulls_time_spine_metric_predicate_pushdown__plan0.sql
@@ -57,10 +57,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_2.metric_time__day AS metric_time__day
+                  subq_5.country_latest AS listing__country_latest
+                  , subq_2.metric_time__day AS metric_time__day
                   , subq_2.listing AS listing
                   , subq_2.booking__is_instant AS booking__is_instant
-                  , subq_5.country_latest AS listing__country_latest
                   , subq_2.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -465,10 +465,10 @@ FROM (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_20.metric_time__day AS metric_time__day
+                  subq_23.country_latest AS listing__country_latest
+                  , subq_20.metric_time__day AS metric_time__day
                   , subq_20.listing AS listing
                   , subq_20.booking__is_instant AS booking__is_instant
-                  , subq_23.country_latest AS listing__country_latest
                   , subq_20.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_metric_time_filter_with_two_targets__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_multiple_categorical_dimension_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.user AS user
+            subq_4.home_state_latest AS user__home_state_latest
+            , subq_2.user AS user
             , subq_2.listing__is_lux_latest AS listing__is_lux_latest
             , subq_2.listing__capacity_latest AS listing__capacity_latest
-            , subq_4.home_state_latest AS user__home_state_latest
             , subq_2.listings AS listings
           FROM (
             -- Pass Only Elements: ['listings', 'listing__is_lux_latest', 'listing__capacity_latest', 'user']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_offset_metric_with_query_time_filters__plan0.sql
@@ -45,10 +45,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.country_latest AS listing__country_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
                 , subq_2.booking__is_instant AS booking__is_instant
-                , subq_5.country_latest AS listing__country_latest
                 , subq_2.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']
@@ -438,10 +438,10 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_17.metric_time__day AS metric_time__day
+                subq_20.country_latest AS listing__country_latest
+                , subq_17.metric_time__day AS metric_time__day
                 , subq_17.listing AS listing
                 , subq_17.booking__is_instant AS booking__is_instant
-                , subq_20.country_latest AS listing__country_latest
                 , subq_17.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'booking__is_instant', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_saved_query_with_metric_joins_and_filter__plan0.sql
@@ -36,10 +36,10 @@ FROM (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_2.metric_time__day AS metric_time__day
-              , subq_2.listing AS listing
-              , subq_5.is_lux_latest AS listing__is_lux_latest
+              subq_5.is_lux_latest AS listing__is_lux_latest
               , subq_5.capacity_latest AS listing__capacity_latest
+              , subq_2.metric_time__day AS metric_time__day
+              , subq_2.listing AS listing
               , subq_2.bookings AS bookings
             FROM (
               -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -425,10 +425,10 @@ FULL OUTER JOIN (
           FROM (
             -- Join Standard Outputs
             SELECT
-              subq_14.metric_time__day AS metric_time__day
-              , subq_14.listing AS listing
-              , subq_17.is_lux_latest AS listing__is_lux_latest
+              subq_17.is_lux_latest AS listing__is_lux_latest
               , subq_17.capacity_latest AS listing__capacity_latest
+              , subq_14.metric_time__day AS metric_time__day
+              , subq_14.listing AS listing
               , subq_14.views AS views
             FROM (
               -- Pass Only Elements: ['views', 'metric_time__day', 'listing']
@@ -750,10 +750,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_26.metric_time__day AS metric_time__day
-                  , subq_26.listing AS listing
-                  , subq_29.is_lux_latest AS listing__is_lux_latest
+                  subq_29.is_lux_latest AS listing__is_lux_latest
                   , subq_29.capacity_latest AS listing__capacity_latest
+                  , subq_26.metric_time__day AS metric_time__day
+                  , subq_26.listing AS listing
                   , subq_26.bookings AS bookings
                 FROM (
                   -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -1139,10 +1139,10 @@ FULL OUTER JOIN (
               FROM (
                 -- Join Standard Outputs
                 SELECT
-                  subq_38.metric_time__day AS metric_time__day
-                  , subq_38.listing AS listing
-                  , subq_41.is_lux_latest AS listing__is_lux_latest
+                  subq_41.is_lux_latest AS listing__is_lux_latest
                   , subq_41.capacity_latest AS listing__capacity_latest
+                  , subq_38.metric_time__day AS metric_time__day
+                  , subq_38.listing AS listing
                   , subq_38.views AS views
                 FROM (
                   -- Pass Only Elements: ['views', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_single_categorical_dimension_pushdown__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_skipped_pushdown__plan0.sql
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_rendering.py/SqlQueryPlan/Trino/test_skipped_pushdown__plan0.sql
@@ -29,10 +29,10 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
-            , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
+            subq_5.country_latest AS listing__country_latest
             , subq_5.is_lux_latest AS listing__is_lux_latest
+            , subq_2.listing AS listing
+            , subq_2.booking__is_instant AS booking__is_instant
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/BigQuery/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Databricks/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/DuckDB/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Postgres/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Redshift/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Snowflake/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_filter_with_where_constraint_on_join_dim__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_filter_with_where_constraint_on_join_dim__plan0.sql
@@ -27,9 +27,9 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.listing AS listing
+            subq_5.country_latest AS listing__country_latest
+            , subq_2.listing AS listing
             , subq_2.booking__is_instant AS booking__is_instant
-            , subq_5.country_latest AS listing__country_latest
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'booking__is_instant', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_join_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_join_to_scd_dimension__plan0.sql
@@ -27,11 +27,11 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_2.metric_time__day AS metric_time__day
+            subq_4.capacity AS listing__capacity
             , subq_4.window_start__day AS listing__window_start__day
             , subq_4.window_end__day AS listing__window_end__day
+            , subq_2.metric_time__day AS metric_time__day
             , subq_2.listing AS listing
-            , subq_4.capacity AS listing__capacity
             , subq_2.bookings AS bookings
           FROM (
             -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_measure_constraint__plan0.sql
@@ -39,9 +39,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_2.metric_time__day AS metric_time__day
+                subq_5.is_lux_latest AS listing__is_lux_latest
+                , subq_2.metric_time__day AS metric_time__day
                 , subq_2.listing AS listing
-                , subq_5.is_lux_latest AS listing__is_lux_latest
                 , subq_2.average_booking_value AS average_booking_value
               FROM (
                 -- Pass Only Elements: ['average_booking_value', 'metric_time__day', 'listing']
@@ -424,9 +424,9 @@ FROM (
             FROM (
               -- Join Standard Outputs
               SELECT
-                subq_14.metric_time__day AS metric_time__day
+                subq_17.is_lux_latest AS listing__is_lux_latest
+                , subq_14.metric_time__day AS metric_time__day
                 , subq_14.listing AS listing
-                , subq_17.is_lux_latest AS listing__is_lux_latest
                 , subq_14.bookings AS bookings
               FROM (
                 -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_through_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_7.window_start__day AS listing__window_start__day
         , subq_7.window_end__day AS listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.user__home_state_latest AS listing__user__home_state_latest
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,19 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_3.window_start__day AS window_start__day
+            subq_5.home_state_latest AS user__home_state_latest
+            , subq_5.ds__day AS user__ds__day
+            , subq_5.ds__week AS user__ds__week
+            , subq_5.ds__month AS user__ds__month
+            , subq_5.ds__quarter AS user__ds__quarter
+            , subq_5.ds__year AS user__ds__year
+            , subq_5.ds__extract_year AS user__ds__extract_year
+            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
+            , subq_5.ds__extract_month AS user__ds__extract_month
+            , subq_5.ds__extract_day AS user__ds__extract_day
+            , subq_5.ds__extract_dow AS user__ds__extract_dow
+            , subq_5.ds__extract_doy AS user__ds__extract_doy
+            , subq_3.window_start__day AS window_start__day
             , subq_3.window_start__week AS window_start__week
             , subq_3.window_start__month AS window_start__month
             , subq_3.window_start__quarter AS window_start__quarter
@@ -268,17 +280,6 @@ FROM (
             , subq_3.listing__window_end__extract_day AS listing__window_end__extract_day
             , subq_3.listing__window_end__extract_dow AS listing__window_end__extract_dow
             , subq_3.listing__window_end__extract_doy AS listing__window_end__extract_doy
-            , subq_5.ds__day AS user__ds__day
-            , subq_5.ds__week AS user__ds__week
-            , subq_5.ds__month AS user__ds__month
-            , subq_5.ds__quarter AS user__ds__quarter
-            , subq_5.ds__year AS user__ds__year
-            , subq_5.ds__extract_year AS user__ds__extract_year
-            , subq_5.ds__extract_quarter AS user__ds__extract_quarter
-            , subq_5.ds__extract_month AS user__ds__extract_month
-            , subq_5.ds__extract_day AS user__ds__extract_day
-            , subq_5.ds__extract_dow AS user__ds__extract_dow
-            , subq_5.ds__extract_doy AS user__ds__extract_doy
             , subq_3.listing AS listing
             , subq_3.user AS user
             , subq_3.listing__user AS listing__user
@@ -288,7 +289,6 @@ FROM (
             , subq_3.listing__country AS listing__country
             , subq_3.listing__is_lux AS listing__is_lux
             , subq_3.listing__capacity AS listing__capacity
-            , subq_5.home_state_latest AS user__home_state_latest
           FROM (
             -- Read Elements From Semantic Model 'listings'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multi_hop_to_scd_dimension__plan0.sql
@@ -18,11 +18,11 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.metric_time__day AS metric_time__day
+        subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_7.lux_listing__window_start__day AS listing__lux_listing__window_start__day
         , subq_7.lux_listing__window_end__day AS listing__lux_listing__window_end__day
+        , subq_2.metric_time__day AS metric_time__day
         , subq_2.listing AS listing
-        , subq_7.lux_listing__is_confirmed_lux AS listing__lux_listing__is_confirmed_lux
         , subq_2.bookings AS bookings
       FROM (
         -- Pass Only Elements: ['bookings', 'metric_time__day', 'listing']
@@ -224,7 +224,8 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_5.window_start__day AS lux_listing__window_start__day
+            subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
+            , subq_5.window_start__day AS lux_listing__window_start__day
             , subq_5.window_start__week AS lux_listing__window_start__week
             , subq_5.window_start__month AS lux_listing__window_start__month
             , subq_5.window_start__quarter AS lux_listing__window_start__quarter
@@ -249,7 +250,6 @@ FROM (
             , subq_3.listing AS listing
             , subq_3.lux_listing AS lux_listing
             , subq_3.listing__lux_listing AS listing__lux_listing
-            , subq_5.is_confirmed_lux AS lux_listing__is_confirmed_lux
           FROM (
             -- Read Elements From Semantic Model 'lux_listing_mapping'
             SELECT

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_multihop_node__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_9.ds_partitioned__day AS account_id__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.account_id AS account_id
-        , subq_9.customer_id__customer_name AS account_id__customer_id__customer_name
         , subq_2.txn_count AS txn_count
       FROM (
         -- Pass Only Elements: ['txn_count', 'ds_partitioned__day', 'account_id']
@@ -152,7 +152,31 @@ FROM (
         FROM (
           -- Join Standard Outputs
           SELECT
-            subq_4.ds_partitioned__day AS ds_partitioned__day
+            subq_7.customer_name AS customer_id__customer_name
+            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
+            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
+            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
+            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
+            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
+            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
+            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
+            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
+            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
+            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
+            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
+            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
+            , subq_7.metric_time__day AS customer_id__metric_time__day
+            , subq_7.metric_time__week AS customer_id__metric_time__week
+            , subq_7.metric_time__month AS customer_id__metric_time__month
+            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
+            , subq_7.metric_time__year AS customer_id__metric_time__year
+            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
+            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
+            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
+            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
+            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
+            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
+            , subq_4.ds_partitioned__day AS ds_partitioned__day
             , subq_4.ds_partitioned__week AS ds_partitioned__week
             , subq_4.ds_partitioned__month AS ds_partitioned__month
             , subq_4.ds_partitioned__quarter AS ds_partitioned__quarter
@@ -196,28 +220,6 @@ FROM (
             , subq_4.metric_time__extract_day AS metric_time__extract_day
             , subq_4.metric_time__extract_dow AS metric_time__extract_dow
             , subq_4.metric_time__extract_doy AS metric_time__extract_doy
-            , subq_7.ds_partitioned__day AS customer_id__ds_partitioned__day
-            , subq_7.ds_partitioned__week AS customer_id__ds_partitioned__week
-            , subq_7.ds_partitioned__month AS customer_id__ds_partitioned__month
-            , subq_7.ds_partitioned__quarter AS customer_id__ds_partitioned__quarter
-            , subq_7.ds_partitioned__year AS customer_id__ds_partitioned__year
-            , subq_7.ds_partitioned__extract_year AS customer_id__ds_partitioned__extract_year
-            , subq_7.ds_partitioned__extract_quarter AS customer_id__ds_partitioned__extract_quarter
-            , subq_7.ds_partitioned__extract_month AS customer_id__ds_partitioned__extract_month
-            , subq_7.ds_partitioned__extract_day AS customer_id__ds_partitioned__extract_day
-            , subq_7.ds_partitioned__extract_dow AS customer_id__ds_partitioned__extract_dow
-            , subq_7.ds_partitioned__extract_doy AS customer_id__ds_partitioned__extract_doy
-            , subq_7.metric_time__day AS customer_id__metric_time__day
-            , subq_7.metric_time__week AS customer_id__metric_time__week
-            , subq_7.metric_time__month AS customer_id__metric_time__month
-            , subq_7.metric_time__quarter AS customer_id__metric_time__quarter
-            , subq_7.metric_time__year AS customer_id__metric_time__year
-            , subq_7.metric_time__extract_year AS customer_id__metric_time__extract_year
-            , subq_7.metric_time__extract_quarter AS customer_id__metric_time__extract_quarter
-            , subq_7.metric_time__extract_month AS customer_id__metric_time__extract_month
-            , subq_7.metric_time__extract_day AS customer_id__metric_time__extract_day
-            , subq_7.metric_time__extract_dow AS customer_id__metric_time__extract_dow
-            , subq_7.metric_time__extract_doy AS customer_id__metric_time__extract_doy
             , subq_4.account_id AS account_id
             , subq_4.customer_id AS customer_id
             , subq_4.account_id__customer_id AS account_id__customer_id
@@ -226,8 +228,6 @@ FROM (
             , subq_4.extra_dim AS extra_dim
             , subq_4.account_id__extra_dim AS account_id__extra_dim
             , subq_4.bridge_account__extra_dim AS bridge_account__extra_dim
-            , subq_7.customer_name AS customer_id__customer_name
-            , subq_7.customer_atomic_weight AS customer_id__customer_atomic_weight
             , subq_4.account_customer_combos AS account_customer_combos
           FROM (
             -- Metric Time Dimension 'ds_partitioned'

--- a/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_partitioned_join__plan0.sql
+++ b/tests_metricflow/snapshots/test_query_rendering.py/SqlQueryPlan/Trino/test_partitioned_join__plan0.sql
@@ -15,10 +15,10 @@ FROM (
     FROM (
       -- Join Standard Outputs
       SELECT
-        subq_2.ds_partitioned__day AS ds_partitioned__day
+        subq_5.home_state AS user__home_state
         , subq_5.ds_partitioned__day AS user__ds_partitioned__day
+        , subq_2.ds_partitioned__day AS ds_partitioned__day
         , subq_2.user AS user
-        , subq_5.home_state AS user__home_state
         , subq_2.identity_verifications AS identity_verifications
       FROM (
         -- Pass Only Elements: ['identity_verifications', 'ds_partitioned__day', 'user']


### PR DESCRIPTION
There is an internal bug in the dataflow to SQL logic for the `JoinOnEntitiesNode` that does not appear to impact production, but does impact work I'm doing up the stack. The instances generated in the node contained column associations that were not correct. They referenced the old column associations (from the parent dataset), which did not include the entity links that were added in this node. These incorrect column associations did not appear to be used for anything, and the select columns were generated from the specs instead (which is correct), so that's why this bug flew under the radar.

This PR removes the logic that was causing the bug (the `AddLinkToLinkableElements` instance converter). Instead, it adds logic to loop through the parent instances and build new instances & select columns simultaneously.

This change left a lot of boilerplate & duplicate code in the function, so I moved a lot of that out to helpers for the instances and specs.

This also adds a lot of simplification for the `JoinOnEntitiesNode`. It's one of our oldest nodes and was quite verbose. 

I recommend reviewing by commit. The snapshot changes are primarily changes to the column order and some node identifiers. There should be no actual behavior changes here.