### PR TITLE
Split column pruner into two phases

### DIFF
--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -385,7 +385,9 @@ class DataflowToSqlQueryPlanConverter(DataflowPlanNodeVisitor[SqlDataSet]):
     def visit_source_node(self, node: ReadSqlSourceNode) -> SqlDataSet:
         """Generate the SQL to read from the source."""
         return SqlDataSet(
-            sql_select_node=node.data_set.checked_sql_select_node,
+            # This visitor is assumed to create a unique SELECT node for each dataflow node, so create a copy.
+            # The column pruner relies on this assumption to keep track of what columns are required at each node.
+            sql_select_node=node.data_set.checked_sql_select_node.create_copy(),
             instance_set=node.data_set.instance_set,
         )
 

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -108,7 +108,7 @@ class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
 
         # Can't prune without knowing the structure of the query.
         if required_select_columns is None:
-            logger.debug(
+            logger.error(
                 LazyFormat(
                     "The columns required at this node can't be determined, so skipping column pruning",
                     node=node.structure_text(),

--- a/metricflow/sql/optimizer/column_pruner.py
+++ b/metricflow/sql/optimizer/column_pruner.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
-from typing import Dict, List, Set, Tuple
+from typing import FrozenSet, Mapping
 
 from typing_extensions import override
 
 from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
-from metricflow.sql.sql_exprs import (
-    SqlExpressionTreeLineage,
-)
+from metricflow.sql.optimizer.tag_column_aliases import TaggedColumnAliasSet
+from metricflow.sql.optimizer.tag_required_column_aliases import SqlTagRequiredColumnAliasesVisitor
 from metricflow.sql.sql_plan import (
     SqlCreateTableAsNode,
     SqlCteNode,
-    SqlJoinDescription,
     SqlQueryPlanNode,
     SqlQueryPlanNodeVisitor,
-    SqlSelectColumn,
     SqlSelectQueryFromClauseNode,
     SqlSelectStatementNode,
     SqlTableNode,
@@ -28,177 +24,55 @@ logger = logging.getLogger(__name__)
 class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     """Removes unnecessary columns from SELECT statements in the SQL query plan.
 
-    As the visitor traverses up to the parents, it pushes the list of required columns and rewrites the parent nodes.
+    This requires a set of tagged column aliases that should be kept for each SQL node.
     """
 
     def __init__(
         self,
-        required_column_aliases: Set[str],
+        required_alias_mapping: Mapping[SqlQueryPlanNode, FrozenSet[str]],
     ) -> None:
         """Constructor.
 
         Args:
-            required_column_aliases: the columns aliases that should not be pruned from the SELECT statements that this
-            visits.
+            required_alias_mapping: Describes columns aliases that should be kept / not pruned for each node.
         """
-        self._required_column_aliases = required_column_aliases
-
-    def _search_for_expressions(
-        self, select_node: SqlSelectStatementNode, pruned_select_columns: Tuple[SqlSelectColumn, ...]
-    ) -> SqlExpressionTreeLineage:
-        """Returns the expressions used in the immediate select statement.
-
-        i.e. this does not return expressions used in sub-queries. pruned_select_columns needs to be passed in since the
-        node may have the select columns pruned.
-        """
-        all_expr_search_results: List[SqlExpressionTreeLineage] = []
-
-        for select_column in pruned_select_columns:
-            all_expr_search_results.append(select_column.expr.lineage)
-
-        for join_description in select_node.join_descs:
-            if join_description.on_condition:
-                all_expr_search_results.append(join_description.on_condition.lineage)
-
-        for group_by in select_node.group_bys:
-            all_expr_search_results.append(group_by.expr.lineage)
-
-        for order_by in select_node.order_bys:
-            all_expr_search_results.append(order_by.expr.lineage)
-
-        if select_node.where:
-            all_expr_search_results.append(select_node.where.lineage)
-
-        return SqlExpressionTreeLineage.combine(all_expr_search_results)
-
-    def _prune_columns_from_grandparents(
-        self, node: SqlSelectStatementNode, pruned_select_columns: Tuple[SqlSelectColumn, ...]
-    ) -> SqlSelectStatementNode:
-        """Assume that you need all columns from the parent and prune the grandparents."""
-        pruned_from_source: SqlQueryPlanNode
-        if node.from_source.as_select_node:
-            from_visitor = SqlColumnPrunerVisitor(
-                required_column_aliases={x.column_alias for x in node.from_source.as_select_node.select_columns}
-            )
-            pruned_from_source = node.from_source.as_select_node.accept(from_visitor)
-        else:
-            pruned_from_source = node.from_source
-        pruned_join_descriptions: List[SqlJoinDescription] = []
-        for join_description in node.join_descs:
-            right_source_as_select_node = join_description.right_source.as_select_node
-            if right_source_as_select_node:
-                right_source_visitor = SqlColumnPrunerVisitor(
-                    required_column_aliases={x.column_alias for x in right_source_as_select_node.select_columns}
-                )
-                pruned_join_descriptions.append(
-                    SqlJoinDescription(
-                        right_source=join_description.right_source.accept(right_source_visitor),
-                        right_source_alias=join_description.right_source_alias,
-                        on_condition=join_description.on_condition,
-                        join_type=join_description.join_type,
-                    )
-                )
-            else:
-                pruned_join_descriptions.append(join_description)
-
-        return SqlSelectStatementNode.create(
-            description=node.description,
-            select_columns=pruned_select_columns,
-            from_source=pruned_from_source,
-            from_source_alias=node.from_source_alias,
-            join_descs=tuple(pruned_join_descriptions),
-            group_bys=node.group_bys,
-            order_bys=node.order_bys,
-            where=node.where,
-            limit=node.limit,
-            distinct=node.distinct,
-        )
-
-    @override
-    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
-        raise NotImplementedError
+        self._required_alias_mapping = required_alias_mapping
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         # Remove columns that are not needed from this SELECT statement because the parent SELECT statement doesn't
         # need them. However, keep columns that are in group bys because that changes the meaning of the query.
         # Similarly, if this node is a distinct select node, keep all columns as it may return a different result set.
+        required_column_aliases = self._required_alias_mapping.get(node)
+        if required_column_aliases is None:
+            logger.error(
+                f"Did not find {node.node_id=} in the required alias mapping. Returning the non-pruned version "
+                f"as it should be valid SQL, but this is a bug and should be investigated."
+            )
+            return node
+
+        if len(required_column_aliases) == 0:
+            logger.error(
+                f"Got no required column aliases for {node}. Returning the non-pruned version as it should be valid "
+                f"SQL, but this is a bug and should be investigated."
+            )
+            return node
+
         pruned_select_columns = tuple(
             select_column
             for select_column in node.select_columns
-            if select_column.column_alias in self._required_column_aliases
-            or select_column in node.group_bys
-            or node.distinct
+            if select_column.column_alias in required_column_aliases
         )
-        # TODO: don't prune columns used in join condition! Tricky to derive since the join condition can be any
-        # SqlExpressionNode.
-
-        if len(pruned_select_columns) == 0:
-            raise RuntimeError(
-                "All columns have been removed - this indicates an bug in the pruner or in the inputs.\n"
-                f"Original column aliases: {[col.column_alias for col in node.select_columns]}\n"
-                f"Required column aliases: {self._required_column_aliases}\n"
-                f"Group bys: {node.group_bys}\n"
-                f"Distinct: {node.distinct}"
-            )
-
-        # Based on the expressions in this select statement, figure out what column aliases are needed in the sources of
-        # this query (i.e. tables or sub-queries in the FROM or JOIN clauses).
-        exprs_used_in_this_node = self._search_for_expressions(node, pruned_select_columns)
-
-        # If any of the string expressions don't have context on what columns are used in the expression, then it's
-        # impossible to know what columns can be pruned from the parent sources. So return a SELECT statement that
-        # leaves the parent sources untouched. Columns from the grandparents can be pruned based on the parent node
-        # though.
-        if any([string_expr.used_columns is None for string_expr in exprs_used_in_this_node.string_exprs]):
-            return self._prune_columns_from_grandparents(node, pruned_select_columns)
-
-        # Create a mapping from the source alias to the column aliases needed from the corresponding source.
-        source_alias_to_required_column_alias: Dict[str, Set[str]] = defaultdict(set)
-        for column_reference_expr in exprs_used_in_this_node.column_reference_exprs:
-            column_reference = column_reference_expr.col_ref
-            source_alias_to_required_column_alias[column_reference.table_alias].add(column_reference.column_name)
-
-        # For all string columns, assume that they are needed from all sources since we don't have a table alias
-        # in SqlStringExpression.used_columns
-        for string_expr in exprs_used_in_this_node.string_exprs:
-            if string_expr.used_columns:
-                for column_alias in string_expr.used_columns:
-                    source_alias_to_required_column_alias[node.from_source_alias].add(column_alias)
-                    for join_description in node.join_descs:
-                        source_alias_to_required_column_alias[join_description.right_source_alias].add(column_alias)
-        # Same with unqualified column references.
-        for unqualified_column_reference_expr in exprs_used_in_this_node.column_alias_reference_exprs:
-            column_alias = unqualified_column_reference_expr.column_alias
-            source_alias_to_required_column_alias[node.from_source_alias].add(column_alias)
-            for join_description in node.join_descs:
-                source_alias_to_required_column_alias[join_description.right_source_alias].add(column_alias)
-
-        # Once we know which column aliases are required from which source aliases, replace the sources with new SELECT
-        # statements.
-        from_source_pruner = SqlColumnPrunerVisitor(
-            required_column_aliases=source_alias_to_required_column_alias[node.from_source_alias]
-        )
-        pruned_from_source = node.from_source.accept(from_source_pruner)
-        pruned_join_descriptions: List[SqlJoinDescription] = []
-        for join_description in node.join_descs:
-            join_source_pruner = SqlColumnPrunerVisitor(
-                required_column_aliases=source_alias_to_required_column_alias[join_description.right_source_alias]
-            )
-            pruned_join_descriptions.append(
-                SqlJoinDescription(
-                    right_source=join_description.right_source.accept(join_source_pruner),
-                    right_source_alias=join_description.right_source_alias,
-                    on_condition=join_description.on_condition,
-                    join_type=join_description.join_type,
-                )
-            )
 
         return SqlSelectStatementNode.create(
             description=node.description,
-            select_columns=tuple(pruned_select_columns),
-            from_source=pruned_from_source,
+            select_columns=pruned_select_columns,
+            from_source=node.from_source.accept(self),
             from_source_alias=node.from_source_alias,
-            join_descs=tuple(pruned_join_descriptions),
+            # TODO: Handle CTEs.
+            cte_sources=(),
+            join_descs=tuple(
+                join_desc.with_right_source(join_desc.right_source.accept(self)) for join_desc in node.join_descs
+            ),
             group_bys=node.group_bys,
             order_bys=node.order_bys,
             where=node.where,
@@ -220,6 +94,10 @@ class SqlColumnPrunerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             parent_node=node.parent_node.accept(self),
         )
 
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
+        raise NotImplementedError
+
 
 class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
     """Removes unnecessary columns in the SELECT clauses."""
@@ -229,8 +107,16 @@ class SqlColumnPrunerOptimizer(SqlQueryPlanOptimizer):
         if not node.as_select_node:
             return node
 
-        pruning_visitor = SqlColumnPrunerVisitor(
-            required_column_aliases={x.column_alias for x in node.as_select_node.select_columns}
+        # Figure out which columns in which nodes are required.
+        tagged_column_alias_set = TaggedColumnAliasSet()
+        tagged_column_alias_set.tag_all_aliases_in_node(node.as_select_node)
+        tag_required_column_alias_visitor = SqlTagRequiredColumnAliasesVisitor(
+            tagged_column_alias_set=tagged_column_alias_set,
         )
+        node.accept(tag_required_column_alias_visitor)
 
+        # Re-write the query, pruning columns in the SELECT that are not needed.
+        pruning_visitor = SqlColumnPrunerVisitor(
+            required_alias_mapping=tagged_column_alias_set.get_mapping(),
+        )
         return node.accept(pruning_visitor)

--- a/metricflow/sql/optimizer/tag_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_column_aliases.py
@@ -2,95 +2,32 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Dict, FrozenSet, Iterable, Mapping, Set
-
-from typing_extensions import override
+from typing import Dict, FrozenSet, Iterable, Set
 
 from metricflow.sql.sql_plan import (
-    SqlCreateTableAsNode,
-    SqlCteNode,
     SqlQueryPlanNode,
-    SqlQueryPlanNodeVisitor,
-    SqlSelectQueryFromClauseNode,
-    SqlSelectStatementNode,
-    SqlTableNode,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class TaggedColumnAliasSet:
-    """Keep track of column aliases in SELECT statements that have been tagged.
+class NodeToColumnAliasMapping:
+    """Mutable class for mapping a SQL node to an arbitrary set of column aliases for that node.
 
-    The main use case for this class is to keep track of column aliases / columns that are required so that unnecessary
-    columns can be pruned.
-
-    For example, in this query:
-
-        SELECT source_0.col_0 AS col_0
-        FROM (
-            SELECT
-                example_table.col_0
-                example_table.col_1
-            FROM example_table
-        ) source_0
-
-    this class can be used to tag `example_table.col_0` but not tag `example_table.col_1` since it's not needed for the
-    query to run correctly.
+    * Alternatively, this can be described as mapping a location in the SQL query plan to a set of column aliases.
+    * See `SqlMapRequiredColumnAliasesVisitor` for the main use case for this class.
+    * This is a thin wrapper over a dict to aid readability.
     """
 
     def __init__(self) -> None:  # noqa: D107
         self._node_to_tagged_aliases: Dict[SqlQueryPlanNode, Set[str]] = defaultdict(set)
 
-    def get_tagged_aliases(self, node: SqlQueryPlanNode) -> FrozenSet[str]:
-        """Return the given tagged column aliases associated with the given SQL node."""
+    def get_aliases(self, node: SqlQueryPlanNode) -> FrozenSet[str]:
+        """Return the column aliases added for the given SQL node."""
         return frozenset(self._node_to_tagged_aliases[node])
 
-    def tag_alias(self, node: SqlQueryPlanNode, column_alias: str) -> None:  # noqa: D102
+    def add_alias(self, node: SqlQueryPlanNode, column_alias: str) -> None:  # noqa: D102
         return self._node_to_tagged_aliases[node].add(column_alias)
 
-    def tag_aliases(self, node: SqlQueryPlanNode, column_aliases: Iterable[str]) -> None:  # noqa: D102
+    def add_aliases(self, node: SqlQueryPlanNode, column_aliases: Iterable[str]) -> None:  # noqa: D102
         self._node_to_tagged_aliases[node].update(column_aliases)
-
-    def tag_all_aliases_in_node(self, node: SqlQueryPlanNode) -> None:
-        """Convenience method that tags all column aliases in the given SQL node, where appropriate."""
-        node.accept(_TagAllColumnAliasesInNodeVisitor(self))
-
-    def get_mapping(self) -> Mapping[SqlQueryPlanNode, FrozenSet[str]]:
-        """Return mapping view that associates a given SQL node with the tagged column aliases in that node."""
-        return {node: frozenset(tagged_aliases) for node, tagged_aliases in self._node_to_tagged_aliases.items()}
-
-
-class _TagAllColumnAliasesInNodeVisitor(SqlQueryPlanNodeVisitor[None]):
-    """Visitor to help implement `TaggedColumnAliasSet.tag_all_aliases_in_node`."""
-
-    def __init__(self, required_column_alias_collector: TaggedColumnAliasSet) -> None:
-        self._required_column_alias_collector = required_column_alias_collector
-
-    @override
-    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> None:
-        for select_column in node.select_columns:
-            self._required_column_alias_collector.tag_alias(
-                node=node,
-                column_alias=select_column.column_alias,
-            )
-
-    @override
-    def visit_table_node(self, node: SqlTableNode) -> None:
-        """Columns in a SQL table are not represented."""
-        pass
-
-    @override
-    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> None:
-        """Columns in an arbitrary SQL query are not represented."""
-        pass
-
-    @override
-    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> None:
-        for parent_node in node.parent_nodes:
-            parent_node.accept(self)
-
-    @override
-    def visit_cte_node(self, node: SqlCteNode) -> None:
-        for parent_node in node.parent_nodes:
-            parent_node.accept(self)

--- a/metricflow/sql/optimizer/tag_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_column_aliases.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Dict, FrozenSet, Iterable, Mapping, Set
+
+from typing_extensions import override
+
+from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
+    SqlCteNode,
+    SqlQueryPlanNode,
+    SqlQueryPlanNodeVisitor,
+    SqlSelectQueryFromClauseNode,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TaggedColumnAliasSet:
+    """Keep track of column aliases in SELECT statements that have been tagged.
+
+    The main use case for this class is to keep track of column aliases / columns that are required so that unnecessary
+    columns can be pruned.
+
+    For example, in this query:
+
+        SELECT source_0.col_0 AS col_0
+        FROM (
+            SELECT
+                example_table.col_0
+                example_table.col_1
+            FROM example_table
+        ) source_0
+
+    this class can be used to tag `example_table.col_0` but not tag `example_table.col_1` since it's not needed for the
+    query to run correctly.
+    """
+
+    def __init__(self) -> None:  # noqa: D107
+        self._node_to_tagged_aliases: Dict[SqlQueryPlanNode, Set[str]] = defaultdict(set)
+
+    def get_tagged_aliases(self, node: SqlQueryPlanNode) -> FrozenSet[str]:
+        """Return the given tagged column aliases associated with the given SQL node."""
+        return frozenset(self._node_to_tagged_aliases[node])
+
+    def tag_alias(self, node: SqlQueryPlanNode, column_alias: str) -> None:  # noqa: D102
+        return self._node_to_tagged_aliases[node].add(column_alias)
+
+    def tag_aliases(self, node: SqlQueryPlanNode, column_aliases: Iterable[str]) -> None:  # noqa: D102
+        self._node_to_tagged_aliases[node].update(column_aliases)
+
+    def tag_all_aliases_in_node(self, node: SqlQueryPlanNode) -> None:
+        """Convenience method that tags all column aliases in the given SQL node, where appropriate."""
+        node.accept(_TagAllColumnAliasesInNodeVisitor(self))
+
+    def get_mapping(self) -> Mapping[SqlQueryPlanNode, FrozenSet[str]]:
+        """Return mapping view that associates a given SQL node with the tagged column aliases in that node."""
+        return {node: frozenset(tagged_aliases) for node, tagged_aliases in self._node_to_tagged_aliases.items()}
+
+
+class _TagAllColumnAliasesInNodeVisitor(SqlQueryPlanNodeVisitor[None]):
+    """Visitor to help implement `TaggedColumnAliasSet.tag_all_aliases_in_node`."""
+
+    def __init__(self, required_column_alias_collector: TaggedColumnAliasSet) -> None:
+        self._required_column_alias_collector = required_column_alias_collector
+
+    @override
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> None:
+        for select_column in node.select_columns:
+            self._required_column_alias_collector.tag_alias(
+                node=node,
+                column_alias=select_column.column_alias,
+            )
+
+    @override
+    def visit_table_node(self, node: SqlTableNode) -> None:
+        """Columns in a SQL table are not represented."""
+        pass
+
+    @override
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> None:
+        """Columns in an arbitrary SQL query are not represented."""
+        pass
+
+    @override
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> None:
+        for parent_node in node.parent_nodes:
+            parent_node.accept(self)
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> None:
+        for parent_node in node.parent_nodes:
+            parent_node.accept(self)

--- a/metricflow/sql/optimizer/tag_required_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_required_column_aliases.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Dict, List, Set, Tuple
+
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from typing_extensions import override
+
+from metricflow.sql.optimizer.tag_column_aliases import TaggedColumnAliasSet
+from metricflow.sql.sql_exprs import SqlExpressionTreeLineage
+from metricflow.sql.sql_plan import (
+    SqlCreateTableAsNode,
+    SqlCteNode,
+    SqlQueryPlanNode,
+    SqlQueryPlanNodeVisitor,
+    SqlSelectColumn,
+    SqlSelectQueryFromClauseNode,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SqlTagRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
+    """To aid column pruning, traverse the SQL-query representation DAG and tag all column aliases that are required.
+
+    For example, for the query:
+
+        SELECT source_0.col_0 AS col_0_renamed
+        FROM (
+            SELECT
+                example_table.col_0
+                example_table.col_1
+            FROM example_table_0
+        ) source_0
+
+    The top-level SQL node would have the column alias `col_0_renamed` tagged, and the SQL node associated with
+    `source_0` would have `col_0` tagged. Once tagged, the information can be used to prune the columns in the SELECT:
+
+        SELECT source_0.col_0 AS col_0_renamed
+        FROM (
+            SELECT
+                example_table.col_0
+            FROM example_table_0
+        ) source_0
+    """
+
+    def __init__(self, tagged_column_alias_set: TaggedColumnAliasSet) -> None:
+        """Initializer.
+
+        Args:
+            tagged_column_alias_set: Stores the set of columns that are tagged. This will be updated as the visitor
+            traverses the SQL-query representation DAG.
+        """
+        self._column_alias_tagger = tagged_column_alias_set
+
+    def _search_for_expressions(
+        self, select_node: SqlSelectStatementNode, pruned_select_columns: Tuple[SqlSelectColumn, ...]
+    ) -> SqlExpressionTreeLineage:
+        """Returns the expressions used in the immediate select statement.
+
+        i.e. this does not return expressions used in sub-queries. pruned_select_columns needs to be passed in since the
+        node may have the select columns pruned.
+        """
+        all_expr_search_results: List[SqlExpressionTreeLineage] = []
+
+        for select_column in pruned_select_columns:
+            all_expr_search_results.append(select_column.expr.lineage)
+
+        for join_description in select_node.join_descs:
+            if join_description.on_condition:
+                all_expr_search_results.append(join_description.on_condition.lineage)
+
+        for group_by in select_node.group_bys:
+            all_expr_search_results.append(group_by.expr.lineage)
+
+        for order_by in select_node.order_bys:
+            all_expr_search_results.append(order_by.expr.lineage)
+
+        if select_node.where:
+            all_expr_search_results.append(select_node.where.lineage)
+
+        return SqlExpressionTreeLineage.combine(all_expr_search_results)
+
+    @override
+    def visit_cte_node(self, node: SqlCteNode) -> None:
+        raise NotImplementedError
+
+    def _visit_parents(self, node: SqlQueryPlanNode) -> None:
+        """Default recursive handler to visit the parents of the given node."""
+        for parent_node in node.parent_nodes:
+            parent_node.accept(self)
+        return
+
+    def visit_select_statement_node(self, node: SqlSelectStatementNode) -> None:  # noqa: D102
+        # Based on column aliases that are tagged in this SELECT statement, tag corresponding column aliases in
+        # parent nodes.
+
+        initial_required_column_aliases_in_this_node = self._column_alias_tagger.get_tagged_aliases(node)
+
+        # If this SELECT statement uses DISTINCT, all columns are required as removing them would change the meaning of
+        # the query.
+        updated_required_column_aliases_in_this_node = set(initial_required_column_aliases_in_this_node)
+        if node.distinct:
+            updated_required_column_aliases_in_this_node.update(
+                {select_column.column_alias for select_column in node.select_columns}
+            )
+
+        # Any columns in the group by also need to be kept to have a correct query.
+        updated_required_column_aliases_in_this_node.update(
+            {group_by_select_column.column_alias for group_by_select_column in node.group_bys}
+        )
+        logger.debug(
+            LazyFormat(
+                "Tagging column aliases in parent nodes given what's required in this node",
+                this_node=node,
+                initial_required_column_aliases_in_this_node=list(initial_required_column_aliases_in_this_node),
+                updated_required_column_aliases_in_this_node=list(updated_required_column_aliases_in_this_node),
+            )
+        )
+        # Since additional select columns could have been selected due to DISTINCT or GROUP BY, re-tag.
+        self._column_alias_tagger.tag_aliases(node, updated_required_column_aliases_in_this_node)
+
+        required_select_columns_in_this_node = tuple(
+            select_column
+            for select_column in node.select_columns
+            if select_column.column_alias in updated_required_column_aliases_in_this_node
+        )
+
+        # TODO: don't prune columns used in join condition! Tricky to derive since the join condition can be any
+        # SqlExpressionNode.
+
+        if len(required_select_columns_in_this_node) == 0:
+            raise RuntimeError(
+                "No columns are required in this node - this indicates a bug in this collector or in the inputs."
+            )
+
+        # Based on the expressions in this select statement, figure out what column aliases are needed in the sources of
+        # this query (i.e. tables or sub-queries in the FROM or JOIN clauses).
+        exprs_used_in_this_node = self._search_for_expressions(node, required_select_columns_in_this_node)
+
+        # If any of the string expressions don't have context on what columns are used in the expression, then it's
+        # impossible to know what columns can be pruned from the parent sources. Tag all columns in parents as required.
+        if any([string_expr.used_columns is None for string_expr in exprs_used_in_this_node.string_exprs]):
+            for parent_node in node.parent_nodes:
+                self._column_alias_tagger.tag_all_aliases_in_node(parent_node)
+            self._visit_parents(node)
+            return
+
+        # Create a mapping from the source alias to the column aliases needed from the corresponding source.
+        source_alias_to_required_column_alias: Dict[str, Set[str]] = defaultdict(set)
+        for column_reference_expr in exprs_used_in_this_node.column_reference_exprs:
+            column_reference = column_reference_expr.col_ref
+            source_alias_to_required_column_alias[column_reference.table_alias].add(column_reference.column_name)
+
+        # Appropriately tag the columns required in the parent nodes.
+        if node.from_source_alias in source_alias_to_required_column_alias:
+            aliases_required_in_parent = source_alias_to_required_column_alias[node.from_source_alias]
+            self._column_alias_tagger.tag_aliases(node=node.from_source, column_aliases=aliases_required_in_parent)
+        for join_desc in node.join_descs:
+            if join_desc.right_source_alias in source_alias_to_required_column_alias:
+                aliases_required_in_parent = source_alias_to_required_column_alias[join_desc.right_source_alias]
+                self._column_alias_tagger.tag_aliases(
+                    node=join_desc.right_source, column_aliases=aliases_required_in_parent
+                )
+        # TODO: Handle CTEs parent nodes.
+
+        # For all string columns, assume that they are needed from all sources since we don't have a table alias
+        # in SqlStringExpression.used_columns
+        for string_expr in exprs_used_in_this_node.string_exprs:
+            if string_expr.used_columns:
+                for column_alias in string_expr.used_columns:
+                    for parent_node in node.parent_nodes:
+                        self._column_alias_tagger.tag_alias(parent_node, column_alias)
+
+        # Same with unqualified column references - it's hard to tell which source it came from, so it's safest to say
+        # it's required from all parents.
+        # An unqualified column reference expression is like `SELECT col_0` whereas a qualified column reference
+        # expression is like `SELECT table_0.col_0`.
+        for unqualified_column_reference_expr in exprs_used_in_this_node.column_alias_reference_exprs:
+            column_alias = unqualified_column_reference_expr.column_alias
+            for parent_node in node.parent_nodes:
+                self._column_alias_tagger.tag_alias(parent_node, column_alias)
+
+        # Visit recursively.
+        self._visit_parents(node)
+        return
+
+    def visit_table_node(self, node: SqlTableNode) -> None:
+        """There are no SELECT columns in this node, so pruning cannot apply."""
+        return
+
+    def visit_query_from_clause_node(self, node: SqlSelectQueryFromClauseNode) -> None:
+        """Pruning cannot be done here since this is an arbitrary user-provided SQL query."""
+        return
+
+    def visit_create_table_as_node(self, node: SqlCreateTableAsNode) -> None:  # noqa: D102
+        return self._visit_parents(node)

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -98,6 +98,15 @@ class SqlJoinDescription:
     join_type: SqlJoinType
     on_condition: Optional[SqlExpressionNode] = None
 
+    def with_right_source(self, new_right_source: SqlQueryPlanNode) -> SqlJoinDescription:
+        """Return a copy of this but with the right source replaced."""
+        return SqlJoinDescription(
+            right_source=new_right_source,
+            right_source_alias=self.right_source_alias,
+            join_type=self.join_type,
+            on_condition=self.on_condition,
+        )
+
 
 @dataclass(frozen=True)
 class SqlOrderByDescription:  # noqa: D101

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, Optional, Sequence, Tuple
+from typing import Generic, Mapping, Optional, Sequence, Tuple
 
 from metricflow_semantics.dag.id_prefix import IdPrefix, StaticIdPrefix
 from metricflow_semantics.dag.mf_dag import DagId, DagNode, DisplayedProperty, MetricFlowDag
@@ -49,6 +49,22 @@ class SqlQueryPlanNode(DagNode["SqlQueryPlanNode"], ABC):
     @abstractmethod
     def as_select_node(self) -> Optional[SqlSelectStatementNode]:
         """If possible, return this as a select statement node."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
+        """Return the SELECT columns that are in this node or the closest `SqlSelectStatementNode` of its ancestors.
+
+        * For a SELECT statement node, this is just the columns in the node.
+        * For a node that has a SELECT statement node as its only parent (e.g. CREATE TABLE ... AS SELECT ...), this
+          would be the SELECT columns in the parent.
+        * If not known (e.g. an arbitrary SQL statement as a string), return None.
+        * This is used to figure out which columns are needed at a leaf node of the DAG for column pruning.
+        * A SQL table could refer to a CTE, so a mapping from the name of the CTE to the CTE node should be provided to
+          get the associated SELECT columns.
+        """
         raise NotImplementedError
 
 
@@ -205,6 +221,12 @@ class SqlSelectStatementNode(SqlQueryPlanNode):
     def description(self) -> str:
         return self._description
 
+    @override
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
+        return self.select_columns
+
 
 @dataclass(frozen=True, eq=False)
 class SqlTableNode(SqlQueryPlanNode):
@@ -242,6 +264,16 @@ class SqlTableNode(SqlQueryPlanNode):
     def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D102
         return None
 
+    @override
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
+        if self.sql_table.schema_name is None:
+            cte_node = cte_source_mapping.get(self.sql_table.table_name)
+            if cte_node is not None:
+                return cte_node.nearest_select_columns(cte_source_mapping)
+        return None
+
 
 @dataclass(frozen=True, eq=False)
 class SqlSelectQueryFromClauseNode(SqlQueryPlanNode):
@@ -277,6 +309,12 @@ class SqlSelectQueryFromClauseNode(SqlQueryPlanNode):
 
     @property
     def as_select_node(self) -> Optional[SqlSelectStatementNode]:  # noqa: D102
+        return None
+
+    @override
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
         return None
 
 
@@ -330,6 +368,12 @@ class SqlCreateTableAsNode(SqlQueryPlanNode):
     def id_prefix(cls) -> IdPrefix:
         return StaticIdPrefix.SQL_PLAN_CREATE_TABLE_AS_ID_PREFIX
 
+    @override
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
+        return self.parent_node.nearest_select_columns(cte_source_mapping)
+
 
 class SqlQueryPlan(MetricFlowDag[SqlQueryPlanNode]):
     """Model for an SQL Query as a DAG."""
@@ -358,6 +402,10 @@ class SqlCteNode(SqlQueryPlanNode):
 
     select_statement: SqlSelectStatementNode
     cte_alias: str
+
+    def __post_init__(self) -> None:  # noqa: D105
+        super().__post_init__()
+        assert len(self.parent_nodes) == 1
 
     @staticmethod
     def create(select_statement: SqlSelectStatementNode, cte_alias: str) -> SqlCteNode:  # noqa: D102
@@ -390,3 +438,9 @@ class SqlCteNode(SqlQueryPlanNode):
     @override
     def id_prefix(cls) -> IdPrefix:
         return StaticIdPrefix.SQL_PLAN_COMMON_TABLE_EXPRESSION_ID_PREFIX
+
+    @override
+    def nearest_select_columns(
+        self, cte_source_mapping: Mapping[str, SqlCteNode]
+    ) -> Optional[Sequence[SqlSelectColumn]]:
+        return self.select_statement.nearest_select_columns(cte_source_mapping)

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -227,6 +227,21 @@ class SqlSelectStatementNode(SqlQueryPlanNode):
     ) -> Optional[Sequence[SqlSelectColumn]]:
         return self.select_columns
 
+    def create_copy(self) -> SqlSelectStatementNode:  # noqa: D102
+        return SqlSelectStatementNode.create(
+            description=self.description,
+            select_columns=self.select_columns,
+            from_source=self.from_source,
+            from_source_alias=self.from_source_alias,
+            cte_sources=self.cte_sources,
+            join_descs=self.join_descs,
+            group_bys=self.group_bys,
+            order_bys=self.order_bys,
+            where=self.where,
+            limit=self.limit,
+            distinct=self.distinct,
+        )
+
 
 @dataclass(frozen=True, eq=False)
 class SqlTableNode(SqlQueryPlanNode):

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_count_with_no_group_by__plan0.xml
@@ -6,15 +6,15 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_15') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_221), column_alias='visit_buy_conversions') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_14') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -25,10 +25,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_13), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -36,25 +36,25 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -236,12 +236,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -397,25 +397,25 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_10') -->
+                <!-- node_id = NodeId(id_str='ss_13') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- node_id = NodeId(id_str='ss_12') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_217), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_8') -->
+                        <!-- node_id = NodeId(id_str='ss_11') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_215), -->
@@ -427,12 +427,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_214), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_7') -->
+                            <!-- node_id = NodeId(id_str='ss_10') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -455,10 +455,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                             <!-- join_0 =                                               -->
                             <!--   SqlJoinDescription(                                  -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9), -->
                             <!--     right_source_alias='subq_9',                       -->
                             <!--     join_type=INNER,                                   -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
