### PR TITLE
Add a method to figure out common nodes in a dataflow plan

### DIFF
--- a/metricflow-semantics/metricflow_semantics/dag/mf_dag.py
+++ b/metricflow-semantics/metricflow_semantics/dag/mf_dag.py
@@ -32,7 +32,7 @@ class DisplayedProperty:  # type: ignore
     value: Any  # type: ignore
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class NodeId:
     """Unique identifier for nodes in DAGs."""
 

--- a/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
+++ b/metricflow-semantics/metricflow_semantics/mf_logging/pretty_print.py
@@ -437,15 +437,19 @@ def mf_pformat_dict(  # type: ignore
     include_none_object_fields: bool = False,
     include_empty_object_fields: bool = False,
     preserve_raw_strings: bool = False,
+    pad_items_with_newlines: bool = False,
 ) -> str:
     """Prints many objects in an indented form.
 
-    If preserve_raw_strings is set, and a value of the obj_dict is of type str, then use the value itself, not the
+    If `preserve_raw_strings` is set, and a value of the obj_dict is of type str, then use the value itself, not the
     representation of the string. e.g. if value="foo", then "foo" instead of "'foo'". Useful for values that contain
     newlines.
+
+    If `pad_items_with_newlines` is set , each key / value section is padded with newlines.
     """
-    lines: List[str] = [description] if description is not None else []
+    description_lines: List[str] = [description] if description is not None else []
     obj_dict = obj_dict or {}
+    item_sections = []
     for key, value in obj_dict.items():
         if preserve_raw_strings and isinstance(value, str):
             value_str = value
@@ -460,9 +464,9 @@ def mf_pformat_dict(  # type: ignore
             )
 
         lines_in_value_str = len(value_str.split("\n"))
-        item_block_lines: Tuple[str, ...]
+        item_section_lines: Tuple[str, ...]
         if lines_in_value_str > 1:
-            item_block_lines = (
+            item_section_lines = (
                 f"{key}:",
                 indent(
                     value_str,
@@ -470,11 +474,15 @@ def mf_pformat_dict(  # type: ignore
                 ),
             )
         else:
-            item_block_lines = (f"{key}: {value_str}",)
-        item_block = "\n".join(item_block_lines)
+            item_section_lines = (f"{key}: {value_str}",)
+        item_section = "\n".join(item_section_lines)
 
         if description is None:
-            lines.append(item_block)
+            item_sections.append(item_section)
         else:
-            lines.append(indent(item_block))
-    return "\n".join(lines)
+            item_sections.append(indent(item_section))
+
+    if pad_items_with_newlines:
+        return "\n\n".join(description_lines + item_sections)
+    else:
+        return "\n".join(description_lines + item_sections)

--- a/metricflow-semantics/metricflow_semantics/visitor.py
+++ b/metricflow-semantics/metricflow_semantics/visitor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC
 from typing import TypeVar
 
-VisitorOutputT = TypeVar("VisitorOutputT")
+VisitorOutputT = TypeVar("VisitorOutputT", covariant=True)
 
 
 class Visitable(ABC):

--- a/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
+++ b/metricflow-semantics/tests_metricflow_semantics/collection_helpers/test_pretty_print.py
@@ -218,3 +218,19 @@ def test_pformat_dict_with_empty_message() -> None:
         )
         == result
     )
+
+
+def test_pformat_dict_with_pad_sections_with_newline() -> None:
+    """Test `mf_pformat_dict` with new lines between sections."""
+    result = mf_pformat_dict(obj_dict={"object_0": (1, 2, 3), "object_1": {4: 5}}, pad_items_with_newlines=True)
+
+    assert (
+        mf_dedent(
+            """
+            object_0: (1, 2, 3)
+
+            object_1: {4: 5}
+            """
+        )
+        == result
+    )

