### PR TITLE
Support CTEs in the column pruner

### DIFF
--- a/metricflow/sql/optimizer/tag_required_column_aliases.py
+++ b/metricflow/sql/optimizer/tag_required_column_aliases.py
@@ -106,13 +106,27 @@ class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
 
     @override
     def visit_cte_node(self, node: SqlCteNode) -> None:
-        raise NotImplementedError
+        select_statement = node.select_statement
+        # Copy the tagged aliases from the CTE to the SELECT since when visiting a SELECT, the CTE node (not the SELECT
+        # in the CTE) was tagged with the required aliases.
+        required_column_aliases_in_this_node = self._current_required_column_alias_mapping.get_aliases(node)
+        self._current_required_column_alias_mapping.add_aliases(select_statement, required_column_aliases_in_this_node)
+        # Visit parent nodes.
+        select_statement.accept(self)
 
     def _visit_parents(self, node: SqlQueryPlanNode) -> None:
         """Default recursive handler to visit the parents of the given node."""
         for parent_node in node.parent_nodes:
             parent_node.accept(self)
         return
+
+    def _tag_potential_cte_node(self, table_name: str, column_aliases: Set[str]) -> None:
+        """A reference to a SQL table might be a CTE. If so, tag the appropriate aliases in the CTEs."""
+        cte_node = self._cte_alias_to_cte_node.get(table_name)
+        if cte_node is not None:
+            self._current_required_column_alias_mapping.add_aliases(cte_node, column_aliases)
+            # `visit_cte_node` will handle propagating the required aliases to all CTEs that this CTE node depends on.
+            cte_node.accept(self)
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> None:
         """Based on required column aliases for this SELECT, figure out required column aliases in parents."""
@@ -191,14 +205,24 @@ class SqlMapRequiredColumnAliasesVisitor(SqlQueryPlanNodeVisitor[None]):
             self._current_required_column_alias_mapping.add_aliases(
                 node=node.from_source, column_aliases=aliases_required_in_parent
             )
-
+            from_source_as_sql_table_node = node.from_source.as_sql_table_node
+            if from_source_as_sql_table_node is not None:
+                self._tag_potential_cte_node(
+                    table_name=from_source_as_sql_table_node.sql_table.table_name,
+                    column_aliases=aliases_required_in_parent,
+                )
         for join_desc in node.join_descs:
             if join_desc.right_source_alias in source_alias_to_required_column_aliases:
                 aliases_required_in_parent = source_alias_to_required_column_aliases[join_desc.right_source_alias]
                 self._current_required_column_alias_mapping.add_aliases(
                     node=join_desc.right_source, column_aliases=aliases_required_in_parent
                 )
-        # TODO: Handle CTEs parent nodes.
+                right_source_as_sql_table_node = join_desc.right_source.as_sql_table_node
+                if right_source_as_sql_table_node is not None:
+                    self._tag_potential_cte_node(
+                        table_name=right_source_as_sql_table_node.sql_table.table_name,
+                        column_aliases=aliases_required_in_parent,
+                    )
 
         # For all string columns, assume that they are needed from all sources since we don't have a table alias
         # in SqlStringExpression.used_columns

--- a/metricflow/sql/sql_plan.py
+++ b/metricflow/sql/sql_plan.py
@@ -432,6 +432,13 @@ class SqlCteNode(SqlQueryPlanNode):
             cte_alias=cte_alias,
         )
 
+    def with_new_select(self, new_select_statement: SqlQueryPlanNode) -> SqlCteNode:
+        """Return a node with the same attributes but with the new SELECT statement."""
+        return SqlCteNode.create(
+            select_statement=new_select_statement,
+            cte_alias=self.cte_alias,
+        )
+
     @override
     def accept(self, visitor: SqlQueryPlanNodeVisitor[VisitorOutputT]) -> VisitorOutputT:
         return visitor.visit_cte_node(self)

--- a/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_multi_child_pruning__result.txt
+++ b/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_multi_child_pruning__result.txt
@@ -1,0 +1,55 @@
+test_name: test_multi_child_pruning
+test_filename: test_cte_column_pruner.py
+docstring:
+  Tests the case of pruning a CTE where difference sources depend on the same CTE.
+---
+optimizer:
+  SqlColumnPrunerOptimizer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+      , test_table_alias.col_1 AS cte_source_0__col_2
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN (
+    -- Joined sub-query
+    SELECT
+      cte_source_0_alias_in_right_source.cte_source_0__col_0 AS right_source__col_0
+      , cte_source_0_alias_in_right_source.cte_source_0__col_1 AS right_source__col_1
+    FROM cte_source_0 cte_source_0_alias_in_right_source
+  ) right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN (
+    -- Joined sub-query
+    SELECT
+      cte_source_0_alias_in_right_source.cte_source_0__col_1 AS right_source__col_1
+    FROM cte_source_0 cte_source_0_alias_in_right_source
+  ) right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1