@@ -467,7 +467,7 @@ docstring:
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
@@ -483,12 +483,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
@@ -694,12 +694,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
                                     <!--     column_alias='visitors',                          -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28011') -->
+                                        <!-- node_id = NodeId(id_str='ss_4') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -863,7 +863,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_6') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
@@ -1124,12 +1124,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
@@ -1385,12 +1385,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28002') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0.xml
@@ -6,19 +6,19 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_16') -->
+        <!-- node_id = NodeId(id_str='ss_19') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_239), column_alias='metric_time__day') -->
         <!-- col1 =                                                                -->
         <!--   SqlSelectColumn(                                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),                 -->
         <!--     column_alias='visit_buy_conversion_rate_7days_fill_nulls_with_0', -->
         <!--   )                                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_15') -->
+            <!-- node_id = NodeId(id_str='ss_18') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_6, sql_function=COALESCE), -->
@@ -34,10 +34,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
             <!--     column_alias='buys',                                                       -->
             <!--   )                                                                            -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_14),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_17),  -->
             <!--     right_source_alias='subq_19',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_5), -->
@@ -51,14 +51,14 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
-                <!-- node_id = NodeId(id_str='ss_4') -->
+                <!-- node_id = NodeId(id_str='ss_5') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_49), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_48), column_alias='visits') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -67,7 +67,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Time Spine' -->
-                    <!-- node_id = NodeId(id_str='ss_3') -->
+                    <!-- node_id = NodeId(id_str='ss_4') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_45), -->
@@ -84,7 +84,7 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_2') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -95,7 +95,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='visits',                                                -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- group_by0 =                                           -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -105,7 +105,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['visits', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_1') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                -->
                         <!--   SqlSelectColumn(                                    -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
@@ -113,12 +113,12 @@ docstring:
                         <!--   )                                                   -->
                         <!-- col1 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
