### PR TITLE
Update `SqlTableAliasSimplifier` to handle CTEs

### DIFF
--- a/metricflow/sql/optimizer/table_alias_simplifier.py
+++ b/metricflow/sql/optimizer/table_alias_simplifier.py
@@ -29,7 +29,7 @@ class SqlTableAliasSimplifierVisitor(SqlQueryPlanNodeVisitor[SqlQueryPlanNode]):
         return node.with_new_select(node.select_statement.accept(self))
 
     def visit_select_statement_node(self, node: SqlSelectStatementNode) -> SqlQueryPlanNode:  # noqa: D102
-        # If there is only a single parent, no table aliases are required since there's no ambiguity.
+        # If there is only a single source in the SELECT, no table aliases are required since there's no ambiguity.
         should_simplify_table_aliases = len(node.join_descs) == 0
 
         if should_simplify_table_aliases:

--- a/tests_metricflow/snapshots/test_cte_table_alias_simplifier.py/str/test_table_alias_no_simplification__result.txt
+++ b/tests_metricflow/snapshots/test_cte_table_alias_simplifier.py/str/test_table_alias_no_simplification__result.txt
@@ -1,0 +1,41 @@
+test_name: test_table_alias_no_simplification
+test_filename: test_cte_table_alias_simplifier.py
+docstring:
+  Tests that table aliases in the SELECT statement of a CTE are not removed when required.
+---
+optimizer:
+  SqlTableAliasSimplifier
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      from_source_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table_0 from_source_alias
+    INNER JOIN
+      test_schema.test_table_1 right_source_alias
+    ON
+      from_source_alias.col_0 = right_source_alias.col_0
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      from_source_alias.col_0 AS cte_source_0__col_0
+    FROM test_schema.test_table_0 from_source_alias
+    INNER JOIN
+      test_schema.test_table_1 right_source_alias
+    ON
+      from_source_alias.col_0 = right_source_alias.col_0
+  )
+
+  SELECT
+    cte_source_0__col_0 AS top_level__col_0
+  FROM cte_source_0 cte_source_0_alias

--- a/tests_metricflow/snapshots/test_cte_table_alias_simplifier.py/str/test_table_alias_simplification__result.txt
+++ b/tests_metricflow/snapshots/test_cte_table_alias_simplifier.py/str/test_table_alias_simplification__result.txt
@@ -1,0 +1,85 @@
+test_name: test_table_alias_simplification
+test_filename: test_cte_table_alias_simplifier.py
+docstring:
+  Tests that table aliases in the SELECT statement of a CTE are removed when not needed.
+---
+optimizer:
+  SqlTableAliasSimplifier
+
+sql_before_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      test_table_alias.col_0 AS cte_source_0__col_0
+      , test_table_alias.col_1 AS cte_source_0__col_1
+    FROM (
+      -- CTE source 0 sub-query
+      SELECT
+        test_table_alias.col_0 AS cte_source_0_subquery__col_0
+        , test_table_alias.col_0 AS cte_source_0_subquery__col_1
+      FROM test_schema.test_table test_table_alias
+    ) cte_source_0_subquery
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      test_table_alias.col_0 AS cte_source_1__col_0
+      , test_table_alias.col_1 AS cte_source_1__col_1
+    FROM (
+      -- CTE source 1 sub-query
+      SELECT
+        cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_0
+        , cte_source_0_alias.cte_source_0__col_0 AS cte_source_1_subquery__col_1
+      FROM cte_source_0 cte_source_0_alias
+    ) cte_source_1_subquery
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1
+
+sql_after_optimizing:
+  -- Top-level SELECT
+  WITH cte_source_0 AS (
+    -- CTE source 0
+    SELECT
+      col_0 AS cte_source_0__col_0
+      , col_1 AS cte_source_0__col_1
+    FROM (
+      -- CTE source 0 sub-query
+      SELECT
+        col_0 AS cte_source_0_subquery__col_0
+        , col_0 AS cte_source_0_subquery__col_1
+      FROM test_schema.test_table test_table_alias
+    ) cte_source_0_subquery
+  )
+
+  , cte_source_1 AS (
+    -- CTE source 1
+    SELECT
+      col_0 AS cte_source_1__col_0
+      , col_1 AS cte_source_1__col_1
+    FROM (
+      -- CTE source 1 sub-query
+      SELECT
+        cte_source_0__col_0 AS cte_source_1_subquery__col_0
+        , cte_source_0__col_0 AS cte_source_1_subquery__col_1
+      FROM cte_source_0 cte_source_0_alias
+    ) cte_source_1_subquery
+  )
+
+  SELECT
+    cte_source_0_alias.cte_source_0__col_0 AS top_level__col_0
+    , right_source_alias.right_source__col_1 AS top_level__col_1
+  FROM cte_source_0 cte_source_0_alias
+  INNER JOIN
+    cte_source_1 right_source_alias
+  ON
+    cte_source_0_alias.cte_source_0__col_1 = right_source_alias.right_source__col_1