--- a/metricflow/dataflow/dataflow_plan_analyzer.py
+++ b/metricflow/dataflow/dataflow_plan_analyzer.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, FrozenSet, Mapping, Sequence, Set
+
+from typing_extensions import override
+
+from metricflow.dataflow.dataflow_plan import DataflowPlan, DataflowPlanNode
+from metricflow.dataflow.dataflow_plan_visitor import DataflowPlanNodeVisitorWithDefaultHandler
+
+
+class DataflowPlanAnalyzer:
+    """Class to determine more complex properties of the dataflow plan.
+
+    These could also be made as member methods of the dataflow plan, but this requires resolving some circular
+    dependency issues to break out the functionality into separate files.
+    """
+
+    @staticmethod
+    def find_common_branches(dataflow_plan: DataflowPlan) -> Sequence[DataflowPlanNode]:
+        """Starting from the sink node, find the common branches that exist in the associated DAG.
+
+        Returns a sorted sequence for reproducibility.
+        """
+        counting_visitor = _CountDataflowNodeVisitor()
+        dataflow_plan.sink_node.accept(counting_visitor)
+
+        node_to_common_count = counting_visitor.get_node_counts()
+
+        common_nodes = []
+        for node, count in node_to_common_count.items():
+            if count > 1:
+                common_nodes.append(node)
+
+        common_branches_visitor = _FindLargestCommonBranchesVisitor(frozenset(common_nodes))
+
+        return tuple(sorted(dataflow_plan.sink_node.accept(common_branches_visitor)))
+
+
+class _CountDataflowNodeVisitor(DataflowPlanNodeVisitorWithDefaultHandler[None]):
+    """Helper visitor to build a dict from a node in the plan to the number of times it appears in the plan."""
+
+    def __init__(self) -> None:
+        self._node_to_count: Dict[DataflowPlanNode, int] = defaultdict(int)
+
+    def get_node_counts(self) -> Mapping[DataflowPlanNode, int]:
+        return self._node_to_count
+
+    @override
+    def _default_handler(self, node: DataflowPlanNode) -> None:
+        for parent_node in node.parent_nodes:
+            parent_node.accept(self)
+        self._node_to_count[node] += 1
+
+
+class _FindLargestCommonBranchesVisitor(DataflowPlanNodeVisitorWithDefaultHandler[FrozenSet[DataflowPlanNode]]):
+    """Given the nodes that are known to appear in the DAG multiple times, find the common branches.
+
+    To get the largest common branches, (e.g. for `A -> B -> C -> D` and `B -> C -> D`, both `B -> C -> D`
+    and `C -> D` can be considered common branches, and we want the largest one), this uses preorder traversal and
+    returns the first common node that is seen.
+    """
+
+    def __init__(self, common_nodes: FrozenSet[DataflowPlanNode]) -> None:
+        self._common_nodes = common_nodes
+
+    @override
+    def _default_handler(self, node: DataflowPlanNode) -> FrozenSet[DataflowPlanNode]:
+        # Traversal starts from the leaf node and then goes to the parent branches. By doing this check first, we don't
+        # return smaller common branches that are a part of a larger common branch.
+        if node in self._common_nodes:
+            return frozenset({node})
+
+        common_branch_leaf_nodes: Set[DataflowPlanNode] = set()
+
+        for parent_node in node.parent_nodes:
+            common_branch_leaf_nodes.update(parent_node.accept(self))
+
+        return frozenset(common_branch_leaf_nodes)

--- a/metricflow/dataflow/dataflow_plan_visitor.py
+++ b/metricflow/dataflow/dataflow_plan_visitor.py
@@ -5,8 +5,10 @@ from abc import ABC, abstractmethod
 from typing import Generic
 
 from metricflow_semantics.visitor import VisitorOutputT
+from typing_extensions import override
 
 if typing.TYPE_CHECKING:
+    from metricflow.dataflow.dataflow_plan import DataflowPlanNode
     from metricflow.dataflow.nodes.add_generated_uuid import AddGeneratedUuidColumnNode
     from metricflow.dataflow.nodes.aggregate_measures import AggregateMeasuresNode
     from metricflow.dataflow.nodes.combine_aggregated_outputs import CombineAggregatedOutputsNode