-                            <!-- node_id = NodeId(id_str='ss_0') -->
+                            <!-- node_id = NodeId(id_str='ss_1') -->
                             <!-- col0 =                                               -->
                             <!--   SqlSelectColumn(                                   -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -318,12 +318,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_1), -->
                             <!--     column_alias='visitors',                         -->
                             <!--   )                                                  -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                <!-- node_id = NodeId(id_str='ss_28011') -->
+                                <!-- node_id = NodeId(id_str='ss_0') -->
                                 <!-- col0 =                                                      -->
                                 <!--   SqlSelectColumn(                                          -->
                                 <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -489,14 +489,14 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Join to Time Spine Dataset' -->
-                <!-- node_id = NodeId(id_str='ss_14') -->
+                <!-- node_id = NodeId(id_str='ss_17') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_232), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_231), column_alias='buys') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_12),  -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_15),  -->
                 <!--     right_source_alias='subq_16',                        -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_4), -->
@@ -505,7 +505,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Time Spine' -->
-                    <!-- node_id = NodeId(id_str='ss_13') -->
+                    <!-- node_id = NodeId(id_str='ss_16') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_228), -->
@@ -522,7 +522,7 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_12') -->
+                    <!-- node_id = NodeId(id_str='ss_15') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_227), -->
@@ -533,7 +533,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='buys',                                                  -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                     <!-- group_by0 =                                            -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_227), -->
@@ -543,7 +543,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['buys', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_11') -->
+                        <!-- node_id = NodeId(id_str='ss_14') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_225), -->
@@ -551,12 +551,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col1 =                                                                                    -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_224), column_alias='buys') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_13) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Find conversions for user within the range of 7 day' -->
-                            <!-- node_id = NodeId(id_str='ss_10') -->
+                            <!-- node_id = NodeId(id_str='ss_13') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_222), -->
@@ -571,12 +571,12 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_221), -->
                             <!--     column_alias='visits',                             -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                             <!-- where = None -->
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                                <!-- node_id = NodeId(id_str='ss_9') -->
+                                <!-- node_id = NodeId(id_str='ss_12') -->
                                 <!-- col0 =                                                                          -->
                                 <!--   SqlSelectColumn(                                                              -->
                                 <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -602,19 +602,19 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_219), -->
                                 <!--     column_alias='buys',                               -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
