### PR TITLE
Align dataflow plans

### DIFF
--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_dimensions_with_time_constraint__dfp_0.xml
@@ -4,7 +4,7 @@
         <!-- node_id = NodeId(id_str='wrd_0') -->
         <FilterElementsNode>
             <!-- description = "Pass Only Elements: ['listing__is_lux_latest', 'metric_time__month']" -->
-            <!-- node_id = NodeId(id_str='pfe_2') -->
+            <!-- node_id = NodeId(id_str='pfe_1') -->
             <!-- include_spec =                                                                                         -->
             <!--   DimensionSpec(element_name='is_lux_latest', entity_links=(EntityReference(element_name='listing'),)) -->
             <!-- include_spec =                                                                      -->
@@ -21,8 +21,8 @@
                 <JoinOnEntitiesNode>
                     <!-- description = 'Join Standard Outputs' -->
                     <!-- node_id = NodeId(id_str='jso_0') -->
-                    <!-- join0_for_node_id_pfe_1 =                                                            -->
-                    <!--   JoinDescription(join_node=FilterElementsNode(node_id=pfe_1), join_type=CROSS_JOIN) -->
+                    <!-- join0_for_node_id_pfe_0 =                                                            -->
+                    <!--   JoinDescription(join_node=FilterElementsNode(node_id=pfe_0), join_type=CROSS_JOIN) -->
                     <ReadSqlSourceNode>
                         <!-- description = "Read From SemanticModelDataSet('listings_latest')" -->
                         <!-- node_id = NodeId(id_str='rss_28024') -->
