### PR TITLE
Add performance tracking machinery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dmypy.json
 
 # Performance profiler results.
 **/cprofile_output.bin
+
+# Performance reports
+performance-report.json
+performance-comparison.md

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,13 @@ PARALLELISM = auto
 # Additional command line options to pass to pytest.
 ADDITIONAL_PYTEST_OPTIONS =
 
+PERFORMANCE_OUTPUT_FILE = performance-report.json
+PERFORMANCE_COMPARISON_OUTPUT_FILE = performance-comparison.md
+TESTS_PERFORMANCE = tests_metricflow/performance
+
 # Pytest that can populate the persistent source schema
 USE_PERSISTENT_SOURCE_SCHEMA = --use-persistent-source-schema
 TESTS_METRICFLOW = tests_metricflow
-TESTS_PERFORMANCE = tests_metricflow/performance
 TESTS_METRICFLOW_SEMANTICS = tests_metricflow_semantics
 POPULATE_PERSISTENT_SOURCE_SCHEMA = $(TESTS_METRICFLOW)/source_schema_tools.py::populate_source_schema
 
@@ -21,7 +24,11 @@ install-hatch:
 
 .PHONY: perf
 perf:
-	hatch -v run dev-env:pytest -vv -n 1 $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_PERFORMANCE)/
+	hatch -v run dev-env:pytest -vv -n 1 $(ADDITIONAL_PYTEST_OPTIONS) --output-json $(PERFORMANCE_OUTPUT_FILE) $(TESTS_PERFORMANCE)/
+
+.PHONY: perf-compare
+perf-compare:
+	hatch -v run dev-env:python $(TESTS_PERFORMANCE)/compare_reports.py $A $B $(PERFORMANCE_COMPARISON_OUTPUT_FILE)
 
 # Testing and linting
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ADDITIONAL_PYTEST_OPTIONS =
 # Pytest that can populate the persistent source schema
 USE_PERSISTENT_SOURCE_SCHEMA = --use-persistent-source-schema
 TESTS_METRICFLOW = tests_metricflow
+TESTS_PERFORMANCE = tests_metricflow/performance
 TESTS_METRICFLOW_SEMANTICS = tests_metricflow_semantics
 POPULATE_PERSISTENT_SOURCE_SCHEMA = $(TESTS_METRICFLOW)/source_schema_tools.py::populate_source_schema
 
@@ -17,6 +18,10 @@ POPULATE_PERSISTENT_SOURCE_SCHEMA = $(TESTS_METRICFLOW)/source_schema_tools.py::
 .PHONY: install-hatch
 install-hatch:
 	pip3 install hatch
+
+.PHONY: perf
+perf:
+	hatch -v run dev-env:pytest -vv -n 1 $(ADDITIONAL_PYTEST_OPTIONS) $(TESTS_PERFORMANCE)/
 
 # Testing and linting
 .PHONY: test