-                                <!-- join_0 =                                               -->
-                                <!--   SqlJoinDescription(                                  -->
-                                <!--     right_source=SqlSelectStatementNode(node_id=ss_8), -->
-                                <!--     right_source_alias='subq_12',                      -->
-                                <!--     join_type=INNER,                                   -->
-                                <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
-                                <!--   )                                                    -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                                <!-- join_0 =                                                -->
+                                <!--   SqlJoinDescription(                                   -->
+                                <!--     right_source=SqlSelectStatementNode(node_id=ss_11), -->
+                                <!--     right_source_alias='subq_12',                       -->
+                                <!--     join_type=INNER,                                    -->
+                                <!--     on_condition=SqlLogicalExpression(node_id=lo_1),    -->
+                                <!--   )                                                     -->
                                 <!-- where = None -->
                                 <!-- distinct = True -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                    <!-- node_id = NodeId(id_str='ss_6') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
@@ -630,12 +630,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
                                     <!--     column_alias='visits',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='ss_5') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                -->
                                         <!--   SqlSelectColumn(                                    -->
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_54), -->
@@ -841,12 +841,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
                                         <!--     column_alias='visitors',                          -->
                                         <!--   )                                                   -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlSelectStatementNode>
                                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                                            <!-- node_id = NodeId(id_str='ss_6') -->
                                             <!-- col0 =                                                      -->
                                             <!--   SqlSelectColumn(                                          -->
                                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -1010,7 +1010,7 @@ docstring:
                                 </SqlSelectStatementNode>
                                 <SqlSelectStatementNode>
                                     <!-- description = 'Add column with generated UUID' -->
-                                    <!-- node_id = NodeId(id_str='ss_8') -->
+                                    <!-- node_id = NodeId(id_str='ss_11') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_147), -->
@@ -1271,12 +1271,12 @@ docstring:
                                     <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                     <!--     column_alias='mf_internal_uuid',                -->
                                     <!--   )                                                 -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
-                                        <!-- node_id = NodeId(id_str='ss_7') -->
+                                        <!-- node_id = NodeId(id_str='ss_10') -->
                                         <!-- col0 =                                                -->
                                         <!--   SqlSelectColumn(                                    -->
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_96), -->
@@ -1532,12 +1532,12 @@ docstring:
                                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
                                         <!--     column_alias='buyers',                            -->
                                         <!--   )                                                   -->
-                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                        <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                         <!-- where = None -->
                                         <!-- distinct = False -->
                                         <SqlSelectStatementNode>
                                             <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                            <!-- node_id = NodeId(id_str='ss_28002') -->
+                                            <!-- node_id = NodeId(id_str='ss_9') -->
                                             <!-- col0 =                                                      -->
                                             <!--   SqlSelectColumn(                                          -->
                                             <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_15') -->
         <!-- col0 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_237), column_alias='visit__referrer_id') -->
         <!-- col1 =                                                                                                        -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='visit_buy_conversion_rate') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_14') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -32,10 +32,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_10),  -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_13),  -->
             <!--     right_source_alias='subq_13',                        -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_2), -->
@@ -49,7 +49,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -60,7 +60,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                           -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
@@ -70,19 +70,19 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_42), -->
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -264,12 +264,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -425,7 +425,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_10') -->
+                <!-- node_id = NodeId(id_str='ss_13') -->
                 <!-- col0 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_230), -->
@@ -436,7 +436,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                            -->
                 <!--   SqlSelectColumn(                                     -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_230), -->
@@ -446,19 +446,19 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id']" -->
-                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- node_id = NodeId(id_str='ss_12') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_228), -->
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_227), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of INF' -->
-                        <!-- node_id = NodeId(id_str='ss_8') -->
+                        <!-- node_id = NodeId(id_str='ss_11') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_225), -->
@@ -475,12 +475,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_222), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_223), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_7') -->
+                            <!-- node_id = NodeId(id_str='ss_10') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -508,10 +508,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_221), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                             <!-- join_0 =                                               -->
                             <!--   SqlJoinDescription(                                  -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9), -->
                             <!--     right_source_alias='subq_9',                       -->
                             <!--     join_type=INNER,                                   -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
@@ -521,7 +521,7 @@ docstring:
                             <SqlSelectStatementNode>
                                 <!-- description =                                                                        -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
@@ -542,12 +542,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_86), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_49), -->
@@ -753,12 +753,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_46), -->
                                     <!--     column_alias='visitors',                          -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28011') -->
+                                        <!-- node_id = NodeId(id_str='ss_4') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -922,7 +922,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_6') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_143), -->
@@ -1183,12 +1183,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_92), -->
@@ -1444,12 +1444,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_91), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28002') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_constant_properties__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_15') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_261), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_260), column_alias='visit__referrer_id') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0),    -->
         <!--     column_alias='visit_buy_conversion_rate_by_session', -->
         <!--   )                                                      -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_14') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -41,10 +41,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_13), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -63,7 +63,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- col1 =                                                -->
@@ -76,7 +76,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                           -->
@@ -88,7 +88,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
@@ -100,12 +100,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -287,12 +287,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -448,7 +448,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_10') -->
+                <!-- node_id = NodeId(id_str='ss_13') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_249), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
@@ -461,7 +461,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_249), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
@@ -473,7 +473,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- node_id = NodeId(id_str='ss_12') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_246), -->
@@ -485,12 +485,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_244), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_8') -->
+                        <!-- node_id = NodeId(id_str='ss_11') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_241), -->
@@ -509,12 +509,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_238), column_alias='buys') -->
                         <!-- col5 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_239), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_7') -->
+                            <!-- node_id = NodeId(id_str='ss_10') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -547,10 +547,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col6 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_237), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                             <!-- join_0 =                                               -->
                             <!--   SqlJoinDescription(                                  -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9), -->
                             <!--     right_source_alias='subq_9',                       -->
                             <!--     join_type=INNER,                                   -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
@@ -561,7 +561,7 @@ docstring:
                                 <!-- description =                                                                  -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', " -->
                                 <!--    "'user', 'session']")                                                       -->
-                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
@@ -587,12 +587,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
@@ -798,12 +798,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
                                     <!--     column_alias='visitors',                          -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28011') -->
+                                        <!-- node_id = NodeId(id_str='ss_4') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -967,7 +967,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_6') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_146), -->
@@ -1228,12 +1228,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_95), -->
@@ -1489,12 +1489,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28002') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_no_group_by__plan0.xml
@@ -6,18 +6,18 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_15') -->
         <!-- col0 =                                                -->
         <!--   SqlSelectColumn(                                    -->
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_14') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=MAX), -->
@@ -28,10 +28,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_13), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=CROSS_JOIN,                               -->
             <!--   )                                                     -->
@@ -39,25 +39,25 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits',]" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -239,12 +239,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -400,25 +400,25 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_10') -->
+                <!-- node_id = NodeId(id_str='ss_13') -->
                 <!-- col0 =                                                                    -->
                 <!--   SqlSelectColumn(                                                        -->
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys',]" -->
-                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- node_id = NodeId(id_str='ss_12') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_217), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_8') -->
+                        <!-- node_id = NodeId(id_str='ss_11') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_215), -->
@@ -430,12 +430,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_213), column_alias='buys') -->
                         <!-- col3 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_214), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_7') -->