@@ -30,7 +30,7 @@
                     </ReadSqlSourceNode>
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['metric_time__month',]" -->
-                        <!-- node_id = NodeId(id_str='pfe_1') -->
+                        <!-- node_id = NodeId(id_str='pfe_0') -->
                         <!-- include_spec =                                                                      -->
                         <!--   TimeDimensionSpec(                                                                -->
                         <!--     element_name='metric_time',                                                     -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_distinct_values_plan_with_join__dfp_0.xml
@@ -16,7 +16,7 @@
             <!-- limit = '100' -->
             <FilterElementsNode>
                 <!-- description = "Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest']" -->
-                <!-- node_id = NodeId(id_str='pfe_2') -->
+                <!-- node_id = NodeId(id_str='pfe_1') -->
                 <!-- include_spec =                                            -->
                 <!--   DimensionSpec(                                          -->
                 <!--     element_name='home_state_latest',                     -->
@@ -73,9 +73,9 @@
                     <JoinOnEntitiesNode>
                         <!-- description = 'Join Standard Outputs' -->
                         <!-- node_id = NodeId(id_str='jso_0') -->
-                        <!-- join0_for_node_id_pfe_1 =                                   -->
+                        <!-- join0_for_node_id_pfe_0 =                                   -->
                         <!--   JoinDescription(                                          -->
-                        <!--     join_node=FilterElementsNode(node_id=pfe_1),            -->
+                        <!--     join_node=FilterElementsNode(node_id=pfe_0),            -->
                         <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
                         <!--     join_type=FULL_OUTER,                                   -->
                         <!--   )                                                         -->
@@ -86,7 +86,7 @@
                         </ReadSqlSourceNode>
                         <FilterElementsNode>
                             <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                            <!-- node_id = NodeId(id_str='pfe_1') -->
+                            <!-- node_id = NodeId(id_str='pfe_0') -->
                             <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
                             <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                             <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_metric_time_with_other_dimensions__dfp_0.xml
@@ -6,7 +6,7 @@
             <!-- description =                                                                                       -->
             <!--   ("Pass Only Elements: ['user__home_state_latest', 'listing__is_lux_latest', 'metric_time__day', " -->
             <!--    "'metric_time__month']")                                                                         -->
-            <!-- node_id = NodeId(id_str='pfe_4') -->
+            <!-- node_id = NodeId(id_str='pfe_2') -->
             <!-- include_spec =                                                                                          -->
             <!--   DimensionSpec(element_name='home_state_latest', entity_links=(EntityReference(element_name='user'),)) -->
             <!-- include_spec =                                                                                         -->
@@ -25,11 +25,11 @@
             <JoinOnEntitiesNode>
                 <!-- description = 'Join Standard Outputs' -->
                 <!-- node_id = NodeId(id_str='jso_0') -->
-                <!-- join0_for_node_id_pfe_2 =                                                            -->
-                <!--   JoinDescription(join_node=FilterElementsNode(node_id=pfe_2), join_type=CROSS_JOIN) -->
-                <!-- join1_for_node_id_pfe_3 =                                   -->
+                <!-- join0_for_node_id_pfe_0 =                                                            -->
+                <!--   JoinDescription(join_node=FilterElementsNode(node_id=pfe_0), join_type=CROSS_JOIN) -->
+                <!-- join1_for_node_id_pfe_1 =                                   -->
                 <!--   JoinDescription(                                          -->
-                <!--     join_node=FilterElementsNode(node_id=pfe_3),            -->
+                <!--     join_node=FilterElementsNode(node_id=pfe_1),            -->
                 <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
                 <!--     join_type=FULL_OUTER,                                   -->
                 <!--   )                                                         -->
@@ -40,7 +40,7 @@
                 </ReadSqlSourceNode>
                 <FilterElementsNode>
                     <!-- description = "Pass Only Elements: ['metric_time__day', 'metric_time__month']" -->
-                    <!-- node_id = NodeId(id_str='pfe_2') -->
+                    <!-- node_id = NodeId(id_str='pfe_0') -->
                     <!-- include_spec =                                                                  -->
                     <!--   TimeDimensionSpec(                                                            -->
                     <!--     element_name='metric_time',                                                 -->
@@ -65,7 +65,7 @@
                 </FilterElementsNode>
                 <FilterElementsNode>
                     <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                    <!-- node_id = NodeId(id_str='pfe_3') -->
+                    <!-- node_id = NodeId(id_str='pfe_1') -->
                     <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
                     <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                     <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -157,7 +157,7 @@
                     <!-- node_id = NodeId(id_str='am_1') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_5') -->
+                        <!-- node_id = NodeId(id_str='pfe_4') -->
                         <!-- include_spec = MeasureSpec(element_name='buys') -->
                         <!-- include_spec =                                            -->
                         <!--   DimensionSpec(                                          -->
@@ -190,7 +190,7 @@
                                 <!-- description =                                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', " -->
                                 <!--    "'metric_time__day', 'user']")                                                     -->
-                                <!-- node_id = NodeId(id_str='pfe_4') -->
+                                <!-- node_id = NodeId(id_str='pfe_3') -->
                                 <!-- include_spec = MeasureSpec(element_name='visits') -->
                                 <!-- include_spec =                                             -->
                                 <!--   DimensionSpec(                                           -->
@@ -254,9 +254,9 @@
                                     <JoinOnEntitiesNode>
                                         <!-- description = 'Join Standard Outputs' -->
                                         <!-- node_id = NodeId(id_str='jso_1') -->
-                                        <!-- join0_for_node_id_pfe_3 =                                   -->
+                                        <!-- join0_for_node_id_pfe_2 =                                   -->
                                         <!--   JoinDescription(                                          -->
-                                        <!--     join_node=FilterElementsNode(node_id=pfe_3),            -->
+                                        <!--     join_node=FilterElementsNode(node_id=pfe_2),            -->
                                         <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
                                         <!--     join_type=LEFT_OUTER,                                   -->
                                         <!--   )                                                         -->
@@ -272,7 +272,7 @@
                                         </MetricTimeDimensionTransformNode>
                                         <FilterElementsNode>
                                             <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                                            <!-- node_id = NodeId(id_str='pfe_3') -->
+                                            <!-- node_id = NodeId(id_str='pfe_2') -->
                                             <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
                                             <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                             <!-- distinct = False -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -62,7 +62,7 @@
                     <FilterElementsNode>
                         <!-- description =                                                                     -->
                         <!--   "Pass Only Elements: ['visits', 'user__home_state_latest', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_7') -->
+                        <!-- node_id = NodeId(id_str='pfe_6') -->
                         <!-- include_spec = MeasureSpec(element_name='visits') -->
                         <!-- include_spec =                                            -->
                         <!--   DimensionSpec(                                          -->
@@ -78,9 +78,9 @@
                         <JoinOnEntitiesNode>
                             <!-- description = 'Join Standard Outputs' -->
                             <!-- node_id = NodeId(id_str='jso_2') -->
-                            <!-- join0_for_node_id_pfe_6 =                                   -->
+                            <!-- join0_for_node_id_pfe_5 =                                   -->
                             <!--   JoinDescription(                                          -->
-                            <!--     join_node=FilterElementsNode(node_id=pfe_6),            -->
+                            <!--     join_node=FilterElementsNode(node_id=pfe_5),            -->
                             <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
                             <!--     join_type=LEFT_OUTER,                                   -->
                             <!--   )                                                         -->
@@ -139,7 +139,7 @@
                             </WhereConstraintNode>
                             <FilterElementsNode>
                                 <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                                <!-- node_id = NodeId(id_str='pfe_6') -->
+                                <!-- node_id = NodeId(id_str='pfe_5') -->
                                 <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
                                 <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                 <!-- distinct = False -->
@@ -157,7 +157,7 @@
                     <!-- node_id = NodeId(id_str='am_3') -->
                     <FilterElementsNode>
                         <!-- description = "Pass Only Elements: ['buys', 'user__home_state_latest', 'metric_time__day']" -->
-                        <!-- node_id = NodeId(id_str='pfe_10') -->
+                        <!-- node_id = NodeId(id_str='pfe_9') -->
                         <!-- include_spec = MeasureSpec(element_name='buys') -->
                         <!-- include_spec =                                            -->
                         <!--   DimensionSpec(                                          -->
@@ -190,7 +190,7 @@
                                 <!-- description =                                                                         -->
                                 <!--   ("Pass Only Elements: ['visits', 'visit__referrer_id', 'user__home_state_latest', " -->
                                 <!--    "'metric_time__day', 'user']")                                                     -->
-                                <!-- node_id = NodeId(id_str='pfe_9') -->
+                                <!-- node_id = NodeId(id_str='pfe_8') -->
                                 <!-- include_spec = MeasureSpec(element_name='visits') -->
                                 <!-- include_spec =                                             -->
                                 <!--   DimensionSpec(                                           -->
@@ -212,9 +212,9 @@
                                 <JoinOnEntitiesNode>
                                     <!-- description = 'Join Standard Outputs' -->
                                     <!-- node_id = NodeId(id_str='jso_3') -->
-                                    <!-- join0_for_node_id_pfe_8 =                                   -->
+                                    <!-- join0_for_node_id_pfe_7 =                                   -->
                                     <!--   JoinDescription(                                          -->
-                                    <!--     join_node=FilterElementsNode(node_id=pfe_8),            -->
+                                    <!--     join_node=FilterElementsNode(node_id=pfe_7),            -->
                                     <!--     join_on_entity=LinklessEntitySpec(element_name='user'), -->
                                     <!--     join_type=LEFT_OUTER,                                   -->
                                     <!--   )                                                         -->
@@ -273,7 +273,7 @@
                                     </WhereConstraintNode>
                                     <FilterElementsNode>
                                         <!-- description = "Pass Only Elements: ['home_state_latest', 'user']" -->
-                                        <!-- node_id = NodeId(id_str='pfe_8') -->
+                                        <!-- node_id = NodeId(id_str='pfe_7') -->
                                         <!-- include_spec = DimensionSpec(element_name='home_state_latest') -->
                                         <!-- include_spec = LinklessEntitySpec(element_name='user') -->
                                         <!-- distinct = False -->


### PR DESCRIPTION
Dedupe logic in the `DataflowPlanBuilder`. Diverging paths in the dataflow plan have frequently been a source of bugs. To reduce similar future bugs, this PR unifies some of the logic across all paths. There are several steps we always take after source node generation and before aggregation. This PR moves all that logic into a helper function to ensure we always use the same logic.