--- a/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_nested_pruning__result.txt
+++ b/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_nested_pruning__result.txt
@@ -1,0 +1,49 @@
+test_name: test_nested_pruning
+test_filename: test_cte_column_pruner.py
+docstring:
+  Tests the case of pruning a CTE where a query depends on a CTE, and that CTE depends on another CTE.
+---
+optimizer:
+  SqlColumnPrunerOptimizer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM test_schema.test_table test_table_alias
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      cte_source_0_alias.cte_source_0__col_0 AS cte_source_1__col_0
+      , cte_source_0_alias.cte_source_0__col_0 AS cte_source_1__col_1
+    FROM cte_source_0 cte_source_0_alias
+  )
+
+  SELECT
+    cte_source_1_alias.cte_source_1__col_0 AS top_level__col_0
+  FROM cte_source_1 cte_source_1_alias
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table test_table_alias
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      cte_source_0_alias.cte_source_0__col_0 AS cte_source_1__col_0
+    FROM cte_source_0 cte_source_0_alias
+  )
+
+  SELECT
+    cte_source_1_alias.cte_source_1__col_0 AS top_level__col_0
+  FROM cte_source_1 cte_source_1_alias

--- a/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_no_pruning__result.txt
+++ b/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_no_pruning__result.txt
@@ -1,0 +1,33 @@
+test_name: test_no_pruning
+test_filename: test_cte_column_pruner.py
+docstring:
+  Tests a case where no pruning should occur for a CTE.
+---
+optimizer:
+  SqlColumnPrunerOptimizer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias

--- a/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_simple_pruning__result.txt
+++ b/tests_metricflow/snapshots/test_cte_column_pruner.py/str/test_simple_pruning__result.txt
@@ -1,0 +1,34 @@
+test_name: test_simple_pruning
+test_filename: test_cte_column_pruner.py
+docstring:
+  Tests the simplest case of pruning a CTE where a query depends on a CTE, and that CTE is pruned.
+---
+optimizer:
+  SqlColumnPrunerOptimizer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_0 AS cte_source_0__col_1
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table test_table_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias

--- a/tests_metricflow/sql/optimizer/check_optimizer.py
+++ b/tests_metricflow/sql/optimizer/check_optimizer.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.formatting import indent
+from metricflow_semantics.mf_logging.lazy_formattable import LazyFormat
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import assert_str_snapshot_equal
+
+from metricflow.sql.optimizer.sql_query_plan_optimizer import SqlQueryPlanOptimizer
+from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.sql_plan import SqlQueryPlan, SqlSelectStatementNode
+
+logger = logging.getLogger(__name__)
+
+
+def assert_optimizer_result_snapshot_equal(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    optimizer: SqlQueryPlanOptimizer,
+    sql_plan_renderer: SqlQueryPlanRenderer,
+    select_statement: SqlSelectStatementNode,
+) -> None:
+    """Helper to assert that the SQL snapshot of the optimizer result is the same as the stored one."""
+    sql_before_optimizing = sql_plan_renderer.render_sql_query_plan(SqlQueryPlan(select_statement)).sql
+    logger.debug(
+        LazyFormat(
+            "Optimizing SELECT statement",
+            select_statement=select_statement.structure_text(),
+            sql_before_optimizing=sql_before_optimizing,
+        )
+    )
+
+    column_pruned_select_node = optimizer.optimize(select_statement)
+    sql_after_optimizing = sql_plan_renderer.render_sql_query_plan(SqlQueryPlan(column_pruned_select_node)).sql
+    logger.debug(
+        LazyFormat(
+            "Optimized SQL",
+            sql_before_optimizing=sql_before_optimizing,
+            sql_after_optimizing=sql_after_optimizing,
+        )
+    )
+    snapshot_str = "\n".join(
+        [
+            "optimizer:",
+            indent(optimizer.__class__.__name__),
+            "",
+            "sql_before_optimizing:",
+            indent(sql_before_optimizing),
+            "",
+            "sql_after_optimizing:",
+            indent(sql_after_optimizing),
+        ]
+    )
+    assert_str_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        snapshot_id="result",
+        snapshot_str=snapshot_str,
+    )