+                            <!-- node_id = NodeId(id_str='ss_10') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -458,10 +458,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col4 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_212), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                             <!-- join_0 =                                               -->
                             <!--   SqlJoinDescription(                                  -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9), -->
                             <!--     right_source_alias='subq_9',                       -->
                             <!--     join_type=INNER,                                   -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
@@ -470,7 +470,7 @@ docstring:
                             <!-- distinct = True -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['visits', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_85), -->
@@ -486,12 +486,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_84), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_47), -->
@@ -697,12 +697,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_44), -->
                                     <!--     column_alias='visitors',                          -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28011') -->
+                                        <!-- node_id = NodeId(id_str='ss_4') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -866,7 +866,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_6') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_140), -->
@@ -1127,12 +1127,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_89), -->
@@ -1388,12 +1388,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28002') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/test_conversion_rate_with_window__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_12') -->
+        <!-- node_id = NodeId(id_str='ss_15') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_246), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_245), column_alias='visit__referrer_id') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlRatioComputationExpression(node_id=rc_0), -->
         <!--     column_alias='visit_buy_conversion_rate_7days',   -->
         <!--   )                                                   -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_11') -->
+            <!-- node_id = NodeId(id_str='ss_14') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -41,10 +41,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='buys',                                                  -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_10), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_13), -->
             <!--     right_source_alias='subq_13',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_2),    -->
@@ -63,7 +63,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- col1 =                                                -->
@@ -76,7 +76,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='visits',                                                -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                          -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_46), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                           -->
@@ -88,7 +88,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_43), -->
@@ -100,12 +100,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                -->
                     <!--   )                                                   -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_41), column_alias='visits') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -287,12 +287,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='visits') -->
                         <!-- col40 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='visitors') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28011') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -448,7 +448,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_10') -->
+                <!-- node_id = NodeId(id_str='ss_13') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_234), column_alias='metric_time__day') -->
                 <!-- col1 =                                                 -->
@@ -461,7 +461,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='buys',                                                  -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_234), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                            -->
@@ -473,7 +473,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['buys', 'visit__referrer_id', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_9') -->
+                    <!-- node_id = NodeId(id_str='ss_12') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_231), -->
@@ -485,12 +485,12 @@ docstring:
                     <!--     column_alias='visit__referrer_id',                 -->
                     <!--   )                                                    -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_229), column_alias='buys') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Find conversions for user within the range of 7 day' -->
-                        <!-- node_id = NodeId(id_str='ss_8') -->
+                        <!-- node_id = NodeId(id_str='ss_11') -->
                         <!-- col0 =                                                 -->
                         <!--   SqlSelectColumn(                                     -->
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_227), -->
@@ -507,12 +507,12 @@ docstring:
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_224), column_alias='buys') -->
                         <!-- col4 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_225), column_alias='visits') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Dedupe the fanout with mf_internal_uuid in the conversion data set' -->
-                            <!-- node_id = NodeId(id_str='ss_7') -->
+                            <!-- node_id = NodeId(id_str='ss_10') -->
                             <!-- col0 =                                                                          -->
                             <!--   SqlSelectColumn(                                                              -->
                             <!--     expr=SqlWindowFunctionExpression(node_id=wfnc_0, sql_function=FIRST_VALUE), -->
@@ -540,10 +540,10 @@ docstring:
                             <!--   )                                                    -->
                             <!-- col5 =                                                                                    -->
                             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_223), column_alias='buys') -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                             <!-- join_0 =                                               -->
                             <!--   SqlJoinDescription(                                  -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_6), -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9), -->
                             <!--     right_source_alias='subq_9',                       -->
                             <!--     join_type=INNER,                                   -->
                             <!--     on_condition=SqlLogicalExpression(node_id=lo_1),   -->
@@ -553,7 +553,7 @@ docstring:
                             <SqlSelectStatementNode>
                                 <!-- description =                                                                        -->
                                 <!--   "Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']" -->
-                                <!-- node_id = NodeId(id_str='ss_4') -->
+                                <!-- node_id = NodeId(id_str='ss_6') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_90), -->
@@ -574,12 +574,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_88), -->
                                 <!--     column_alias='visits',                            -->
                                 <!--   )                                                   -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_3') -->
+                                    <!-- node_id = NodeId(id_str='ss_5') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_51), -->
@@ -785,12 +785,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_48), -->
                                     <!--     column_alias='visitors',                          -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28011) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'visits_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28011') -->
+                                        <!-- node_id = NodeId(id_str='ss_4') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28010 sql_expr=1), -->
@@ -954,7 +954,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = 'Add column with generated UUID' -->
-                                <!-- node_id = NodeId(id_str='ss_6') -->
+                                <!-- node_id = NodeId(id_str='ss_9') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_145), -->
@@ -1215,12 +1215,12 @@ docstring:
                                 <!--     expr=SqlGenerateUuidExpression(node_id=uuid_0), -->
                                 <!--     column_alias='mf_internal_uuid',                -->
                                 <!--   )                                                 -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_5') -->
+                                    <!-- node_id = NodeId(id_str='ss_8') -->
                                     <!-- col0 =                                                -->
                                     <!--   SqlSelectColumn(                                    -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_94), -->
@@ -1476,12 +1476,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_93), -->
                                     <!--     column_alias='buyers',                            -->
                                     <!--   )                                                   -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28002) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'buys_source'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28002') -->
+                                        <!-- node_id = NodeId(id_str='ss_7') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28003 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_combine_output_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_combine_output_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_8, sql_function=COALESCE), -->
@@ -27,10 +27,10 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_7, sql_function=COALESCE), -->
         <!--     column_alias='bookers',                                                    -->
         <!--   )                                                                            -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
         <!--     right_source_alias='subq_5',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -44,28 +44,28 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='is_instant') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='bookings',                                              -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='is_instant') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['bookings', 'is_instant']" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='is_instant') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_28001') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -453,7 +453,7 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_instant') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
@@ -465,23 +465,23 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_2, sql_function=COUNT_DISTINCT), -->
             <!--     column_alias='bookers',                                                          -->
             <!--   )                                                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='is_instant') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='is_instant') -->
                 <!-- col1 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='instant_bookings') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='bookers') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_28001') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -28,7 +28,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='bookings',                                              -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -39,7 +39,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
@@ -47,10 +47,10 @@ docstring:
                 <!--   )                                                  -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -59,16 +59,16 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_28001') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -497,16 +497,16 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28005') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_15') -->
+        <!-- node_id = NodeId(id_str='ss_19') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_489), column_alias='ds__day') -->
         <!-- col1 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_488), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_view') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_18) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Combine Aggregated Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_14') -->
+            <!-- node_id = NodeId(id_str='ss_18') -->
             <!-- col0 =                                                                         -->
             <!--   SqlSelectColumn(                                                             -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_5, sql_function=COALESCE), -->
@@ -37,10 +37,10 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
             <!--     column_alias='views',                                                 -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- join_0 =                                                -->
             <!--   SqlJoinDescription(                                   -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_13), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_17), -->
             <!--     right_source_alias='subq_17',                       -->
             <!--     join_type=FULL_OUTER,                               -->
             <!--     on_condition=SqlLogicalExpression(node_id=lo_0),    -->
@@ -59,7 +59,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_6') -->
+                <!-- node_id = NodeId(id_str='ss_8') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_275), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
@@ -67,12 +67,12 @@ docstring:
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_276), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_5') -->
+                    <!-- node_id = NodeId(id_str='ss_7') -->
                     <!-- col0 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_273), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
@@ -85,7 +85,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                     <!--     column_alias='bookings',                                              -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                     <!-- group_by0 =                                                                                  -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_273), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
@@ -97,7 +97,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_4') -->
+                        <!-- node_id = NodeId(id_str='ss_6') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_270), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
@@ -107,12 +107,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                        -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_268), column_alias='bookings') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_3') -->
+                            <!-- node_id = NodeId(id_str='ss_5') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_169), -->
@@ -605,10 +605,10 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_182),     -->
                             <!--     column_alias='approximate_discrete_booking_value_p99', -->
                             <!--   )                                                        -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
                             <!--     right_source_alias='subq_4',                         -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -617,7 +617,7 @@ docstring:
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='ss_0') -->
+                                <!-- node_id = NodeId(id_str='ss_1') -->
                                 <!-- col0 =                                                -->
                                 <!--   SqlSelectColumn(                                    -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_15), -->
@@ -1108,12 +1108,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                                 <!--     column_alias='approximate_discrete_booking_value_p99', -->
                                 <!--   )                                                        -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                                    <!-- node_id = NodeId(id_str='ss_28001') -->
+                                    <!-- node_id = NodeId(id_str='ss_0') -->
                                     <!-- col0 =                                                      -->
                                     <!--   SqlSelectColumn(                                          -->
                                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -1566,7 +1566,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_2') -->
+                                <!-- node_id = NodeId(id_str='ss_4') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_166), -->
@@ -1577,12 +1577,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_165), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_1') -->
+                                    <!-- node_id = NodeId(id_str='ss_3') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_107), -->
@@ -1918,12 +1918,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_100), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28005') -->
+                                        <!-- node_id = NodeId(id_str='ss_2') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -2222,7 +2222,7 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
-                <!-- node_id = NodeId(id_str='ss_13') -->
+                <!-- node_id = NodeId(id_str='ss_17') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_476), column_alias='ds__day') -->
                 <!-- col1 =                                                 -->
                 <!--   SqlSelectColumn(                                     -->
@@ -2230,12 +2230,12 @@ docstring:
                 <!--     column_alias='listing__country_latest',            -->
                 <!--   )                                                    -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_477), column_alias='views') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_16) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = 'Aggregate Measures' -->
-                    <!-- node_id = NodeId(id_str='ss_12') -->
+                    <!-- node_id = NodeId(id_str='ss_16') -->
                     <!-- col0 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_474), column_alias='ds__day') -->
                     <!-- col1 =                                                 -->
@@ -2248,7 +2248,7 @@ docstring:
                     <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                     <!--     column_alias='views',                                                 -->
                     <!--   )                                                                       -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_15) -->
                     <!-- group_by0 =                                                                                  -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_474), column_alias='ds__day') -->
                     <!-- group_by1 =                                            -->
@@ -2260,7 +2260,7 @@ docstring:
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Pass Only Elements: ['views', 'listing__country_latest', 'ds__day']" -->
-                        <!-- node_id = NodeId(id_str='ss_11') -->
+                        <!-- node_id = NodeId(id_str='ss_15') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_471), column_alias='ds__day') -->
                         <!-- col1 =                                                 -->
@@ -2270,12 +2270,12 @@ docstring:
                         <!--   )                                                    -->
                         <!-- col2 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_469), column_alias='views') -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_14) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Join Standard Outputs' -->
-                            <!-- node_id = NodeId(id_str='ss_10') -->
+                            <!-- node_id = NodeId(id_str='ss_14') -->
                             <!-- col0 =                                                 -->
                             <!--   SqlSelectColumn(                                     -->
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_408), -->
@@ -2578,10 +2578,10 @@ docstring:
                             <!--     expr=SqlColumnReferenceExpression(node_id=cr_409), -->
                             <!--     column_alias='views',                              -->
                             <!--   )                                                    -->