--- a/metricflow-semantics/metricflow_semantics/test_helpers/performance_helpers.py
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/performance_helpers.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import functools
+import logging
+import statistics
+import sys
+import time
+from collections import defaultdict
+from contextlib import ExitStack, contextmanager
+from typing import Any, Callable, Dict, Iterator, List, Optional, TypeVar
+from unittest.mock import patch as mock_patch
+
+from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
+from typing_extensions import ParamSpec
+
+from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+
+logger = logging.getLogger(__name__)
+
+
+_tracking_class_methods: List[Callable[..., Any]] = [  # type: ignore
+    DataflowPlanBuilder.build_plan,
+    DataflowPlanBuilder.build_plan_for_distinct_values,
+]
+
+
+# TODO: maybe do object pooling and prealloc a bunch of these
+# so we dont pay the allocation tax when tracking perf
+class Call(FrozenBaseModel):
+    """A call to some method."""
+
+    # TODO: use psutil to track memory and CPU
+    # https://github.com/giampaolo/psutil
+    total_cpu_ns: int
+    total_wall_ns: int
+
+
+class ContextReport(FrozenBaseModel):
+    """Contains aggregated runtime statistics about a single performance context."""
+
+    context_id: str
+
+    cpu_ns_average: int
+    cpu_ns_median: int
+    cpu_ns_max: int
+
+    wall_ns_average: int
+    wall_ns_median: int
+    wall_ns_max: int
+
+    @classmethod
+    def from_calls(cls, context_id: str, calls: List[Call]) -> ContextReport:
+        """Init from a list of calls."""
+        return cls(
+            context_id=context_id,
+            cpu_ns_average=int(statistics.mean(c.total_cpu_ns for c in calls)),
+            cpu_ns_median=int(statistics.median(c.total_cpu_ns for c in calls)),
+            cpu_ns_max=int(max(c.total_cpu_ns for c in calls)),
+            wall_ns_average=int(statistics.mean(c.total_wall_ns for c in calls)),
+            wall_ns_median=int(statistics.median(c.total_wall_ns for c in calls)),
+            wall_ns_max=int(max(c.total_wall_ns for c in calls)),
+        )
+
+
+class SessionReport(FrozenBaseModel):
+    """A performance report containing aggregated runtime statistics from a session."""
+
+    session_id: str
+    contexts: Dict[str, ContextReport]
+
+
+class SessionReportSet(FrozenBaseModel):
+    """A set of session reports."""
+
+    sessions: Dict[str, SessionReport] = {}
+
+    def add_report(self, report: SessionReport) -> None:
+        """Add a report and associate it with the session ID."""
+        self.sessions[report.session_id] = report
+
+
+class PerformanceTracker:
+    """Track performance metrics across different contexts.
+
+    Don't use this directly. Instead, use the global methods in this method which interact
+    with the _perf singleton.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the tracker."""
+        self._session_id: Optional[str] = None
+        self._call_map: Dict[str, List[Call]] = defaultdict(list)
+
+        self._session_set = SessionReportSet()
+
+    @contextmanager
+    def session(self, session_id: str) -> Iterator[None]:
+        """Create a new measurement session.
+
+        At session start, all state is fresh and it gets cleaned when the session ends.
+        """
+        if self._session_id:
+            raise ValueError("Cannot create nested sessions.")
+
+        self._session_id = session_id
+
+        yield
+
+        report = self.get_session_report()
+        self._session_set.add_report(report)
+
+        self._call_map = defaultdict(list)
+        self._session_id = None
+
+    @contextmanager
+    def measure(self, context_id: str) -> Iterator[PerformanceTracker]:
+        """Measure performance while executing this block."""
+        if not self._session_id:
+            raise ValueError("Cannot measure outside of a session.")
+
+        start_wall = time.time_ns()
+        start_cpu = time.process_time_ns()
+
+        yield self
+
+        end_wall = time.time_ns()
+        end_cpu = time.process_time_ns()
+
+        self._call_map[context_id].append(
+            Call(
+                total_wall_ns=(end_wall - start_wall),
+                total_cpu_ns=(end_cpu - start_cpu),
+            )
+        )
+
+    def get_session_report(self) -> SessionReport:
+        """Generate a report based on all the tracked calls in the current session."""
+        if not self._session_id:
+            raise ValueError("Cannot create report outside of a session.")
+
+        return SessionReport(
+            session_id=self._session_id,
+            contexts={
+                context_id: ContextReport.from_calls(context_id, calls) for context_id, calls in self._call_map.items()
+            },
+        )
+
+    def get_report_set(self) -> SessionReportSet:
+        """Get the performance report set for all opened sessions so far."""
+        return self._session_set
+
+
+TRet = TypeVar("TRet")
+TParam = ParamSpec("TParam")
+
+
+@contextmanager
+def _track_performance_single(target: Callable[TParam, TRet], perf: PerformanceTracker) -> Iterator[None]:
+    """Enable tracking for a single target.
+
+    This method patches all instances where it is imported.
+    """
+
+    @functools.wraps(target)
+    def wrap_tracking(*args: TParam.args, **kwargs: TParam.kwargs) -> TRet:
+        with perf.measure(target.__qualname__):
+            return target(*args, **kwargs)
+
+    mod_name = target.__module__
+    class_name, method_name = target.__qualname__.split(".")
+    mod = sys.modules[mod_name]
+    klass = getattr(mod, class_name)
+    full_name = f"{mod_name}.{target.__qualname__}"
+
+    patchers = []
+
+    # patch the module itself for future imports
+    patchers.append(mock_patch(full_name, new=wrap_tracking))
+
+    # patch all current references to the method
+    for module in sys.modules.values():
+        # no need to patch sys modules, third party libraries etc
+        if not module.__name__.startswith("metricflow"):
+            continue
+
+        for module_target_name, module_target in module.__dict__.items():
+            if module_target is klass:
+                module_target_full_name = f"{module.__name__}.{module_target_name}.{method_name}"
+                patchers.append(mock_patch(module_target_full_name, new=wrap_tracking))
+
+    for patcher in patchers:
+        patcher.start()
+
+    yield
+
+    for patcher in patchers:
+        patcher.stop()
+
+
+@contextmanager
+def track_performance() -> Iterator[PerformanceTracker]:
+    """Enable performance tracking while in this context manager."""
+    global _tracking_class_methods
+
+    logger.info("Enabling performance tracking")
+    perf = PerformanceTracker()
+
+    with ExitStack() as stack:
+        for target in _tracking_class_methods:
+            stack.enter_context(_track_performance_single(target, perf))
+
+        yield perf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,3 +179,4 @@ filterwarnings = [
   'ignore:.*Type google.*:DeprecationWarning',
 ]
 python_functions = "test_* populate_source_schema"
