### PR TITLE
Support CTEs in sub-query reducer

### DIFF
--- a/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
+++ b/metricflow/sql/optimizer/rewriting_sub_query_reducer.py
@@ -106,12 +106,12 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             ),
             join_descs=tuple(
                 SqlJoinDescription(
-                    right_source=x.right_source.accept(self),
-                    right_source_alias=x.right_source_alias,
-                    on_condition=x.on_condition,
-                    join_type=x.join_type,
+                    right_source=join_desc.right_source.accept(self),
+                    right_source_alias=join_desc.right_source_alias,
+                    on_condition=join_desc.on_condition,
+                    join_type=join_desc.join_type,
                 )
-                for x in node.join_descs
+                for join_desc in node.join_descs
             ),
             group_bys=node.group_bys,
             order_bys=node.order_bys,
@@ -199,7 +199,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             if select_column.expr.lineage.contains_aggregate_exprs:
                 return False
         return (
-            len(node.parent_nodes) <= 1
+            len(node.join_descs) == 0
             and len(node.group_bys) == 0
             and len(node.order_bys) == 0
             and not node.limit
@@ -212,20 +212,15 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
         Reducing this node means eliminating the SELECT of this node and merging it with the parent SELECT. This
         checks for the cases where we are able to reduce.
         """
-        # If this node has multiple parents (i.e. a join) that are complex, then this can't be collapsed.
-        is_join = len(node.join_descs) > 0
-        has_multiple_parent_nodes = len(node.parent_nodes) > 1
-        if has_multiple_parent_nodes or is_join:
+        # If this node has joins, then don't collapse this as it can be complex.
+        if len(node.join_descs) > 0:
             return False
-
-        assert len(node.parent_nodes) == 1
-        parent_node = node.parent_nodes[0]
 
         # If the parent node is not a SELECT statement, then this can't be collapsed. e.g. with a table as a parent like
         # SELECT foo FROM bar
-        if not parent_node.as_select_node:
+        from_source_node_as_select_node = node.from_source.as_select_node
+        if from_source_node_as_select_node is None:
             return False
-        parent_select_node = parent_node.as_select_node
 
         # More conditions where we don't want to collapse. It's not impossible with these cases, but not reducing in
         # these cases for simplicity.
@@ -235,15 +230,15 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             return False
 
         # Don't reduce distinct selects
-        if parent_select_node.distinct:
+        if from_source_node_as_select_node.distinct:
             return False
 
         # Skip this case for simplicity of reasoning.
-        if len(node.order_bys) > 0 and len(parent_select_node.order_bys) > 0:
+        if len(node.order_bys) > 0 and len(from_source_node_as_select_node.order_bys) > 0:
             return False
 
         # Skip this case for simplicity of reasoning.
-        if len(parent_select_node.group_bys) > 0 and len(node.group_bys) > 0:
+        if len(from_source_node_as_select_node.group_bys) > 0 and len(node.group_bys) > 0:
             return False
 
         # If there is a column in the parent group by that is not used in the current select statement, don't reduce or it
@@ -270,9 +265,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             if select_column.expr.as_column_reference_expression
         }
         all_parent_group_bys_used_in_current_select = True
-        for group_by in parent_select_node.group_bys:
+        for group_by in from_source_node_as_select_node.group_bys:
             parent_group_by_select = SqlGroupByRewritingVisitor._find_matching_select(
-                expr=group_by.expr, select_columns=parent_select_node.select_columns
+                expr=group_by.expr, select_columns=from_source_node_as_select_node.select_columns
             )
             if parent_group_by_select and parent_group_by_select.column_alias not in current_select_column_refs:
                 all_parent_group_bys_used_in_current_select = False
@@ -293,13 +288,13 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
 
         # If the parent has a GROUP BY and this has a WHERE, avoid reducing as the WHERE could reference an
         # aggregation expression.
-        if len(parent_select_node.group_bys) > 0 and node.where:
+        if len(from_source_node_as_select_node.group_bys) > 0 and node.where:
             return False
 
         # If the parent has a GROUP BY, the case where it's easiest to merge this with the parent is if all select
         # columns are column references.
         if len(
-            parent_select_node.group_bys
+            from_source_node_as_select_node.group_bys
         ) > 0 and not SqlRewritingSubQueryReducerVisitor._select_columns_are_column_references(node.select_columns):
             return False
 
@@ -308,7 +303,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
         parent_column_aliases_with_window_functions = {
             select_column.column_alias
             for select_column in SqlRewritingSubQueryReducerVisitor._select_columns_with_window_functions(
-                parent_select_node.select_columns
+                from_source_node_as_select_node.select_columns
             )
         }
         if len(node.group_bys) > 0 and [
@@ -355,7 +350,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
         # item in the SELECT to group by.
 
         if len(node.group_bys) > 0 and SqlRewritingSubQueryReducerVisitor._select_columns_contain_string_expressions(
-            select_columns=parent_select_node.select_columns,
+            select_columns=from_source_node_as_select_node.select_columns,
         ):
             return False
 
@@ -419,8 +414,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
                 return select_column
         return None
 
-    @staticmethod
-    def _rewrite_node_with_join(node: SqlSelectStatementNode) -> SqlSelectStatementNode:
+    def _rewrite_node_with_join(self, node: SqlSelectStatementNode) -> SqlSelectStatementNode:
         """Reduces nodes with joins if the join source is simple to reduce.
 
         Converts this:
@@ -558,7 +552,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
 
             clauses_to_rewrite.rewrite(column_replacements=column_replacements)
             # This was already checked in _is_simple_source().
-            assert len(from_source_select.parent_nodes) == 1
+            assert len(from_source_select.join_descs) == 0
             from_source = from_source_select.from_source
             from_source_alias = from_source_select.from_source_alias
 
@@ -579,6 +573,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             select_columns=tuple(clauses_to_rewrite.select_columns),
             from_source=from_source,
             from_source_alias=from_source_alias,
+            cte_sources=tuple(
+                cte_source.with_new_select(cte_source.select_statement.accept(self)) for cte_source in node.cte_sources
+            ),
             join_descs=tuple(new_join_descs),
             group_bys=tuple(clauses_to_rewrite.group_bys),
             order_bys=tuple(clauses_to_rewrite.order_bys),
@@ -595,7 +592,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
         node_with_reduced_parents = self._reduce_parents(node)
 
         if len(node_with_reduced_parents.join_descs) > 0:
-            return SqlRewritingSubQueryReducerVisitor._rewrite_node_with_join(node_with_reduced_parents)
+            return self._rewrite_node_with_join(node_with_reduced_parents)
 
         if not self._current_node_can_be_reduced(node_with_reduced_parents):
             return node_with_reduced_parents
@@ -615,7 +612,7 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
         # JOIN dim_listings c
         # ON a.listing_id = b.listing_id
 
-        from_source_node = node_with_reduced_parents.parent_nodes[0]
+        from_source_node = node_with_reduced_parents.from_source
         from_source_select_node = from_source_node.as_select_node
         assert (
             from_source_select_node is not None
@@ -699,6 +696,9 @@ class SqlRewritingSubQueryReducerVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNod
             ),
             from_source=from_source_select_node.from_source,
             from_source_alias=from_source_select_node.from_source_alias,
+            cte_sources=tuple(
+                cte_source.with_new_select(cte_source.select_statement.accept(self)) for cte_source in node.cte_sources
+            ),
             join_descs=from_source_select_node.join_descs,
             group_bys=new_group_bys,
             order_bys=tuple(new_order_bys),
@@ -733,13 +733,13 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
     ) -> Optional[SqlSelectColumn]:
         """Given an expression, find the SELECT column that has the same expression."""
         for select_column in select_columns:
-            if select_column.expr == expr:
+            if select_column.expr.matches(expr):
                 return select_column
         return None
 
     @override
     def visit_cte_node(self, node: SqlCteNode) -> SqlQueryPlanNode:
-        raise NotImplementedError
+        return node.with_new_select(node.select_statement.accept(self))
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
         new_group_bys = []
@@ -767,6 +767,9 @@ class SqlGroupByRewritingVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
             select_columns=node.select_columns,
             from_source=node.from_source.accept(self),
             from_source_alias=node.from_source_alias,
+            cte_sources=tuple(
+                cte_source.with_new_select(cte_source.select_statement.accept(self)) for cte_source in node.cte_sources
+            ),
             join_descs=tuple(
                 SqlJoinDescription(
                     right_source=x.right_source.accept(self),

--- a/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_reduce_cte__result.txt
+++ b/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_reduce_cte__result.txt
@@ -1,0 +1,81 @@
+test_name: test_reduce_cte
+test_filename: test_cte_rewriting_sub_query_reducer.py
+docstring:
+  Tests that the SELECT statements in CTEs are reduced.
+---
+optimizer:
+  SqlRewritingSubQueryReducer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM (
+      -- CTE source 0 sub-query
+      SELECT
+        test_table_alias.col_0 AS cte_source_0_subquery__col_0
+        , test_table_alias.col_0 AS cte_source_0_subquery__col_1
+      FROM test_schema.test_table test_table_alias
+    ) cte_source_0_subquery
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      test_table_alias.col_0 AS cte_source_1__col_0
+      , test_table_alias.col_1 AS cte_source_1__col_1
+    FROM (
+      -- CTE source 1 sub-query
+      SELECT
+        cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_0
+        , cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_1
+      FROM cte_source_0 cte_source_0_alias
+    ) cte_source_1_subquery
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+  GROUP BY
+    cte_source_0_alias.cte_source_0__col_0
+    , right_source_alias.right_source__col_1
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0 sub-query
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM test_schema.test_table test_table_alias
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1 sub-query
+    -- CTE source 1
+    SELECT
+      test_table_alias.col_0 AS cte_source_1__col_0
+      , test_table_alias.col_1 AS cte_source_1__col_1
+    FROM cte_source_0 cte_source_0_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+  GROUP BY
+    cte_source_0_alias.cte_source_0__col_0
+    , right_source_alias.right_source__col_1

--- a/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_reduce_cte_with_use_column_alias_in_group_bys__result.txt
+++ b/tests_metricflow/snapshots/test_cte_rewriting_sub_query_reducer.py/str/test_reduce_cte_with_use_column_alias_in_group_bys__result.txt
@@ -1,0 +1,81 @@
+test_name: test_reduce_cte_with_use_column_alias_in_group_bys
+test_filename: test_cte_rewriting_sub_query_reducer.py
+docstring:
+  This tests reducing with the `use_column_alias_in_group_bys` flag set.
+---
+optimizer:
+  SqlRewritingSubQueryReducer
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM (
+      -- CTE source 0 sub-query
+      SELECT
+        test_table_alias.col_0 AS cte_source_0_subquery__col_0
+        , test_table_alias.col_0 AS cte_source_0_subquery__col_1
+      FROM test_schema.test_table test_table_alias
+    ) cte_source_0_subquery
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      test_table_alias.col_0 AS cte_source_1__col_0
+      , test_table_alias.col_1 AS cte_source_1__col_1
+    FROM (
+      -- CTE source 1 sub-query
+      SELECT
+        cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_0
+        , cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_1
+      FROM cte_source_0 cte_source_0_alias
+    ) cte_source_1_subquery
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+  GROUP BY
+    cte_source_0_alias.cte_source_0__col_0
+    , right_source_alias.right_source__col_1
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0 sub-query
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM test_schema.test_table test_table_alias
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1 sub-query
+    -- CTE source 1
+    SELECT
+      test_table_alias.col_0 AS cte_source_1__col_0
+      , test_table_alias.col_1 AS cte_source_1__col_1
+    FROM cte_source_0 cte_source_0_alias
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+  GROUP BY
+    top_level__col_0
+    , top_level__col_1

--- a/tests_metricflow/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__after_reducing.sql
+++ b/tests_metricflow/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__after_reducing.sql
@@ -1,7 +1,7 @@
 test_name: test_reducing_join_statement
 test_filename: test_rewriting_sub_query_reducer.py
 docstring:
-  Tests a case where a join query should not reduced an aggregate.
+  Tests a case where a join query should not reduce an aggregate.
 ---
 -- query
 SELECT

--- a/tests_metricflow/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__before_reducing.sql
+++ b/tests_metricflow/snapshots/test_rewriting_sub_query_reducer.py/SqlQueryPlan/test_reducing_join_statement__before_reducing.sql
@@ -1,7 +1,7 @@
 test_name: test_reducing_join_statement
 test_filename: test_rewriting_sub_query_reducer.py
 docstring:
-  Tests a case where a join query should not reduced an aggregate.
+  Tests a case where a join query should not reduce an aggregate.
 ---
 -- query
 SELECT

--- a/tests_metricflow/sql/optimizer/test_cte_rewriting_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_cte_rewriting_sub_query_reducer.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.sql.sql_table import SqlTable
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from metricflow.sql.optimizer.rewriting_sub_query_reducer import SqlRewritingSubQueryReducer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer, SqlQueryPlanRenderer
+from metricflow.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlComparison,
+    SqlComparisonExpression,
+)
+from metricflow.sql.sql_plan import (
+    SqlCteNode,
+    SqlJoinDescription,
+    SqlSelectColumn,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+from tests_metricflow.sql.optimizer.check_optimizer import assert_optimizer_result_snapshot_equal
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def sub_query_reducer() -> SqlRewritingSubQueryReducer:  # noqa: D103
+    return SqlRewritingSubQueryReducer()
+
+
+@pytest.fixture
+def sql_plan_renderer() -> SqlQueryPlanRenderer:  # noqa: D103
+    return DefaultSqlQueryPlanRenderer()
+
+
+@pytest.fixture(scope="module")
+def base_select_statement_to_reduce() -> SqlSelectStatementNode:
+    """A SELECT statement that has sub-queries that can be reduced.
+
+    This renders to the following SQL:
+
+    -- Top-level SELECT
+    WITH cte_source_0 AS (
+      -- CTE source 0
+      SELECT
+        test_table_alias.col_0 AS cte_source_0__col_0
+        , test_table_alias.col_1 AS cte_source_0__col_1
+      FROM (
+        -- CTE source 0 sub-query
+        SELECT
+          test_table_alias.col_0 AS cte_source_0_subquery__col_0
+          , test_table_alias.col_0 AS cte_source_0_subquery__col_1
+        FROM test_schema.test_table test_table_alias
+      ) cte_source_0_subquery
+    )
+
+    , cte_source_1 AS (
+      -- CTE source 1
+      SELECT
+        test_table_alias.col_0 AS cte_source_1__col_0
+        , test_table_alias.col_1 AS cte_source_1__col_1
+      FROM (
+        -- CTE source 1 sub-query
+        SELECT
+          cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_0
+          , cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_1
+        FROM cte_source_0 cte_source_0_alias
+      ) cte_source_1_subquery
+    )
+
+    SELECT
+      cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+      , right_source_alias.right_source__col_1 AS top_level__col_1
+    FROM cte_source_0 cte_source_0_alias
+    INNER JOIN
+      cte_source_1 right_source_alias
+    ON
+      cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+    GROUP BY
+      cte_source_0_alias.cte_source_0__col_0
+      , right_source_alias.right_source__col_1
+    """
+    return SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                ),
+                column_alias="top_level__col_1",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+        from_source_alias="cte_source_0_alias",
+        join_descs=(
+            SqlJoinDescription(
+                right_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_1")),
+                right_source_alias="right_source_alias",
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_1")
+                    ),
+                    comparison=SqlComparison.EQUALS,
+                    right_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                    ),
+                ),
+                join_type=SqlJoinType.INNER,
+            ),
+        ),
+        group_bys=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                ),
+                column_alias="top_level__col_1",
+            ),
+        ),
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_0__col_1",
+                        ),
+                    ),
+                    from_source=SqlSelectStatementNode.create(
+                        description="CTE source 0 sub-query",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                                ),
+                                column_alias="cte_source_0_subquery__col_0",
+                            ),
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                                ),
+                                column_alias="cte_source_0_subquery__col_1",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                        ),
+                        from_source_alias="test_table_alias",
+                    ),
+                    from_source_alias="cte_source_0_subquery",
+                ),
+            ),
+            SqlCteNode.create(
+                cte_alias="cte_source_1",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 1",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_1__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_1__col_1",
+                        ),
+                    ),
+                    from_source=SqlSelectStatementNode.create(
+                        description="CTE source 1 sub-query",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(
+                                        table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                    )
+                                ),
+                                column_alias="cte_source_1_subquery__col_0",
+                            ),
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(
+                                        table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                    )
+                                ),
+                                column_alias="cte_source_1_subquery__col_1",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name=None, table_name="cte_source_0")
+                        ),
+                        from_source_alias="cte_source_0_alias",
+                    ),
+                    from_source_alias="cte_source_1_subquery",
+                ),
+            ),
+        ),
+    )
+
+
+def test_reduce_cte(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sub_query_reducer: SqlRewritingSubQueryReducer,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    base_select_statement_to_reduce: SqlSelectStatementNode,
+) -> None:
+    """Tests that the SELECT statements in CTEs are reduced."""
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=sub_query_reducer,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=base_select_statement_to_reduce,
+    )
+
+
+def test_reduce_cte_with_use_column_alias_in_group_bys(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+    base_select_statement_to_reduce: SqlSelectStatementNode,
+) -> None:
+    """This tests reducing with the `use_column_alias_in_group_bys` flag set."""
+    sub_query_reducer = SqlRewritingSubQueryReducer(use_column_alias_in_group_bys=True)
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=sub_query_reducer,
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=base_select_statement_to_reduce,
+    )

--- a/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
+++ b/tests_metricflow/sql/optimizer/test_rewriting_sub_query_reducer.py
@@ -822,7 +822,7 @@ def test_reducing_join_statement(
     mf_test_configuration: MetricFlowTestConfiguration,
     reducing_join_statement: SqlSelectStatementNode,
 ) -> None:
-    """Tests a case where a join query should not reduced an aggregate."""
+    """Tests a case where a join query should not reduce an aggregate."""
     assert_default_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,


### PR DESCRIPTION
This updates the sub-query reducer to support CTEs. The `SELECT` statement in each CTE is treated like a `SELECT`, and all CTEs are retained. i.e. a CTE is not reduced with another CTE. The CTEs are retained to make mapping to dataflow plan nodes easier in later PRs.