-                            <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
+                            <!-- from_source = SqlSelectStatementNode(node_id=ss_10) -->
                             <!-- join_0 =                                                 -->
                             <!--   SqlJoinDescription(                                    -->
-                            <!--     right_source=SqlSelectStatementNode(node_id=ss_9),   -->
+                            <!--     right_source=SqlSelectStatementNode(node_id=ss_13),  -->
                             <!--     right_source_alias='subq_13',                        -->
                             <!--     join_type=LEFT_OUTER,                                -->
                             <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -2590,7 +2590,7 @@ docstring:
                             <!-- distinct = False -->
                             <SqlSelectStatementNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
-                                <!-- node_id = NodeId(id_str='ss_7') -->
+                                <!-- node_id = NodeId(id_str='ss_10') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_278), -->
@@ -2891,12 +2891,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_277), -->
                                 <!--     column_alias='views',                              -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_28010) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_9) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Read Elements From Semantic Model 'views_source'" -->
-                                    <!-- node_id = NodeId(id_str='ss_28010') -->
+                                    <!-- node_id = NodeId(id_str='ss_9') -->
                                     <!-- col0 =                                                      -->
                                     <!--   SqlSelectColumn(                                          -->
                                     <!--     expr=SqlStringExpression(node_id=str_28009 sql_expr=1), -->
@@ -3154,7 +3154,7 @@ docstring:
                             </SqlSelectStatementNode>
                             <SqlSelectStatementNode>
                                 <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                                <!-- node_id = NodeId(id_str='ss_9') -->
+                                <!-- node_id = NodeId(id_str='ss_13') -->
                                 <!-- col0 =                                                 -->
                                 <!--   SqlSelectColumn(                                     -->
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_405), -->
@@ -3165,12 +3165,12 @@ docstring:
                                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_404), -->
                                 <!--     column_alias='country_latest',                     -->
                                 <!--   )                                                    -->
-                                <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
+                                <!-- from_source = SqlSelectStatementNode(node_id=ss_12) -->
                                 <!-- where = None -->
                                 <!-- distinct = False -->
                                 <SqlSelectStatementNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
-                                    <!-- node_id = NodeId(id_str='ss_8') -->
+                                    <!-- node_id = NodeId(id_str='ss_12') -->
                                     <!-- col0 =                                                 -->
                                     <!--   SqlSelectColumn(                                     -->
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_346), -->
@@ -3506,12 +3506,12 @@ docstring:
                                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_339), -->
                                     <!--     column_alias='smallest_listing',                   -->
                                     <!--   )                                                    -->
-                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                                    <!-- from_source = SqlSelectStatementNode(node_id=ss_11) -->
                                     <!-- where = None -->
                                     <!-- distinct = False -->
                                     <SqlSelectStatementNode>
                                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                                        <!-- node_id = NodeId(id_str='ss_28005') -->
+                                        <!-- node_id = NodeId(id_str='ss_11') -->
                                         <!-- col0 =                                                      -->
                                         <!--   SqlSelectColumn(                                          -->
                                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_ratio_from_single_semantic_model__plan0.xml
@@ -6,18 +6,18 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='listing__country_latest') -->
         <!-- col2 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlRatioComputationExpression(node_id=rc_0), column_alias='bookings_per_booker') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -34,7 +34,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=COUNT_DISTINCT), -->
             <!--     column_alias='bookers',                                                          -->
             <!--   )                                                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -45,7 +45,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_7), -->
@@ -54,10 +54,10 @@ docstring:
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='listing') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookings') -->
                 <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='bookers') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -66,17 +66,17 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'bookers', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='listing') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
                     <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='bookers') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_28001') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -505,16 +505,16 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28005') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_compute_metrics_node_simple_expr__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Compute Metrics via Expressions' -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='listing__country_latest') -->
@@ -15,12 +15,12 @@ docstring:
         <!--     expr=SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05), -->
         <!--     column_alias='booking_fees',                                           -->
         <!--   )                                                                        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Aggregate Measures' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- col1 =                                                -->
             <!--   SqlSelectColumn(                                    -->
@@ -32,7 +32,7 @@ docstring:
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
             <!--     column_alias='booking_value',                                         -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing') -->
             <!-- group_by1 =                                           -->
             <!--   SqlSelectColumn(                                    -->
@@ -43,7 +43,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_6), -->
@@ -52,10 +52,10 @@ docstring:
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
                 <!-- col2 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='booking_value') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
                 <!--     right_source_alias='subq_3',                         -->
                 <!--     join_type=LEFT_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -64,16 +64,16 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_value', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
                     <!-- col1 =                                                                                           -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='booking_value') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_28001') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -502,16 +502,16 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
                     <!-- col1 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28005') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_constrain_time_range_node__plan0.xml
@@ -6,34 +6,34 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-02T00:00:00]' -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_3') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='metric_time__day') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
         <!-- where = SqlBetweenExpression(node_id=betw_0) -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_2') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
             <!-- col1 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='metric_time__day') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['bookings', 'ds__day']" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_1') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                    <!-- node_id = NodeId(id_str='ss_28001') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimension_with_joined_where_constraint__plan0.xml
@@ -6,17 +6,17 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest',]" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_5') -->
         <!-- col0 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- group_by0 =                                                                                                  -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='user__home_state_latest') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
@@ -203,12 +203,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=listing__country_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -409,10 +409,10 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -421,7 +421,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28005') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -661,19 +661,19 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                     <!-- col1 =                                               -->
                     <!--   SqlSelectColumn(                                   -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
                     <!--     column_alias='home_state_latest',                -->
                     <!--   )                                                  -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28009') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- group_by0 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -205,10 +205,10 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -217,7 +217,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -422,16 +422,16 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                 <!-- col1 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28009') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_node__plan0.xml
@@ -6,14 +6,14 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['bookings',]" -->
-        <!-- node_id = NodeId(id_str='ss_0') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28001') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_filter_with_where_constraint_node__plan0.xml
@@ -6,23 +6,23 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Constrain Output with WHERE' -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- where = SqlStringExpression(node_id=str_0 sql_expr=booking__ds__day = '2020-01-01') -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'ds__day']" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28001') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_to_grain__plan0.xml
@@ -6,14 +6,14 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join to Time Spine Dataset' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='metric_time__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='listing') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_110), column_alias='booking_fees') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
         <!--     right_source_alias='subq_4',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -22,7 +22,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Time Spine' -->
-            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
             <!-- from_source = SqlTableNode(node_id=tfc_0) -->
@@ -36,7 +36,7 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='metric_time__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='listing') -->
@@ -45,12 +45,12 @@ docstring:
             <!--     expr=SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05), -->
             <!--     column_alias='booking_fees',                                           -->
             <!--   )                                                                        -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='listing') -->
@@ -59,7 +59,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='booking_value',                                         -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                                                                  -->
@@ -68,7 +68,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -78,12 +78,12 @@ docstring:
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='listing') -->
                     <!-- col2 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='booking_value') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
@@ -547,12 +547,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28001') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -6,14 +6,14 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join to Time Spine Dataset' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='metric_time__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='listing') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_110), column_alias='booking_fees') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
         <!--     right_source_alias='subq_4',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -22,7 +22,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Time Spine' -->
-            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
             <!-- from_source = SqlTableNode(node_id=tfc_0) -->
@@ -36,7 +36,7 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='metric_time__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='listing') -->
@@ -45,12 +45,12 @@ docstring:
             <!--     expr=SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05), -->
             <!--     column_alias='booking_fees',                                           -->
             <!--   )                                                                        -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='listing') -->
@@ -59,7 +59,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='booking_value',                                         -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                                                                  -->
@@ -68,7 +68,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -78,12 +78,12 @@ docstring:
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='listing') -->
                     <!-- col2 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='booking_value') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
@@ -547,12 +547,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28001') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_join_to_time_spine_node_without_offset__plan0.xml
@@ -6,14 +6,14 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join to Time Spine Dataset' -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_112), column_alias='metric_time__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_111), column_alias='listing') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_110), column_alias='booking_fees') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_4),   -->
         <!--     right_source_alias='subq_4',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -22,7 +22,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Time Spine' -->
-            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_106), column_alias='metric_time__day') -->
             <!-- from_source = SqlTableNode(node_id=tfc_0) -->
@@ -36,7 +36,7 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_104), column_alias='metric_time__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_105), column_alias='listing') -->
@@ -45,12 +45,12 @@ docstring:
             <!--     expr=SqlStringExpression(node_id=str_0 sql_expr=booking_value * 0.05), -->
             <!--     column_alias='booking_fees',                                           -->
             <!--   )                                                                        -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='listing') -->
@@ -59,7 +59,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='booking_value',                                         -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
                 <!-- group_by1 =                                                                                  -->
@@ -68,7 +68,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_value', 'metric_time__day', 'listing']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -78,12 +78,12 @@ docstring:
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='listing') -->
                     <!-- col2 =                                                                                            -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='booking_value') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
@@ -547,12 +547,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28001') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_measure_aggregation_node__plan0.xml
@@ -8,7 +8,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Aggregate Measures' -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                    -->
         <!--   SqlSelectColumn(                                                        -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
@@ -29,25 +29,25 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=AVERAGE), -->
         <!--     column_alias='average_booking_value',                                     -->
         <!--   )                                                                           -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description =                                                                                -->
             <!--   "Pass Only Elements: ['bookings', 'instant_bookings', 'average_booking_value', 'bookers']" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
             <!-- col1 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='instant_bookings') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='bookers') -->
             <!-- col3 =                                                                                                   -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='average_booking_value') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28001') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_multi_join_node__plan0.xml
@@ -6,24 +6,24 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join Standard Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_6') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='listing__country_latest') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='listing__country_latest') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='listing') -->
         <!-- col3 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
         <!--     right_source_alias='subq_3',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
         <!--   )                                                      -->
         <!-- join_1 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
         <!--     right_source_alias='subq_5',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_1), -->
@@ -32,15 +32,15 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28001') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -370,15 +370,15 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='country_latest') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -584,15 +584,15 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- node_id = NodeId(id_str='ss_5') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='country_latest') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_4') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_order_by_node__plan0.xml
@@ -6,27 +6,27 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Order By ['ds__day', 'bookings']" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='is_instant') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- where = None -->
         <!-- order_by0 = SqlOrderByDescription(expr=SqlColumnReferenceExpression(node_id=cr_9), desc=False) -->
         <!-- order_by1 = SqlOrderByDescription(expr=SqlColumnReferenceExpression(node_id=cr_10), desc=True) -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='is_instant') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_8), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='is_instant') -->
                 <!-- col2 =                                                                    -->
@@ -34,7 +34,7 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- group_by0 =                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__day') -->
                 <!-- group_by1 =                                                                                   -->
@@ -43,18 +43,18 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'is_instant', 'ds__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__day') -->
                     <!-- col1 =                                                                                        -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='is_instant') -->
                     <!-- col2 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                        <!-- node_id = NodeId(id_str='ss_28001') -->
+                        <!-- node_id = NodeId(id_str='ss_0') -->
                         <!-- col0 =                                                      -->
                         <!--   SqlSelectColumn(                                          -->
                         <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by None' -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_9), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_6),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28000') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -219,18 +219,18 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28000') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_grouping__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Join on MAX(ds) and ['user'] grouping by None" -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_13), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_14), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_9),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                               -->
         <!--   SqlJoinDescription(                                  -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_0), -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_1), -->
         <!--     right_source_alias='subq_2',                       -->
         <!--     join_type=INNER,                                   -->
         <!--     on_condition=SqlLogicalExpression(node_id=lo_0),   -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28000') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -219,20 +219,20 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MAX(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MAX), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28000') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_semi_additive_join_node_with_queried_group_by__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join on MIN(ds) and [] grouping by ds' -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_10), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_11), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_12), column_alias='ds__month') -->