--- a/tests_metricflow/snapshots/test_table_alias_simplifier.py/SqlQueryPlan/test_table_alias_simplification__after_alias_simplification.sql
+++ b/tests_metricflow/snapshots/test_table_alias_simplifier.py/SqlQueryPlan/test_table_alias_simplification__after_alias_simplification.sql
@@ -1,7 +1,7 @@
 test_name: test_table_alias_simplification
 test_filename: test_table_alias_simplifier.py
 docstring:
-  Tests a case where no pruning should occur.
+  Tests that table aliases are removed when not needed.
 ---
 -- test0
 SELECT

--- a/tests_metricflow/snapshots/test_table_alias_simplifier.py/SqlQueryPlan/test_table_alias_simplification__before_alias_simplification.sql
+++ b/tests_metricflow/snapshots/test_table_alias_simplifier.py/SqlQueryPlan/test_table_alias_simplification__before_alias_simplification.sql
@@ -1,7 +1,7 @@
 test_name: test_table_alias_simplification
 test_filename: test_table_alias_simplifier.py
 docstring:
-  Tests a case where no pruning should occur.
+  Tests that table aliases are removed when not needed.
 ---
 -- test0
 SELECT

--- a/tests_metricflow/sql/optimizer/test_cte_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_cte_table_alias_simplifier.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.sql.sql_join_type import SqlJoinType
+from metricflow_semantics.sql.sql_table import SqlTable
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+
+from metricflow.sql.optimizer.table_alias_simplifier import SqlTableAliasSimplifier
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+from metricflow.sql.sql_exprs import (
+    SqlColumnReference,
+    SqlColumnReferenceExpression,
+    SqlComparison,
+    SqlComparisonExpression,
+)
+from metricflow.sql.sql_plan import (
+    SqlCteNode,
+    SqlJoinDescription,
+    SqlSelectColumn,
+    SqlSelectStatementNode,
+    SqlTableNode,
+)
+from tests_metricflow.sql.optimizer.check_optimizer import assert_optimizer_result_snapshot_equal
+
+
+@pytest.fixture
+def sql_plan_renderer() -> DefaultSqlQueryPlanRenderer:  # noqa: D103
+    return DefaultSqlQueryPlanRenderer()
+
+
+def test_table_alias_simplification(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    sql_plan_renderer: DefaultSqlQueryPlanRenderer,
+) -> None:
+    """Tests that table aliases are removed when not needed in CTEs."""
+    select_statement = SqlSelectStatementNode.create(
+        description="Top-level SELECT",
+        select_columns=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                ),
+                column_alias="top_level__col_1",
+            ),
+        ),
+        from_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_0")),
+        from_source_alias="cte_source_0_alias",
+        join_descs=(
+            SqlJoinDescription(
+                right_source=SqlTableNode.create(sql_table=SqlTable(schema_name=None, table_name="cte_source_1")),
+                right_source_alias="right_source_alias",
+                on_condition=SqlComparisonExpression.create(
+                    left_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_1")
+                    ),
+                    comparison=SqlComparison.EQUALS,
+                    right_expr=SqlColumnReferenceExpression.create(
+                        col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                    ),
+                ),
+                join_type=SqlJoinType.INNER,
+            ),
+        ),
+        group_bys=(
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="cte_source_0_alias", column_name="cte_source_0__col_0")
+                ),
+                column_alias="top_level__col_0",
+            ),
+            SqlSelectColumn(
+                expr=SqlColumnReferenceExpression.create(
+                    col_ref=SqlColumnReference(table_alias="right_source_alias", column_name="right_source__col_1")
+                ),
+                column_alias="top_level__col_1",
+            ),
+        ),
+        cte_sources=(
+            SqlCteNode.create(
+                cte_alias="cte_source_0",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 0",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_0__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_0__col_1",
+                        ),
+                    ),
+                    from_source=SqlSelectStatementNode.create(
+                        description="CTE source 0 sub-query",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                                ),
+                                column_alias="cte_source_0_subquery__col_0",
+                            ),
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                                ),
+                                column_alias="cte_source_0_subquery__col_1",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name="test_schema", table_name="test_table")
+                        ),
+                        from_source_alias="test_table_alias",
+                    ),
+                    from_source_alias="cte_source_0_subquery",
+                ),
+            ),
+            SqlCteNode.create(
+                cte_alias="cte_source_1",
+                select_statement=SqlSelectStatementNode.create(
+                    description="CTE source 1",
+                    select_columns=(
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_0")
+                            ),
+                            column_alias="cte_source_1__col_0",
+                        ),
+                        SqlSelectColumn(
+                            expr=SqlColumnReferenceExpression.create(
+                                col_ref=SqlColumnReference(table_alias="test_table_alias", column_name="col_1")
+                            ),
+                            column_alias="cte_source_1__col_1",
+                        ),
+                    ),
+                    from_source=SqlSelectStatementNode.create(
+                        description="CTE source 1 sub-query",
+                        select_columns=(
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(
+                                        table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                    )
+                                ),
+                                column_alias="cte_source_1_subquery__col_0",
+                            ),
+                            SqlSelectColumn(
+                                expr=SqlColumnReferenceExpression.create(
+                                    col_ref=SqlColumnReference(
+                                        table_alias="cte_source_0_alias", column_name="cte_source_0__col_0"
+                                    )
+                                ),
+                                column_alias="cte_source_1_subquery__col_1",
+                            ),
+                        ),
+                        from_source=SqlTableNode.create(
+                            sql_table=SqlTable(schema_name=None, table_name="cte_source_0")
+                        ),
+                        from_source_alias="cte_source_0_alias",
+                    ),
+                    from_source_alias="cte_source_1_subquery",
+                ),
+            ),
+        ),
+    )
+    assert_optimizer_result_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        optimizer=SqlTableAliasSimplifier(),
+        sql_plan_renderer=sql_plan_renderer,
+        select_statement=select_statement,
+    )

--- a/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
+++ b/tests_metricflow/sql/optimizer/test_table_alias_simplifier.py
@@ -145,7 +145,7 @@ def test_table_alias_simplification(
     mf_test_configuration: MetricFlowTestConfiguration,
     base_select_statement: SqlSelectStatementNode,
 ) -> None:
-    """Tests a case where no pruning should occur."""
+    """Tests that table aliases are removed when not needed."""
     assert_default_rendered_sql_equal(
         request=request,
         mf_test_configuration=mf_test_configuration,


### PR DESCRIPTION
Similar to the updates for the other optimizers in https://github.com/dbt-labs/metricflow/pull/1503 and https://github.com/dbt-labs/metricflow/pull/1504, this PR implements the CTE case for the `SqlTableAliasSimplifier`