@@ -39,82 +41,175 @@ class DataflowPlanNodeVisitor(Generic[VisitorOutputT], ABC):
 
     @abstractmethod
     def visit_source_node(self, node: ReadSqlSourceNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_join_on_entities_node(self, node: JoinOnEntitiesNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_window_reaggregation_node(self, node: WindowReaggregationNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_order_by_limit_node(self, node: OrderByLimitNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_where_constraint_node(self, node: WhereConstraintNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_write_to_result_data_table_node(self, node: WriteToResultDataTableNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_filter_elements_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_metric_time_dimension_transform_node(  # noqa: D102
         self, node: MetricTimeDimensionTransformNode
     ) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_min_max_node(self, node: MinMaxNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def visit_join_to_custom_granularity_node(self, node: JoinToCustomGranularityNode) -> VisitorOutputT:  # noqa: D102
-        pass
+        raise NotImplementedError
+
+
+class DataflowPlanNodeVisitorWithDefaultHandler(DataflowPlanNodeVisitor[VisitorOutputT], Generic[VisitorOutputT]):
+    """Similar to `DataflowPlanNodeVisitor`, but with an abstract default handler that gets called for each node.
+
+    This could potentially replace `DataflowPlanNodeVisitor`.
+    """
+
+    @abstractmethod
+    def _default_handler(self, node: DataflowPlanNode) -> VisitorOutputT:
+        raise NotImplementedError
+
+    @override
+    def visit_source_node(self, node: ReadSqlSourceNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_join_on_entities_node(self, node: JoinOnEntitiesNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_aggregate_measures_node(self, node: AggregateMeasuresNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_compute_metrics_node(self, node: ComputeMetricsNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_window_reaggregation_node(self, node: WindowReaggregationNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_order_by_limit_node(self, node: OrderByLimitNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_where_constraint_node(self, node: WhereConstraintNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_write_to_result_data_table_node(self, node: WriteToResultDataTableNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_write_to_result_table_node(self, node: WriteToResultTableNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_filter_elements_node(self, node: FilterElementsNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_combine_aggregated_outputs_node(self, node: CombineAggregatedOutputsNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_constrain_time_range_node(self, node: ConstrainTimeRangeNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_join_over_time_range_node(self, node: JoinOverTimeRangeNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_semi_additive_join_node(self, node: SemiAdditiveJoinNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_metric_time_dimension_transform_node(  # noqa: D102
+        self, node: MetricTimeDimensionTransformNode
+    ) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_join_to_time_spine_node(self, node: JoinToTimeSpineNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_min_max_node(self, node: MinMaxNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_add_generated_uuid_column_node(self, node: AddGeneratedUuidColumnNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_join_conversion_events_node(self, node: JoinConversionEventsNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)
+
+    @override
+    def visit_join_to_custom_granularity_node(self, node: JoinToCustomGranularityNode) -> VisitorOutputT:  # noqa: D102
+        return self._default_handler(node)

--- a/tests_metricflow/snapshots/test_common_dataflow_branches.py/str/test_shared_metric_query__result.txt
+++ b/tests_metricflow/snapshots/test_common_dataflow_branches.py/str/test_shared_metric_query__result.txt
@@ -1,0 +1,162 @@
+test_name: test_shared_metric_query
+test_filename: test_common_dataflow_branches.py
+docstring:
+  For a known case, test that a metric computation node is identified as a common branch.
+
+      A query for `bookings` and `bookings_per_booker` should have the computation for `bookings` as a common branch in
+      the dataflow plan.
+---
+dataflow_plan:
+  <DataflowPlan>
+      <WriteToResultDataTableNode>
+          <!-- description = 'Write to DataTable' -->
+          <!-- node_id = NodeId(id_str='wrd_0') -->
+          <CombineAggregatedOutputsNode>
+              <!-- description = 'Combine Aggregated Outputs' -->
+              <!-- node_id = NodeId(id_str='cao_1') -->
+              <ComputeMetricsNode>
+                  <!-- description = 'Compute Metrics via Expressions' -->
+                  <!-- node_id = NodeId(id_str='cm_0') -->
+                  <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
+                  <AggregateMeasuresNode>
+                      <!-- description = 'Aggregate Measures' -->
+                      <!-- node_id = NodeId(id_str='am_0') -->
+                      <FilterElementsNode>
+                          <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
+                          <!-- node_id = NodeId(id_str='pfe_0') -->
+                          <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                          <!-- include_spec =                                                                  -->
+                          <!--   TimeDimensionSpec(                                                            -->
+                          <!--     element_name='metric_time',                                                 -->
+                          <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                          <!--   )                                                                             -->
+                          <!-- distinct = False -->
+                          <MetricTimeDimensionTransformNode>
+                              <!-- description = "Metric Time Dimension 'ds'" -->
+                              <!-- node_id = NodeId(id_str='sma_28009') -->
+                              <!-- aggregation_time_dimension = 'ds' -->
+                              <ReadSqlSourceNode>
+                                  <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                  <!-- node_id = NodeId(id_str='rss_28020') -->
+                                  <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                              </ReadSqlSourceNode>
+                          </MetricTimeDimensionTransformNode>
+                      </FilterElementsNode>
+                  </AggregateMeasuresNode>
+              </ComputeMetricsNode>
+              <ComputeMetricsNode>
+                  <!-- description = 'Compute Metrics via Expressions' -->
+                  <!-- node_id = NodeId(id_str='cm_2') -->
+                  <!-- metric_spec = MetricSpec(element_name='bookings_per_booker', filter_spec_set=WhereFilterSpecSet()) -->
+                  <CombineAggregatedOutputsNode>
+                      <!-- description = 'Combine Aggregated Outputs' -->
+                      <!-- node_id = NodeId(id_str='cao_0') -->
+                      <ComputeMetricsNode>
+                          <!-- description = 'Compute Metrics via Expressions' -->
+                          <!-- node_id = NodeId(id_str='cm_0') -->
+                          <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
+                          <AggregateMeasuresNode>
+                              <!-- description = 'Aggregate Measures' -->
+                              <!-- node_id = NodeId(id_str='am_0') -->
+                              <FilterElementsNode>
+                                  <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
+                                  <!-- node_id = NodeId(id_str='pfe_0') -->
+                                  <!-- include_spec = MeasureSpec(element_name='bookings') -->
+                                  <!-- include_spec =                                                                  -->
+                                  <!--   TimeDimensionSpec(                                                            -->
+                                  <!--     element_name='metric_time',                                                 -->
+                                  <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                  <!--   )                                                                             -->
+                                  <!-- distinct = False -->
+                                  <MetricTimeDimensionTransformNode>
+                                      <!-- description = "Metric Time Dimension 'ds'" -->
+                                      <!-- node_id = NodeId(id_str='sma_28009') -->
+                                      <!-- aggregation_time_dimension = 'ds' -->
+                                      <ReadSqlSourceNode>
+                                          <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                          <!-- node_id = NodeId(id_str='rss_28020') -->
+                                          <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                      </ReadSqlSourceNode>
+                                  </MetricTimeDimensionTransformNode>
+                              </FilterElementsNode>
+                          </AggregateMeasuresNode>
+                      </ComputeMetricsNode>
+                      <ComputeMetricsNode>
+                          <!-- description = 'Compute Metrics via Expressions' -->
+                          <!-- node_id = NodeId(id_str='cm_1') -->
+                          <!-- metric_spec = MetricSpec(element_name='bookers', filter_spec_set=WhereFilterSpecSet()) -->
+                          <AggregateMeasuresNode>
+                              <!-- description = 'Aggregate Measures' -->
+                              <!-- node_id = NodeId(id_str='am_1') -->
+                              <FilterElementsNode>
+                                  <!-- description = "Pass Only Elements: ['bookers', 'metric_time__day']" -->
+                                  <!-- node_id = NodeId(id_str='pfe_1') -->
+                                  <!-- include_spec = MeasureSpec(element_name='bookers') -->
+                                  <!-- include_spec =                                                                  -->
+                                  <!--   TimeDimensionSpec(                                                            -->
+                                  <!--     element_name='metric_time',                                                 -->
+                                  <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+                                  <!--   )                                                                             -->
+                                  <!-- distinct = False -->
+                                  <MetricTimeDimensionTransformNode>
+                                      <!-- description = "Metric Time Dimension 'ds'" -->
+                                      <!-- node_id = NodeId(id_str='sma_28009') -->
+                                      <!-- aggregation_time_dimension = 'ds' -->
+                                      <ReadSqlSourceNode>
+                                          <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                                          <!-- node_id = NodeId(id_str='rss_28020') -->
+                                          <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                                      </ReadSqlSourceNode>
+                                  </MetricTimeDimensionTransformNode>
+                              </FilterElementsNode>
+                          </AggregateMeasuresNode>
+                      </ComputeMetricsNode>
+                  </CombineAggregatedOutputsNode>
+              </ComputeMetricsNode>
+          </CombineAggregatedOutputsNode>
+      </WriteToResultDataTableNode>
+  </DataflowPlan>
+
+common_branch_0:
+  <ComputeMetricsNode>
+      <!-- description = 'Compute Metrics via Expressions' -->
+      <!-- node_id = NodeId(id_str='cm_0') -->
+      <!-- metric_spec = MetricSpec(element_name='bookings', filter_spec_set=WhereFilterSpecSet()) -->
+      <AggregateMeasuresNode>
+          <!-- description = 'Aggregate Measures' -->
+          <!-- node_id = NodeId(id_str='am_0') -->
+          <FilterElementsNode>
+              <!-- description = "Pass Only Elements: ['bookings', 'metric_time__day']" -->
+              <!-- node_id = NodeId(id_str='pfe_0') -->
+              <!-- include_spec = MeasureSpec(element_name='bookings') -->
+              <!-- include_spec =                                                                  -->
+              <!--   TimeDimensionSpec(                                                            -->
+              <!--     element_name='metric_time',                                                 -->
+              <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
+              <!--   )                                                                             -->
+              <!-- distinct = False -->
+              <MetricTimeDimensionTransformNode>
+                  <!-- description = "Metric Time Dimension 'ds'" -->
+                  <!-- node_id = NodeId(id_str='sma_28009') -->
+                  <!-- aggregation_time_dimension = 'ds' -->
+                  <ReadSqlSourceNode>
+                      <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+                      <!-- node_id = NodeId(id_str='rss_28020') -->
+                      <!-- data_set = SemanticModelDataSet('bookings_source') -->
+                  </ReadSqlSourceNode>
+              </MetricTimeDimensionTransformNode>
+          </FilterElementsNode>
+      </AggregateMeasuresNode>
+  </ComputeMetricsNode>
+
+common_branch_1:
+  <MetricTimeDimensionTransformNode>
+      <!-- description = "Metric Time Dimension 'ds'" -->
+      <!-- node_id = NodeId(id_str='sma_28009') -->
+      <!-- aggregation_time_dimension = 'ds' -->
+      <ReadSqlSourceNode>
+          <!-- description = "Read From SemanticModelDataSet('bookings_source')" -->
+          <!-- node_id = NodeId(id_str='rss_28020') -->
+          <!-- data_set = SemanticModelDataSet('bookings_source') -->
+      </ReadSqlSourceNode>
+  </MetricTimeDimensionTransformNode>

--- a/tests_metricflow/sql/test_common_dataflow_branches.py
+++ b/tests_metricflow/sql/test_common_dataflow_branches.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import logging
+
+from _pytest.fixtures import FixtureRequest
+from metricflow_semantics.mf_logging.pretty_print import mf_pformat_dict
+from metricflow_semantics.query.query_parser import MetricFlowQueryParser
+from metricflow_semantics.specs.column_assoc import ColumnAssociationResolver
+from metricflow_semantics.test_helpers.config_helpers import MetricFlowTestConfiguration
+from metricflow_semantics.test_helpers.snapshot_helpers import (
+    assert_str_snapshot_equal,
+)
+
+from metricflow.dataflow.builder.dataflow_plan_builder import DataflowPlanBuilder
+from metricflow.dataflow.dataflow_plan_analyzer import DataflowPlanAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+def test_shared_metric_query(
+    request: FixtureRequest,
+    mf_test_configuration: MetricFlowTestConfiguration,
+    column_association_resolver: ColumnAssociationResolver,
+    dataflow_plan_builder: DataflowPlanBuilder,
+    query_parser: MetricFlowQueryParser,
+) -> None:
+    """For a known case, test that a metric computation node is identified as a common branch.
+
+    A query for `bookings` and `bookings_per_booker` should have the computation for `bookings` as a common branch in
+    the dataflow plan.
+    """
+    parse_result = query_parser.parse_and_validate_query(
+        metric_names=("bookings", "bookings_per_booker"),
+        group_by_names=("metric_time",),
+    )
+    dataflow_plan = dataflow_plan_builder.build_plan(parse_result.query_spec)
+
+    obj_dict = {
+        "dataflow_plan": dataflow_plan.structure_text(),
+    }
+
+    common_branch_leaf_nodes = DataflowPlanAnalyzer.find_common_branches(dataflow_plan)
+    for i, common_branch_leaf_node in enumerate(sorted(common_branch_leaf_nodes)):
+        obj_dict[f"common_branch_{i}"] = common_branch_leaf_node.structure_text()
+
+    assert_str_snapshot_equal(
+        request=request,
+        mf_test_configuration=mf_test_configuration,
+        snapshot_id="result",
+        snapshot_str=mf_pformat_dict(
+            obj_dict=obj_dict,
+            preserve_raw_strings=True,
+        ),
+    )

--- a/tests_metricflow/sql/test_common_dataflow_branches.py
+++ b/tests_metricflow/sql/test_common_dataflow_branches.py
@@ -50,5 +50,6 @@ def test_shared_metric_query(
         snapshot_str=mf_pformat_dict(
             obj_dict=obj_dict,
             preserve_raw_strings=True,
+            pad_items_with_newlines=True,
         ),
     )


### PR DESCRIPTION
This PR adds a method to figure out nodes in a dataflow plan that appear more than once. i.e. a node that is the parent of multiple nodes. These common nodes indicate operations where a computation is reused, e.g. a metric that is used in the computation of multiple derived metrics in a query. These nodes will be later used to generate CTEs.