@@ -98,10 +98,10 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_7),         -->
         <!--     column_alias='total_account_balance_first_day_of_month', -->
         <!--   )                                                          -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
         <!--     right_source_alias='subq_2',                         -->
         <!--     join_type=INNER,                                     -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -110,7 +110,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28000') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 =                                                                                                 -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_28000), column_alias='account_balance') -->
             <!-- col1 =                                                   -->
@@ -219,20 +219,20 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Filter row on MIN(ds__day)' -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col1 =                                                                    -->
             <!--   SqlSelectColumn(                                                        -->
             <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=MIN), -->
             <!--     column_alias='ds__day__complete',                                     -->
             <!--   )                                                                       -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28000) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- group_by0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'accounts_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28000') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                   -->
                 <!--   SqlSelectColumn(                                       -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_28000), -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_single_join_node__plan0.xml
@@ -6,13 +6,13 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Join Standard Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='listing') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='bookings') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_1),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_3),   -->
         <!--     right_source_alias='subq_3',                         -->
         <!--     join_type=LEFT_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -21,15 +21,15 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['bookings', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='listing') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                <!-- node_id = NodeId(id_str='ss_28001') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
                 <!-- col1 =                                                                                           -->
@@ -359,19 +359,19 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = "Pass Only Elements: ['listing__country_latest', 'listing']" -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='listing') -->
             <!-- col1 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_2), -->
             <!--     column_alias='listing__country_latest',          -->
             <!--   )                                                  -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/test_source_node__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-        <!-- node_id = NodeId(id_str='ss_28001') -->
+        <!-- node_id = NodeId(id_str='ss_0') -->
         <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
         <!-- col1 =                                                                                           -->
         <!--   SqlSelectColumn(                                                                               -->

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimension_values_with_a_join_and_a_filter__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_3') -->
+        <!-- node_id = NodeId(id_str='ss_5') -->
         <!-- col0 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_119), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- group_by0 =                                                                                                 -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_118), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                  -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Output with WHERE' -->
-            <!-- node_id = NodeId(id_str='ss_2') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_71), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_72), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_73), column_alias='ds__month') -->
@@ -207,12 +207,12 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='largest_listing') -->
             <!-- col56 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_63), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = SqlStringExpression(node_id=str_0 sql_expr=user__home_state_latest = 'us') -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                               -->
                 <!--   SqlSelectColumn(                                   -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -413,10 +413,10 @@ docstring:
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
                 <!-- col56 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
                 <!--     right_source_alias='subq_2',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -425,7 +425,7 @@ docstring:
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28005') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -665,19 +665,19 @@ docstring:
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                     <!-- col1 =                                               -->
                     <!--   SqlSelectColumn(                                   -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_0), -->
                     <!--     column_alias='home_state_latest',                -->
                     <!--   )                                                  -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28009') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->

--- a/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
+++ b/tests_metricflow/snapshots/test_distinct_values_to_sql.py/SqlQueryPlan/test_dimensions_requiring_join__plan0.xml
@@ -6,12 +6,12 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-        <!-- node_id = NodeId(id_str='ss_2') -->
+        <!-- node_id = NodeId(id_str='ss_4') -->
         <!-- col0 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_62), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
         <!-- group_by0 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_61), column_alias='listing__is_lux_latest') -->
         <!-- group_by1 =                                                                                                 -->
@@ -20,7 +20,7 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_1') -->
+            <!-- node_id = NodeId(id_str='ss_3') -->
             <!-- col0 =                                               -->
             <!--   SqlSelectColumn(                                   -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_4), -->
@@ -205,10 +205,10 @@ docstring:
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_6), column_alias='largest_listing') -->
             <!-- col56 =                                                                                             -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_7), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- join_0 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_0),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
             <!--     right_source_alias='subq_2',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -217,7 +217,7 @@ docstring:
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -422,16 +422,16 @@ docstring:
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_0') -->
+                <!-- node_id = NodeId(id_str='ss_2') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='user') -->
                 <!-- col1 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28009') -->
+                    <!-- node_id = NodeId(id_str='ss_1') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_non_primary_time__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Metric Time Dimension 'paid_at'" -->
-        <!-- node_id = NodeId(id_str='ss_0') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_3), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_4), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_5), column_alias='ds__month') -->
@@ -230,12 +230,12 @@ docstring:
         <!-- col84 =                                                                                                -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='booking__is_instant') -->
         <!-- col85 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='booking_payments') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28001') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_metric_time_dimension_transform_node_using_primary_time__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Metric Time Dimension 'ds'" -->
-        <!-- node_id = NodeId(id_str='ss_0') -->
+        <!-- node_id = NodeId(id_str='ss_1') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
         <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_16), column_alias='ds__week') -->
         <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_17), column_alias='ds__month') -->
@@ -257,12 +257,12 @@ docstring:
         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
         <!--     column_alias='approximate_discrete_booking_value_p99', -->
         <!--   )                                                        -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-            <!-- node_id = NodeId(id_str='ss_28001') -->
+            <!-- node_id = NodeId(id_str='ss_0') -->
             <!-- col0 = SqlSelectColumn(expr=SqlStringExpression(node_id=str_28000 sql_expr=1), column_alias='bookings') -->
             <!-- col1 =                                                                                           -->
             <!--   SqlSelectColumn(                                                                               -->

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/test_simple_query_with_metric_time_dimension__plan0.xml
@@ -6,7 +6,7 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = 'Combine Aggregated Outputs' -->
-        <!-- node_id = NodeId(id_str='ss_8') -->
+        <!-- node_id = NodeId(id_str='ss_10') -->
         <!-- col0 =                                                                         -->
         <!--   SqlSelectColumn(                                                             -->
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_4, sql_function=COALESCE), -->
@@ -22,10 +22,10 @@ docstring:
         <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_3, sql_function=MAX), -->
         <!--     column_alias='booking_payments',                                      -->
         <!--   )                                                                       -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
         <!-- join_0 =                                                 -->
         <!--   SqlJoinDescription(                                    -->
-        <!--     right_source=SqlSelectStatementNode(node_id=ss_7),   -->
+        <!--     right_source=SqlSelectStatementNode(node_id=ss_9),   -->
         <!--     right_source_alias='subq_9',                         -->
         <!--     join_type=FULL_OUTER,                                -->
         <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -39,16 +39,16 @@ docstring:
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_4') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_102), column_alias='metric_time__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_103), column_alias='bookings') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
@@ -56,14 +56,14 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_0, sql_function=SUM), -->
                 <!--     column_alias='bookings',                                              -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_101), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_99), -->
@@ -71,12 +71,12 @@ docstring:
                     <!--   )                                                   -->
                     <!-- col1 =                                                                                       -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='bookings') -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                      -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_15), column_alias='ds__day') -->
                         <!-- col1 =                                                                                       -->
@@ -540,12 +540,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_12),      -->
                         <!--     column_alias='approximate_discrete_booking_value_p99', -->
                         <!--   )                                                        -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28001') -->
+                            <!-- node_id = NodeId(id_str='ss_0') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->
@@ -992,17 +992,17 @@ docstring:
         </SqlSelectStatementNode>
         <SqlSelectStatementNode>
             <!-- description = 'Compute Metrics via Expressions' -->
-            <!-- node_id = NodeId(id_str='ss_7') -->
+            <!-- node_id = NodeId(id_str='ss_9') -->
             <!-- col0 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_194), column_alias='metric_time__day') -->
             <!-- col1 =                                                                                                -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_195), column_alias='booking_payments') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_8) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Aggregate Measures' -->
-                <!-- node_id = NodeId(id_str='ss_6') -->
+                <!-- node_id = NodeId(id_str='ss_8') -->
                 <!-- col0 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- col1 =                                                                    -->
@@ -1010,14 +1010,14 @@ docstring:
                 <!--     expr=SqlAggregateFunctionExpression(node_id=fnc_1, sql_function=SUM), -->
                 <!--     column_alias='booking_payments',                                      -->
                 <!--   )                                                                       -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
                 <!-- group_by0 =                                                                                           -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_193), column_alias='metric_time__day') -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['booking_payments', 'metric_time__day']" -->
-                    <!-- node_id = NodeId(id_str='ss_5') -->
+                    <!-- node_id = NodeId(id_str='ss_7') -->
                     <!-- col0 =                                                 -->
                     <!--   SqlSelectColumn(                                     -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_191), -->
@@ -1028,12 +1028,12 @@ docstring:
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_190), -->
                     <!--     column_alias='booking_payments',                   -->
                     <!--   )                                                    -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'paid_at'" -->
-                        <!-- node_id = NodeId(id_str='ss_4') -->
+                        <!-- node_id = NodeId(id_str='ss_6') -->
                         <!-- col0 =                                                                                       -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_107), column_alias='ds__day') -->
                         <!-- col1 =                                                                                        -->
@@ -1446,12 +1446,12 @@ docstring:
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_104), -->
                         <!--     column_alias='booking_payments',                   -->
                         <!--   )                                                    -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28001) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_5) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = "Read Elements From Semantic Model 'bookings_source'" -->
-                            <!-- node_id = NodeId(id_str='ss_28001') -->
+                            <!-- node_id = NodeId(id_str='ss_5') -->
                             <!-- col0 =                                                      -->
                             <!--   SqlSelectColumn(                                          -->
                             <!--     expr=SqlStringExpression(node_id=str_28000 sql_expr=1), -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_dimensions_with_time_constraint__plan0.xml
@@ -5,13 +5,13 @@ test_filename: test_metric_time_without_metrics.py
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_5') -->
+        <!-- node_id = NodeId(id_str='ss_8') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_146), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                       -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_147), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_7) -->
         <!-- group_by0 =                                                                                           -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_148), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                 -->
@@ -22,7 +22,7 @@ test_filename: test_metric_time_without_metrics.py
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Constrain Time Range to [2020-01-01T00:00:00, 2020-01-03T00:00:00]' -->
-            <!-- node_id = NodeId(id_str='ss_4') -->
+            <!-- node_id = NodeId(id_str='ss_7') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_98), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_99), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_100), column_alias='ds__month') -->
@@ -211,12 +211,12 @@ test_filename: test_metric_time_without_metrics.py
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_90), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
             <!-- where = SqlBetweenExpression(node_id=betw_0) -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Join Standard Outputs' -->