+addopts = "--ignore tests_metricflow/performance/"

--- a/tests_metricflow/performance/compare_reports.py
+++ b/tests_metricflow/performance/compare_reports.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import json
+from io import StringIO
+
+from metricflow_semantics.test_helpers.performance_helpers import (
+    SessionReportSet,
+    SessionReportSetComparison,
+)
+
+MAX_PCT_CHANGE_WARNING_THRESHOLD = 0.15
+
+
+def _load_report_file(filename: str) -> SessionReportSet:
+    with open(filename, "r") as f:
+        raw = f.read()
+    return SessionReportSet.parse_obj(json.loads(raw))
+
+
+# I hate this code but there's no real elegant way of creating a markdown file
+def _report_comparison_markdown(base_name: str, other_name: str, comp: SessionReportSetComparison) -> str:
+    buf = StringIO()
+
+    buf.write("# Performance comparison\n")
+    buf.write(f"Comparing `{base_name}` against `{other_name}`\n\n")
+    buf.write(f"**Worst performance hit:** {comp.max_pct_change * 100:.2f}% in `{comp.max_pct_change_session}`\n\n")
+
+    for session, session_comp in comp.sessions.items():
+        emoji = (
+            ":question:"
+            if session_comp is None
+            else (":bangbang:" if session_comp.max_pct_change > MAX_PCT_CHANGE_WARNING_THRESHOLD else ":rocket:")
+        )
+
+        buf.write(f"## `{session}` {emoji}\n\n")
+        if session_comp is None:
+            buf.write("Comparison not available since there's no data for this session in one of the reports.\n\n")
+            continue
+
+        buf.write("| context | CPU avg | CPU median | CPU max | Wall avg | Wall median | Wall max |\n")
+        buf.write("| ------- | ------- | ---------- | ------- | -------- | ----------- | -------- |\n")
+        for ctx, ctx_comp in session_comp.contexts.items():
+            buf.write(f"| `{ctx}` ")
+
+            if ctx_comp is None:
+                buf.write(" | n/a" * 6)
+            else:
+                buf.write("| ")
+                buf.write(
+                    " | ".join(
+                        f"{int(abs)/10e6:.4f}ms ({pct * 100:+.2f}%)"
+                        for abs, pct in (
+                            (ctx_comp.cpu_ns_average_abs, ctx_comp.cpu_ns_average_pct),
+                            (ctx_comp.cpu_ns_median_abs, ctx_comp.cpu_ns_median_pct),
+                            (ctx_comp.cpu_ns_max_abs, ctx_comp.cpu_ns_max_pct),
+                            (ctx_comp.wall_ns_average_abs, ctx_comp.wall_ns_average_pct),
+                            (ctx_comp.wall_ns_median_abs, ctx_comp.wall_ns_median_pct),
+                            (ctx_comp.wall_ns_max_abs, ctx_comp.wall_ns_max_pct),
+                        )
+                    )
+                )
+
+            buf.write(" |\n")
+        buf.write("\n\n")
+
+    return buf.getvalue()
+
+
+def main() -> None:  # noqa: D103
+    parser = argparse.ArgumentParser()
+    parser.add_argument("a", help="The base report for the comparison")
+    parser.add_argument("b", help="The other report for the comparison")
+    parser.add_argument("output", help="The output file for the comparison")
+
+    args = parser.parse_args()
+
+    a = _load_report_file(args.a)
+    b = _load_report_file(args.b)
+
+    comparison = a.compare(b)
+    md = _report_comparison_markdown(
+        base_name=args.a,
+        other_name=args.b,
+        comp=comparison,
+    )
+    with open(args.output, "w") as f:
+        f.write(md)
+
+    print(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_metricflow/performance/compare_reports.py
+++ b/tests_metricflow/performance/compare_reports.py
@@ -5,11 +5,29 @@ import json
 from io import StringIO
 
 from metricflow_semantics.test_helpers.performance_helpers import (
+    PerformanceMetricComparison,
     SessionReportSet,
     SessionReportSetComparison,
 )
 
-MAX_PCT_CHANGE_WARNING_THRESHOLD = 0.15
+REPORT_TOP = 10
+
+NEGLIGIBLE_DELTA = 10e-7
+
+WARNING_PERCENT_THRESHOLD = 0.1
+
+LEGEND_HEADER = f"""
+## Legend
+- **Function**: the function name
+- **Base calls**: number of calls, excluding recursion
+- **Total calls**: number of calls, including recursion
+- **Body time**: time spent on the function body, excluding sub-function calls
+- **Total time**: time spent on the function body and in other sub-functions it calls
+
+`n.d.` means "negligible difference", i.e the difference between measured outputs is negligible, and any differences could be down to imprecision, so the reported value is only the absolute measured value
+
+Warnings ( :warning: ) will be emitted whenever there is more than {WARNING_PERCENT_THRESHOLD*100:.0f}% increase in total runtime of a test.
+""".strip()
 
 
 def _load_report_file(filename: str) -> SessionReportSet:
@@ -18,53 +36,99 @@ def _load_report_file(filename: str) -> SessionReportSet:
     return SessionReportSet.parse_obj(json.loads(raw))
 
 
+def _is_negligible(val: int | float) -> bool:
+    return abs(val) < NEGLIGIBLE_DELTA
+
+
+def _format_num(num: int | float) -> str:
+    return f"{num:+.3f}" if isinstance(num, float) else str(num)
+
+
+def _format_comp(comp: PerformanceMetricComparison[int] | PerformanceMetricComparison[float], unit: str = "") -> str:
+    """Return a float percent value as (val_as_percent%)."""
+    a_fmt = _format_num(comp.a)
+    b_fmt = _format_num(comp.b)
+    abs_fmt = _format_num(comp.abs)
+
+    if _is_negligible(comp.abs):
+        return f"{a_fmt}{unit} (n.d.)"
+
+    return f"{a_fmt}{unit} - {b_fmt}{unit} = {abs_fmt}{unit} ({comp.pct * 100:+.3f}%)"
+
+
 # I hate this code but there's no real elegant way of creating a markdown file
-def _report_comparison_markdown(base_name: str, other_name: str, comp: SessionReportSetComparison) -> str:
+def _report_comparison_markdown(
+    base_name: str, other_name: str, comp: SessionReportSetComparison, report_top: int
+) -> str:
     buf = StringIO()
 
     buf.write("# Performance comparison\n")
     buf.write(f"Comparing `{base_name}` against `{other_name}`\n\n")
-    buf.write(f"**Worst performance hit:** {comp.max_pct_change * 100:.2f}% in `{comp.max_pct_change_session}`\n\n")
+    buf.write(
+        f"Reporting top {report_top} highest non-negligible absolute total time differences for each session.\n\n"
+    )
+
+    buf.write(LEGEND_HEADER + "\n\n")
+    buf.write("-------------\n\n")
 
     for session, session_comp in comp.sessions.items():
-        emoji = (
-            ":question:"
-            if session_comp is None
-            else (":bangbang:" if session_comp.max_pct_change > MAX_PCT_CHANGE_WARNING_THRESHOLD else ":rocket:")
+        warn_str = (
+            " :warning: :warning:"
+            if session_comp is not None and session_comp.total_time.pct > WARNING_PERCENT_THRESHOLD
+            else ""
         )
 
-        buf.write(f"## `{session}` {emoji}\n\n")
+        buf.write(f"### `{session}`{warn_str}\n\n")
         if session_comp is None:
             buf.write("Comparison not available since there's no data for this session in one of the reports.\n\n")
             continue
 
-        buf.write("| context | CPU avg | CPU median | CPU max | Wall avg | Wall median | Wall max |\n")
-        buf.write("| ------- | ------- | ---------- | ------- | -------- | ----------- | -------- |\n")
-        for ctx, ctx_comp in session_comp.contexts.items():
-            buf.write(f"| `{ctx}` ")
+        total_time_fmt = _format_comp(session_comp.total_time, "s")
+        buf.write(f"**Total time:** {total_time_fmt}\n\n")
 
-            if ctx_comp is None:
+        buf.write(
+            "| i | Function | Base calls | Total calls | Body time (cumulative) | Body time (per call) | Total time (cumulative) | Total time (per call) |\n"
+        )
+        buf.write(
+            "| - | -------- | ---------- | ----------- | ---------------------- | -------------------- | ----------------------- | --------------------- |\n"
+        )
+
+        top_functions = sorted(
+            (
+                (func_name, abs(func_comp.total_time.abs))
+                for func_name, func_comp in session_comp.functions.items()
+                if func_comp is not None and not _is_negligible(func_comp.total_time.abs)
+            ),
+            key=lambda tup: tup[1],
+            reverse=True,
+        )
+
+        for i, (func_name, _) in enumerate(top_functions[0:report_top]):
+            buf.write(f"| #{i+1} | `{func_name}` ")
+
+            func_comp = session_comp.functions[func_name]
+
+            if func_comp is None:
                 buf.write(" | n/a" * 6)
             else:
                 buf.write("| ")
                 buf.write(
                     " | ".join(
-                        f"{int(abs)/10e6:.4f}ms ({pct * 100:+.2f}%)"
-                        for abs, pct in (
-                            (ctx_comp.cpu_ns_average_abs, ctx_comp.cpu_ns_average_pct),
-                            (ctx_comp.cpu_ns_median_abs, ctx_comp.cpu_ns_median_pct),
-                            (ctx_comp.cpu_ns_max_abs, ctx_comp.cpu_ns_max_pct),
-                            (ctx_comp.wall_ns_average_abs, ctx_comp.wall_ns_average_pct),
-                            (ctx_comp.wall_ns_median_abs, ctx_comp.wall_ns_median_pct),
-                            (ctx_comp.wall_ns_max_abs, ctx_comp.wall_ns_max_pct),
-                        )
+                        [
+                            _format_comp(func_comp.base_calls),
+                            _format_comp(func_comp.total_calls),
+                            _format_comp(func_comp.body_time, "s"),
+                            _format_comp(func_comp.per_call_body_time, "s"),
+                            _format_comp(func_comp.total_time, "s"),
+                            _format_comp(func_comp.per_call_total_time, "s"),
+                        ]
                     )
                 )
 
             buf.write(" |\n")
         buf.write("\n\n")
 
-    return buf.getvalue()
+    return buf.getvalue().strip()
 
 
 def main() -> None:  # noqa: D103
@@ -72,6 +136,9 @@ def main() -> None:  # noqa: D103
     parser.add_argument("a", help="The base report for the comparison")
     parser.add_argument("b", help="The other report for the comparison")
     parser.add_argument("output", help="The output file for the comparison")
+    parser.add_argument(
+        "--top", type=int, default=REPORT_TOP, help="Number of functions to report, sorted by percent difference"
+    )
 
     args = parser.parse_args()
 
@@ -83,6 +150,7 @@ def main() -> None:  # noqa: D103
         base_name=args.a,
         other_name=args.b,
         comp=comparison,
+        report_top=args.top,
     )
     with open(args.output, "w") as f:
         f.write(md)

--- a/tests_metricflow/performance/conftest.py
+++ b/tests_metricflow/performance/conftest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Iterator, Protocol
+
+import pytest
+from metricflow_semantics.dag.mf_dag import DagId
+from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
+from metricflow_semantics.test_helpers.config_helpers import DirectoryPathAnchor
+from metricflow_semantics.test_helpers.performance_helpers import (
+    PerformanceTracker,
+    SessionReport,
+    track_performance,
+)
+
+from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.dataflow.optimizer.dataflow_optimizer_factory import DataflowPlanOptimization
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.protocols.sql_client import SqlClient
+from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
+
+ANCHOR = DirectoryPathAnchor()
+
+GLOBAL_TRACKING_CONTEXT = "global"
+
+
+@pytest.fixture(scope="session")
+def perf_tracker() -> PerformanceTracker:
+    """Instrument MetricFlow with performance tracking utilities."""
+    with track_performance() as perf:
+        return perf
+
+
+class MeasureFixture(Protocol):  # noqa: D101
+    def __call__(  # noqa: D102
+        self,
+        dataflow_plan_builder: DataflowPlanBuilder,
+        dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+        sql_client: SqlClient,
+        query_spec: MetricFlowQuerySpec,
+    ) -> SessionReport:
+        ...
+
+
+@pytest.fixture(scope="session")
+def measure_compilation_performance(perf_tracker: PerformanceTracker) -> Iterator[MeasureFixture]:
+    """Fixture that returns a function which measures compilation performance for a given query."""
+
+    def _measure(
+        dataflow_plan_builder: DataflowPlanBuilder,
+        dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+        sql_client: SqlClient,
+        query_spec: MetricFlowQuerySpec,
+    ) -> SessionReport:
+        caller = inspect.stack()[1]
+        caller_filename = Path(caller.filename).relative_to(ANCHOR.directory)
+        session_id = f"{caller_filename}::{caller.function}"
+
+        with perf_tracker.session(session_id):
+            with perf_tracker.measure(GLOBAL_TRACKING_CONTEXT):
+                is_distinct_values_plan = not query_spec.metric_specs
+                if is_distinct_values_plan:
+                    optimized_plan = dataflow_plan_builder.build_plan_for_distinct_values(
+                        query_spec, optimizations=DataflowPlanOptimization.enabled_optimizations()
+                    )
+                else:
+                    optimized_plan = dataflow_plan_builder.build_plan(
+                        query_spec, optimizations=DataflowPlanOptimization.enabled_optimizations()
+                    )
+                _ = dataflow_to_sql_converter.convert_to_sql_query_plan(
+                    sql_engine_type=sql_client.sql_engine_type,
+                    dataflow_plan_node=optimized_plan.sink_node,
+                    optimization_level=SqlQueryOptimizationLevel.O4,
+                    sql_query_plan_id=DagId.from_str("plan0_optimized"),
+                )
+
+            report = perf_tracker.get_session_report()
+
+        return report
+
+    yield _measure
+
+    report_set = perf_tracker.get_report_set()
+
+    print(report_set.to_pretty_json())

--- a/tests_metricflow/performance/test_simple_manifest.py
+++ b/tests_metricflow/performance/test_simple_manifest.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dbt_semantic_interfaces.references import EntityReference
+from metricflow_semantics.specs.dimension_spec import DimensionSpec
+from metricflow_semantics.specs.metric_spec import MetricSpec
+from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.protocols.sql_client import SqlClient
+from tests_metricflow.performance.conftest import MeasureFixture
+
+
+def test_simple_query(
+    measure_compilation_performance: MeasureFixture,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+) -> None:
+    """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="identity_verifications"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="home_state",
+                entity_links=(EntityReference(element_name="user"),),
+            ),
+        ),
+    )
+
+    measure_compilation_performance(
+        query_spec=query_spec,
+        dataflow_plan_builder=dataflow_plan_builder,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+    )
+    assert False
+
+
+def test_simple_query_2(
+    measure_compilation_performance: MeasureFixture,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    sql_client: SqlClient,
+) -> None:
+    """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
+    query_spec = MetricFlowQuerySpec(
+        metric_specs=(MetricSpec(element_name="identity_verifications"),),
+        dimension_specs=(
+            DimensionSpec(
+                element_name="home_state",
+                entity_links=(EntityReference(element_name="user"),),
+            ),
+        ),
+    )
+
+    measure_compilation_performance(
+        query_spec=query_spec,
+        dataflow_plan_builder=dataflow_plan_builder,
+        dataflow_to_sql_converter=dataflow_to_sql_converter,
+        sql_client=sql_client,
+    )
+    assert False

--- a/tests_metricflow/performance/test_simple_manifest.py
+++ b/tests_metricflow/performance/test_simple_manifest.py
@@ -36,7 +36,6 @@ def test_simple_query(
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
     )
-    assert False
 
 
 def test_simple_query_2(
@@ -63,4 +62,3 @@ def test_simple_query_2(
         dataflow_to_sql_converter=dataflow_to_sql_converter,
         sql_client=sql_client,
     )
-    assert False

--- a/tests_metricflow/performance/test_simple_manifest.py
+++ b/tests_metricflow/performance/test_simple_manifest.py
@@ -7,7 +7,7 @@ from metricflow_semantics.specs.query_spec import MetricFlowQuerySpec
 from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
 
 from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
-from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
+from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlPlanConverter
 from metricflow.protocols.sql_client import SqlClient
 from tests_metricflow.performance.conftest import MeasureFixture
 
@@ -16,7 +16,7 @@ def test_simple_query(
     measure_compilation_performance: MeasureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""
@@ -42,7 +42,7 @@ def test_simple_query_2(
     measure_compilation_performance: MeasureFixture,
     mf_test_configuration: MetricFlowTestConfiguration,
     dataflow_plan_builder: DataflowPlanBuilder,
-    dataflow_to_sql_converter: DataflowToSqlQueryPlanConverter,
+    dataflow_to_sql_converter: DataflowToSqlPlanConverter,
     sql_client: SqlClient,
 ) -> None:
     """Tests converting a dataflow plan to a SQL query plan where there is a join between 1 measure and 2 dimensions."""


### PR DESCRIPTION
NOTE: I had to significantly refactor the original version of this PR to make it use cProfile, so I changed the description and comments to match.

## Summary

This PR introduces some new testing functionality that we can use to avoid performance regressions. From a user perspective, the performance benchmarking workflow is:
1. Create a new test in `tests_metricflow/performance/` that does something we want to track performance for. You can use `measure_compilation_performance` fixtures to measure the compilation of some SQL based on a query spec and a manifest.
3. Run `make perf` to generate a `performance-report.json`.
4. Run `make perf-compare A=base-report.json B=other-report.json` to generate a Markdown file with a report on changes.

## The performance report

The `performance-report.json` file contains the "raw" data for a given run. It looks like this:
```json
{
    "sessions": {
        "test_simple_manifest.py::test_simple_query": {
            "session_id": "test_simple_manifest.py::test_simple_query",
            "total_time": 0.04,
            "functions": {
                "source_scan_optimizer.py:115 :: __init__": {
                    "function_name": "source_scan_optimizer.py:115 :: __init__",
                    "base_calls": 1,
                    "total_calls":1,
                    "body_time": 0.01,
                    "per_call_body_time": 0.01,
                    "total_time": 0.03,
                    "per_call_total_time": 0.03
                },
                ...
            }
        },
        ...
    }
 }
```

Each "report" contains a list of "sessions". A session is a run where multiple measurements have been taken, i.e a pytest test. Each session contains a variety of "functions", which contain runtime statistics about each one of them.


## Report comparison

I created a script called `compare_reports.py` which takes in two different reports files and calculates the difference between them (in absolute values and also percent). It then generates a markdown file called `performance-comparison.md` with a nice little table like the one on my first comment.

I added a `time.sleep(1)` to `build_plan()` so that I could get a non-negligible result on the first comment.


## How it works

When you run `make perf`, the `measure_compilation_performance` fixture instantiates a `PerformanceTracker` and yields a `_measure()` function that will compile a query while running cProfile.

The tests then all run, and at the end of it all the fixture compiles all reports by calling `perf_tracker.report_set`. This will return all the gathered `SessionReport`s. These reports contain _all_ the data from _all_ functions.

After this, it writes the report to the JSON file.

Then, when you run `make perf-compare` the script loads both the JSON files and uses the `compare()` methods in each of the report classes. These will generate `Comparison` classes with the percent and absolute differences. The script then renders these classes to markdown and writes it to a file. This script filters the comparisons to only show the top 10 most relevant comparisons, if their total runtime difference non-negligible (i.e the percent difference is higher than `10e-7`). If any total runtime has increased by over 10%, it will add warnings ( :warning: ) to the file.

## Next steps
Make a Github Actions bot that runs this on PRs to compare performance against `main`, and comments PRs with the generated markdown.