--- a/tests_metricflow/sql/optimizer/test_cte_column_pruner.py
+++ b/tests_metricflow/sql/optimizer/test_cte_column_pruner.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.sql.sql_table import SqlTable
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from metricflow.sql.optimizer.column_pruner import SqlColumnPrunerOptimizer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlComparison,
+    SqlComparisonExpression,
+)
+from metricflow.sql.sql_plan import (
+    SqlCteNode,
+    SqlJoinDescription,
+    SqlSelectColumn,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+from tests_metricflow.sql.optimizer.check_optimizer import assert_optimizer_result_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def column_pruner() -> SqlColumnPrunerOptimizer:  # noqa: D103
+    return SqlColumnPrunerOptimizer()
+
+
+@pytest.fixture
+def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
+    return DefaultSqlQueryPlanRenderer()
+
+
+def test_no_pruning(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    column_pruner: SqlColumnPrunerOptimizer,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+) -> None:
+    """Tests a case where no pruning should occur for a CTE."""
+    select_statement = SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+        from_source_alias="cte_source_0_alias",
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(
+                        sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                    ),
+                    from_source_alias="test_table_alias",
+                ),
+            ),
+        ),
+    )
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=column_pruner,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=select_statement,
+    )
+
+
+def test_simple_pruning(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    column_pruner: SqlColumnPrunerOptimizer,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+) -> None:
+    """Tests the simplest case of pruning a CTE where a query depends on a CTE, and that CTE is pruned."""
+    select_statement = SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+        from_source_alias="cte_source_0_alias",
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_1",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(
+                        sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                    ),
+                    from_source_alias="test_table_alias",
+                ),
+            ),
+        ),
+    )
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=column_pruner,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=select_statement,
+    )
+
+
+def test_nested_pruning(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    column_pruner: SqlColumnPrunerOptimizer,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+) -> None:
+    """Tests the case of pruning a CTE where a query depends on a CTE, and that CTE depends on another CTE."""
+    select_statement = SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_1_alias", column_name="cte_source_1__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_1")),
+        from_source_alias="cte_source_1_alias",
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_0__col_1",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(
+                        sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                    ),
+                    from_source_alias="test_table_alias",
+                ),
+            ),
+            SqlCteNode.create(
+                cte_alias="cte_source_1",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 1",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(
+                                    table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                )
+                            ),
+                            column_alias="cte_source_1__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(
+                                    table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                )
+                            ),
+                            column_alias="cte_source_1__col_1",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+                    from_source_alias="cte_source_0_alias",
+                ),
+            ),
+        ),
+    )
+
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=column_pruner,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=select_statement,
+    )
+
+
+def test_multi_child_pruning(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    column_pruner: SqlColumnPrunerOptimizer,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+) -> None:
+    """Tests the case of pruning a CTE where difference sources depend on the same CTE."""
+    select_statement = SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                ),
+                column_alias="top_level__col_1",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+        from_source_alias="cte_source_0_alias",
+        join_descs=(
+            SqlJoinDescription(
+                right_source=SqlSelectStatementNode.create(
+                    description="Joined sub-query",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(
+                                    table_alias="cte_source_0_alias_in_right_source", column_name="cte_source_0__col_0"
+                                )
+                            ),
+                            column_alias="right_source__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(
+                                    table_alias="cte_source_0_alias_in_right_source", column_name="cte_source_0__col_1"
+                                )
+                            ),
+                            column_alias="right_source__col_1",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+                    from_source_alias="cte_source_0_alias_in_right_source",
+                ),
+                right_source_alias="right_source_alias",
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_1")
+                    ),
+                    comparison=SqlComparison.EQUALS,
+                    right_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                    ),
+                ),
+                join_type=SqlJoinType.INNER,
+            ),
+        ),
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_0__col_1",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_0__col_2",
+                        ),
+                    ),
+                    from_source=SqlTableNode.create(
+                        sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                    ),
+                    from_source_alias="test_table_alias",
+                ),
+            ),
+        ),
+    )
+
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=column_pruner,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=select_statement,
+    )


### PR DESCRIPTION
This updates the column pruner optimizer to support CTEs. To support CTEs, the required columns are mapped to the corresponding CTE and propagated like other parent nodes.