-                <!-- node_id = NodeId(id_str='ss_3') -->
+                <!-- node_id = NodeId(id_str='ss_6') -->
                 <!-- col0 =                                                -->
                 <!--   SqlSelectColumn(                                    -->
                 <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
@@ -419,16 +419,16 @@ test_filename: test_metric_time_without_metrics.py
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
                 <!-- col57 =                                                                                              -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
                 <!-- join_0 =                                               -->
                 <!--   SqlJoinDescription(                                  -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_1), -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_3), -->
                 <!--     right_source_alias='subq_3',                       -->
                 <!--     join_type=CROSS_JOIN,                              -->
                 <!--   )                                                    -->
                 <!-- join_1 =                                                 -->
                 <!--   SqlJoinDescription(                                    -->
-                <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+                <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
                 <!--     right_source_alias='subq_5',                         -->
                 <!--     join_type=FULL_OUTER,                                -->
                 <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -437,7 +437,7 @@ test_filename: test_metric_time_without_metrics.py
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28005') -->
+                    <!-- node_id = NodeId(id_str='ss_0') -->
                     <!-- col0 =                                                      -->
                     <!--   SqlSelectColumn(                                          -->
                     <!--     expr=SqlStringExpression(node_id=str_28006 sql_expr=1), -->
@@ -677,18 +677,18 @@ test_filename: test_metric_time_without_metrics.py
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                    <!-- node_id = NodeId(id_str='ss_1') -->
+                    <!-- node_id = NodeId(id_str='ss_3') -->
                     <!-- col0 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_24), -->
                     <!--     column_alias='metric_time__day',                  -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Metric Time Dimension 'ds'" -->
-                        <!-- node_id = NodeId(id_str='ss_0') -->
+                        <!-- node_id = NodeId(id_str='ss_2') -->
                         <!-- col0 =                                                                                     -->
                         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
                         <!-- col1 =                                                                                      -->
@@ -797,12 +797,12 @@ test_filename: test_metric_time_without_metrics.py
                         <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
                         <!--     column_alias='metric_time__martian_day',          -->
                         <!--   )                                                   -->
-                        <!-- from_source = SqlSelectStatementNode(node_id=ss_28018) -->
+                        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                         <!-- where = None -->
                         <!-- distinct = False -->
                         <SqlSelectStatementNode>
                             <!-- description = 'Time Spine' -->
-                            <!-- node_id = NodeId(id_str='ss_28018') -->
+                            <!-- node_id = NodeId(id_str='ss_1') -->
                             <!-- col0 =                                                                                   -->
                             <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                             <!-- col1 =                                                                                    -->
@@ -867,19 +867,19 @@ test_filename: test_metric_time_without_metrics.py
                 </SqlSelectStatementNode>
                 <SqlSelectStatementNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='ss_2') -->
+                    <!-- node_id = NodeId(id_str='ss_5') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='user') -->
                     <!-- col1 =                                                -->
                     <!--   SqlSelectColumn(                                    -->
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_25), -->
                     <!--     column_alias='home_state_latest',                 -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                        <!-- node_id = NodeId(id_str='ss_28009') -->
+                        <!-- node_id = NodeId(id_str='ss_4') -->
                         <!-- col0 =                                             -->
                         <!--   SqlSelectColumn(                                 -->
                         <!--     expr=SqlDateTruncExpression(node_id=dt_28202), -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_only__plan0.xml
@@ -6,16 +6,16 @@ docstring:
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                          -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
@@ -78,12 +78,12 @@ docstring:
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
             <!--     column_alias='metric_time__martian_day',          -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28018) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Time Spine' -->
-                <!-- node_id = NodeId(id_str='ss_28018') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28295), column_alias='ds__month') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_quarter_alone__plan0.xml
@@ -4,17 +4,17 @@ test_filename: test_metric_time_without_metrics.py
 <SqlQueryPlan>
     <SqlSelectStatementNode>
         <!-- description = "Pass Only Elements: ['metric_time__quarter',]" -->
-        <!-- node_id = NodeId(id_str='ss_1') -->
+        <!-- node_id = NodeId(id_str='ss_2') -->
         <!-- col0 =                                                                                                   -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__quarter') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
         <!-- group_by0 =                                                                                              -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__quarter') -->
         <!-- where = None -->
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = "Metric Time Dimension 'ds'" -->
-            <!-- node_id = NodeId(id_str='ss_0') -->
+            <!-- node_id = NodeId(id_str='ss_1') -->
             <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
             <!-- col1 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
             <!-- col2 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_2), column_alias='ds__month') -->
@@ -77,12 +77,12 @@ test_filename: test_metric_time_without_metrics.py
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
             <!--     column_alias='metric_time__martian_day',          -->
             <!--   )                                                   -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28018) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- where = None -->
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = 'Time Spine' -->
-                <!-- node_id = NodeId(id_str='ss_28018') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                 <!-- col1 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28294), column_alias='ds__week') -->
                 <!-- col2 = SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28295), column_alias='ds__month') -->

--- a/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
+++ b/tests_metricflow/snapshots/test_metric_time_without_metrics.py/SqlQueryPlan/test_metric_time_with_other_dimensions__plan0.xml
@@ -5,13 +5,13 @@ test_filename: test_metric_time_without_metrics.py
     <SqlSelectStatementNode>
         <!-- description =                                                                                     -->
         <!--   "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day']" -->
-        <!-- node_id = NodeId(id_str='ss_4') -->
+        <!-- node_id = NodeId(id_str='ss_7') -->
         <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='metric_time__day') -->
         <!-- col1 =                                                                                                     -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_87), column_alias='listing__is_lux_latest') -->
         <!-- col2 =                                                                                                      -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_88), column_alias='user__home_state_latest') -->
-        <!-- from_source = SqlSelectStatementNode(node_id=ss_3) -->
+        <!-- from_source = SqlSelectStatementNode(node_id=ss_6) -->
         <!-- group_by0 =                                                                                          -->
         <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_89), column_alias='metric_time__day') -->
         <!-- group_by1 =                                                                                                -->
@@ -22,7 +22,7 @@ test_filename: test_metric_time_without_metrics.py
         <!-- distinct = False -->
         <SqlSelectStatementNode>
             <!-- description = 'Join Standard Outputs' -->
-            <!-- node_id = NodeId(id_str='ss_3') -->
+            <!-- node_id = NodeId(id_str='ss_6') -->
             <!-- col0 =                                                -->
             <!--   SqlSelectColumn(                                    -->
             <!--     expr=SqlColumnReferenceExpression(node_id=cr_29), -->
@@ -210,16 +210,16 @@ test_filename: test_metric_time_without_metrics.py
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_31), column_alias='largest_listing') -->
             <!-- col57 =                                                                                              -->
             <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_32), column_alias='smallest_listing') -->
-            <!-- from_source = SqlSelectStatementNode(node_id=ss_28005) -->
+            <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
             <!-- join_0 =                                               -->
             <!--   SqlJoinDescription(                                  -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_1), -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_3), -->
             <!--     right_source_alias='subq_3',                       -->
             <!--     join_type=CROSS_JOIN,                              -->
             <!--   )                                                    -->
             <!-- join_1 =                                                 -->
             <!--   SqlJoinDescription(                                    -->
-            <!--     right_source=SqlSelectStatementNode(node_id=ss_2),   -->
+            <!--     right_source=SqlSelectStatementNode(node_id=ss_5),   -->
             <!--     right_source_alias='subq_5',                         -->
             <!--     join_type=FULL_OUTER,                                -->
             <!--     on_condition=SqlComparisonExpression(node_id=cmp_0), -->
@@ -228,7 +228,7 @@ test_filename: test_metric_time_without_metrics.py
             <!-- distinct = False -->
             <SqlSelectStatementNode>
                 <!-- description = "Read Elements From Semantic Model 'listings_latest'" -->
-                <!-- node_id = NodeId(id_str='ss_28005') -->
+                <!-- node_id = NodeId(id_str='ss_0') -->
                 <!-- col0 =                                                                                             -->
                 <!--   SqlSelectColumn(expr=SqlStringExpression(node_id=str_28006 sql_expr=1), column_alias='listings') -->
                 <!-- col1 =                                                   -->
@@ -433,15 +433,15 @@ test_filename: test_metric_time_without_metrics.py
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['metric_time__day',]" -->
-                <!-- node_id = NodeId(id_str='ss_1') -->
+                <!-- node_id = NodeId(id_str='ss_3') -->
                 <!-- col0 =                                                                                               -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_24), column_alias='metric_time__day') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_0) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_2) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Metric Time Dimension 'ds'" -->
-                    <!-- node_id = NodeId(id_str='ss_0') -->
+                    <!-- node_id = NodeId(id_str='ss_2') -->
                     <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_0), column_alias='ds__day') -->
                     <!-- col1 =                                                                                      -->
                     <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_1), column_alias='ds__week') -->
@@ -546,12 +546,12 @@ test_filename: test_metric_time_without_metrics.py
                     <!--     expr=SqlColumnReferenceExpression(node_id=cr_23), -->
                     <!--     column_alias='metric_time__martian_day',          -->
                     <!--   )                                                   -->
-                    <!-- from_source = SqlSelectStatementNode(node_id=ss_28018) -->
+                    <!-- from_source = SqlSelectStatementNode(node_id=ss_1) -->
                     <!-- where = None -->
                     <!-- distinct = False -->
                     <SqlSelectStatementNode>
                         <!-- description = 'Time Spine' -->
-                        <!-- node_id = NodeId(id_str='ss_28018') -->
+                        <!-- node_id = NodeId(id_str='ss_1') -->
                         <!-- col0 =                                                                                   -->
                         <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28293), column_alias='ds__day') -->
                         <!-- col1 =                                                                                    -->
@@ -610,16 +610,16 @@ test_filename: test_metric_time_without_metrics.py
             </SqlSelectStatementNode>
             <SqlSelectStatementNode>
                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                <!-- node_id = NodeId(id_str='ss_2') -->
+                <!-- node_id = NodeId(id_str='ss_5') -->
                 <!-- col0 = SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_26), column_alias='user') -->
                 <!-- col1 =                                                                                                -->
                 <!--   SqlSelectColumn(expr=SqlColumnReferenceExpression(node_id=cr_25), column_alias='home_state_latest') -->
-                <!-- from_source = SqlSelectStatementNode(node_id=ss_28009) -->
+                <!-- from_source = SqlSelectStatementNode(node_id=ss_4) -->
                 <!-- where = None -->
                 <!-- distinct = False -->
                 <SqlSelectStatementNode>
                     <!-- description = "Read Elements From Semantic Model 'users_latest'" -->
-                    <!-- node_id = NodeId(id_str='ss_28009') -->
+                    <!-- node_id = NodeId(id_str='ss_4') -->
                     <!-- col0 =                                                                                          -->
                     <!--   SqlSelectColumn(expr=SqlDateTruncExpression(node_id=dt_28202), column_alias='ds_latest__day') -->
                     <!-- col1 =                                                                                           -->

--- a/tests_metricflow/sql/optimizer/test_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_column_pruner.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
 from metricflow_semantics.sql.sql_join_type import SqlJoinType
 from metricflow_semantics.sql.sql_table import SqlTable
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
@@ -24,6 +27,8 @@ from metricflow.sql.sql_plan import (
     SqlTableNode,
 )
 from tests_metricflow.sql.compare_sql_plan import assert_default_rendered_sql_equal
+
+logger = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -206,6 +211,8 @@ def test_no_pruning(
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
     """Tests a case where no pruning should occur."""
+    logger.debug(LazyFormat("Pruning select statement", base_select_statement=base_select_statement.structure_text()))
+
     assert_default_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,
@@ -900,6 +907,9 @@ def test_prune_distinct_select(
         ),
         from_source_alias="b",
     )
+
+    logger.debug(LazyFormat("Pruning select statement", select_statement=select_node.structure_text()))
+
     assert_default_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,


### PR DESCRIPTION
Currently, the column pruner checks the columns that are needed in each `SELECT` statement and generates the pruned SQL in a single pass. For better readability and easier modification, this splits the column pruner into two phases.

First, the SQL nodes are traversed to figure out which columns are required and which can be pruned. Then, the SQL nodes are rewritten with the pruned columns.

The logic in `SqlTagRequiredColumnAliasesVisitor` has been copied from the original implementation.