### PR TITLE
Update MF to support breaking changes in DSI for custom calendar

### DIFF
--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.8.1
+dbt-semantic-interfaces==0.8.3
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/extra-hatch-configuration/requirements.txt
+++ b/extra-hatch-configuration/requirements.txt
@@ -1,5 +1,5 @@
 Jinja2>=3.1.3
-dbt-semantic-interfaces==0.7.2
+dbt-semantic-interfaces==0.8.1
 more-itertools>=8.10.0, <10.2.0
 pydantic>=1.10.0, <3.0
 tabulate>=0.8.9

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces>=0.7.2, <0.8.0
+dbt-semantic-interfaces>=0.8.1, <0.9.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/extra-hatch-configuration/requirements.txt
+++ b/metricflow-semantics/extra-hatch-configuration/requirements.txt
@@ -1,7 +1,7 @@
 # Always support a range of production DSI versions capped at the next breaking version in metricflow-semantics.
 # This allows us to sync new, non-breaking changes to dbt-core without getting a version mismatch in dbt-mantle,
 # which depends on a specific commit of DSI.
-dbt-semantic-interfaces>=0.8.1, <0.9.0
+dbt-semantic-interfaces>=0.8.3, <0.9.0
 graphviz>=0.18.2, <0.21
 python-dateutil>=2.9.0, <2.10.0
 rapidfuzz>=3.0, <4.0

--- a/metricflow-semantics/metricflow_semantics/errors/custom_grain_not_supported.py
+++ b/metricflow-semantics/metricflow_semantics/errors/custom_grain_not_supported.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+
+
+def error_if_not_standard_grain(input_granularity: str, context: Optional[str] = None) -> TimeGranularity:
+    """Cast input grainularity string to TimeGranularity, otherwise error.
+
+    TODO: Not needed once, custom grain is supported for most things.
+    """
+    try:
+        time_grain = TimeGranularity(input_granularity)
+    except ValueError:
+        error_msg = f"Received a non-standard time granularity, which is not supported at the moment, received: {input_granularity}."
+        if context:
+            error_msg += f"\nContext: {context}"
+        raise ValueError(error_msg)
+    return time_grain

--- a/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
@@ -23,7 +23,7 @@ from metricflow_semantics.specs.spec_set import InstanceSpecSet, InstanceSpecSet
 class DunderNamingScheme(QueryItemNamingScheme):
     """A naming scheme using the dundered name syntax.
 
-    TODO: Consolidate with StructuredLinkableSpecName / DunderedNameFormatter.
+    TODO: Consolidate with StructuredLinkableSpecName.
     """
 
     _INPUT_REGEX = re.compile(r"\A[a-z]([a-z0-9_])*[a-z0-9]\Z")

--- a/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/dunder_scheme.py
@@ -52,7 +52,7 @@ class DunderNamingScheme(QueryItemNamingScheme):
 
     @override
     def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> EntityLinkPattern:
-        if not self.input_str_follows_scheme(input_str):
+        if not self.input_str_follows_scheme(input_str, semantic_manifest_lookup=semantic_manifest_lookup):
             raise ValueError(f"{repr(input_str)} does not follow this scheme.")
 
         input_str = input_str.lower()
@@ -119,7 +119,7 @@ class DunderNamingScheme(QueryItemNamingScheme):
         )
 
     @override
-    def input_str_follows_scheme(self, input_str: str) -> bool:
+    def input_str_follows_scheme(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> bool:
         # This naming scheme is case-insensitive.
         input_str = input_str.lower()
         if DunderNamingScheme._INPUT_REGEX.match(input_str) is None:

--- a/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
+++ b/metricflow-semantics/metricflow_semantics/naming/linkable_spec_name.py
@@ -4,6 +4,7 @@ import logging
 from functools import lru_cache
 from typing import Optional, Sequence, Tuple
 
+from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
@@ -105,6 +106,11 @@ class StructuredLinkableSpecName:
     def date_part_suffix(date_part: DatePart) -> str:
         """Suffix used for names with a date_part."""
         return f"extract_{date_part.value}"
+
+    @property
+    def entity_links(self) -> Tuple[EntityReference, ...]:
+        """Returns the entity link references."""
+        return tuple(EntityReference(entity_link_name.lower()) for entity_link_name in self.entity_link_names)
 
     @property
     def granularity_free_qualified_name(self) -> str:

--- a/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/metric_scheme.py
@@ -28,12 +28,12 @@ class MetricNamingScheme(QueryItemNamingScheme):
     @override
     def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> MetricSpecPattern:
         input_str = input_str.lower()
-        if not self.input_str_follows_scheme(input_str):
+        if not self.input_str_follows_scheme(input_str, semantic_manifest_lookup=semantic_manifest_lookup):
             raise RuntimeError(f"{repr(input_str)} does not follow this scheme.")
         return MetricSpecPattern(metric_reference=MetricReference(element_name=input_str))
 
     @override
-    def input_str_follows_scheme(self, input_str: str) -> bool:
+    def input_str_follows_scheme(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> bool:
         # TODO: Use regex.
         return True
 

--- a/metricflow-semantics/metricflow_semantics/naming/naming_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/naming_scheme.py
@@ -42,7 +42,7 @@ class QueryItemNamingScheme(ABC):
         pass
 
     @abstractmethod
-    def input_str_follows_scheme(self, input_str: str) -> bool:
+    def input_str_follows_scheme(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> bool:
         """Returns true if the given input string follows this naming scheme.
 
         Consider adding a structured result that indicates why it does not match the scheme.

--- a/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
+++ b/metricflow-semantics/metricflow_semantics/naming/object_builder_scheme.py
@@ -38,14 +38,16 @@ class ObjectBuilderNamingScheme(QueryItemNamingScheme):
 
     @override
     def spec_pattern(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> SpecPattern:
-        if not self.input_str_follows_scheme(input_str):
+        if not self.input_str_follows_scheme(input_str, semantic_manifest_lookup=semantic_manifest_lookup):
             raise ValueError(
                 f"The specified input {repr(input_str)} does not match the input described by the object builder "
                 f"pattern."
             )
         try:
             # TODO: Update when more appropriate parsing libraries are available.
-            call_parameter_sets = PydanticWhereFilter(where_sql_template="{{ " + input_str + " }}").call_parameter_sets
+            call_parameter_sets = PydanticWhereFilter(where_sql_template="{{ " + input_str + " }}").call_parameter_sets(
+                custom_granularity_names=semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names
+            )
         except ParseWhereFilterException as e:
             raise ValueError(f"A spec pattern can't be generated from the input string {repr(input_str)}") from e
 
@@ -121,11 +123,14 @@ class ObjectBuilderNamingScheme(QueryItemNamingScheme):
         raise RuntimeError("There should have been a return associated with one of the CallParameterSets.")
 
     @override
-    def input_str_follows_scheme(self, input_str: str) -> bool:
+    def input_str_follows_scheme(self, input_str: str, semantic_manifest_lookup: SemanticManifestLookup) -> bool:
         if ObjectBuilderNamingScheme._NAME_REGEX.match(input_str) is None:
             return False
         try:
-            call_parameter_sets = WhereFilterParser.parse_call_parameter_sets("{{ " + input_str + " }}")
+            call_parameter_sets = WhereFilterParser.parse_call_parameter_sets(
+                where_sql_template="{{ " + input_str + " }}",
+                custom_granularity_names=semantic_manifest_lookup.semantic_model_lookup.custom_granularity_names,
+            )
             return_value = (
                 len(call_parameter_sets.dimension_call_parameter_sets)
                 + len(call_parameter_sets.time_dimension_call_parameter_sets)

--- a/metricflow-semantics/metricflow_semantics/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
+++ b/metricflow-semantics/metricflow_semantics/query/group_by_item/filter_spec_resolution/filter_spec_resolver.py
@@ -331,7 +331,9 @@ class _ResolveWhereFilterSpecVisitor(GroupByItemResolutionNodeVisitor[FilterSpec
         for location, where_filters in where_filters_and_locations.items():
             for where_filter in where_filters:
                 try:
-                    filter_call_parameter_sets = where_filter.call_parameter_sets
+                    filter_call_parameter_sets = where_filter.call_parameter_sets(
+                        custom_granularity_names=self._manifest_lookup.semantic_model_lookup.custom_granularity_names
+                    )
                 except Exception as e:
                     non_parsable_resolutions.append(
                         NonParsableFilterResolution(

--- a/metricflow-semantics/metricflow_semantics/query/query_parser.py
+++ b/metricflow-semantics/metricflow_semantics/query/query_parser.py
@@ -210,7 +210,9 @@ class MetricFlowQueryParser:
                 order_by_name_without_prefix = order_by_name
 
             for group_by_item_naming_scheme in self._group_by_item_naming_schemes:
-                if group_by_item_naming_scheme.input_str_follows_scheme(order_by_name_without_prefix):
+                if group_by_item_naming_scheme.input_str_follows_scheme(
+                    order_by_name_without_prefix, semantic_manifest_lookup=self._manifest_lookup
+                ):
                     possible_inputs.append(
                         ResolverInputForGroupByItem(
                             input_obj=order_by_name,
@@ -223,7 +225,9 @@ class MetricFlowQueryParser:
                     break
 
             for metric_naming_scheme in self._metric_naming_schemes:
-                if metric_naming_scheme.input_str_follows_scheme(order_by_name_without_prefix):
+                if metric_naming_scheme.input_str_follows_scheme(
+                    order_by_name_without_prefix, semantic_manifest_lookup=self._manifest_lookup
+                ):
                     possible_inputs.append(
                         ResolverInputForMetric(
                             input_obj=order_by_name,
@@ -373,7 +377,9 @@ class MetricFlowQueryParser:
         for metric_name in metric_names:
             resolver_input_for_metric: Optional[MetricFlowQueryResolverInput] = None
             for metric_naming_scheme in self._metric_naming_schemes:
-                if metric_naming_scheme.input_str_follows_scheme(metric_name):
+                if metric_naming_scheme.input_str_follows_scheme(
+                    metric_name, semantic_manifest_lookup=self._manifest_lookup
+                ):
                     resolver_input_for_metric = ResolverInputForMetric(
                         input_obj=metric_name,
                         naming_scheme=metric_naming_scheme,
@@ -405,7 +411,9 @@ class MetricFlowQueryParser:
         for group_by_name in group_by_names:
             resolver_input_for_group_by_item: Optional[MetricFlowQueryResolverInput] = None
             for group_by_item_naming_scheme in self._group_by_item_naming_schemes:
-                if group_by_item_naming_scheme.input_str_follows_scheme(group_by_name):
+                if group_by_item_naming_scheme.input_str_follows_scheme(
+                    group_by_name, semantic_manifest_lookup=self._manifest_lookup
+                ):
                     spec_pattern = group_by_item_naming_scheme.spec_pattern(
                         group_by_name, semantic_manifest_lookup=self._manifest_lookup
                     )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_dimension.py
@@ -155,7 +155,5 @@ class WhereFilterDimensionFactory(ProtocolHint[QueryInterfaceDimensionFactory]):
             rendered_spec_tracker=self._rendered_spec_tracker,
             element_name=structured_name.element_name,
             entity_links=tuple(EntityReference(entity_link_name.lower()) for entity_link_name in entity_path)
-            + tuple(
-                EntityReference(entity_link_name.lower()) for entity_link_name in structured_name.entity_link_names
-            ),
+            + structured_name.entity_links,
         )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_dimension.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_dimension.py
@@ -7,7 +7,6 @@ from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     TimeDimensionCallParameterSet,
 )
-from dbt_semantic_interfaces.naming.dundered import DunderedNameFormatter
 from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.protocols.query_interface import (
     QueryInterfaceDimension,
@@ -18,6 +17,7 @@ from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from typing_extensions import override
 
 from metricflow_semantics.errors.error_classes import InvalidQuerySyntax
+from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
     FilterSpecResolutionLookUp,
@@ -134,15 +134,19 @@ class WhereFilterDimensionFactory(ProtocolHint[QueryInterfaceDimensionFactory]):
         spec_resolution_lookup: FilterSpecResolutionLookUp,
         where_filter_location: WhereFilterLocation,
         rendered_spec_tracker: RenderedSpecTracker,
+        custom_granularity_names: Sequence[str],
     ):
         self._column_association_resolver = column_association_resolver
         self._resolved_spec_lookup = spec_resolution_lookup
         self._where_filter_location = where_filter_location
         self._rendered_spec_tracker = rendered_spec_tracker
+        self._custom_granularity_names = custom_granularity_names
 
     def create(self, name: str, entity_path: Sequence[str] = ()) -> WhereFilterDimension:
         """Create a WhereFilterDimension."""
-        structured_name = DunderedNameFormatter.parse_name(name.lower())
+        structured_name = StructuredLinkableSpecName.from_name(
+            name.lower(), custom_granularity_names=self._custom_granularity_names
+        )
 
         return WhereFilterDimension(
             column_association_resolver=self._column_association_resolver,
@@ -151,5 +155,7 @@ class WhereFilterDimensionFactory(ProtocolHint[QueryInterfaceDimensionFactory]):
             rendered_spec_tracker=self._rendered_spec_tracker,
             element_name=structured_name.element_name,
             entity_links=tuple(EntityReference(entity_link_name.lower()) for entity_link_name in entity_path)
-            + structured_name.entity_links,
+            + tuple(
+                EntityReference(entity_link_name.lower()) for entity_link_name in structured_name.entity_link_names
+            ),
         )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_entity.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_entity.py
@@ -5,7 +5,6 @@ from typing import Optional, Sequence
 from dbt_semantic_interfaces.call_parameter_sets import (
     EntityCallParameterSet,
 )
-from dbt_semantic_interfaces.naming.dundered import DunderedNameFormatter
 from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.protocols.query_interface import QueryInterfaceEntity, QueryInterfaceEntityFactory
 from dbt_semantic_interfaces.references import EntityReference
@@ -14,6 +13,7 @@ from dbt_semantic_interfaces.type_enums.date_part import DatePart
 from typing_extensions import override
 
 from metricflow_semantics.errors.error_classes import InvalidQuerySyntax
+from metricflow_semantics.naming.linkable_spec_name import StructuredLinkableSpecName
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_location import WhereFilterLocation
 from metricflow_semantics.query.group_by_item.filter_spec_resolution.filter_spec_lookup import (
     FilterSpecResolutionLookUp,
@@ -103,7 +103,7 @@ class WhereFilterEntityFactory(ProtocolHint[QueryInterfaceEntityFactory]):
 
     def create(self, entity_name: str, entity_path: Sequence[str] = ()) -> WhereFilterEntity:
         """Create a WhereFilterEntity."""
-        structured_name = DunderedNameFormatter.parse_name(entity_name.lower())
+        structured_name = StructuredLinkableSpecName.from_name(entity_name.lower(), custom_granularity_names=())
 
         return WhereFilterEntity(
             column_association_resolver=self._column_association_resolver,
@@ -112,5 +112,7 @@ class WhereFilterEntityFactory(ProtocolHint[QueryInterfaceEntityFactory]):
             rendered_spec_tracker=self._rendered_spec_tracker,
             element_name=structured_name.element_name,
             entity_links=tuple(EntityReference(entity_link_name.lower()) for entity_link_name in entity_path)
-            + structured_name.entity_links,
+            + tuple(
+                EntityReference(entity_link_name.lower()) for entity_link_name in structured_name.entity_link_names
+            ),
         )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_entity.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_entity.py
@@ -112,7 +112,5 @@ class WhereFilterEntityFactory(ProtocolHint[QueryInterfaceEntityFactory]):
             rendered_spec_tracker=self._rendered_spec_tracker,
             element_name=structured_name.element_name,
             entity_links=tuple(EntityReference(entity_link_name.lower()) for entity_link_name in entity_path)
-            + tuple(
-                EntityReference(entity_link_name.lower()) for entity_link_name in structured_name.entity_link_names
-            ),
+            + structured_name.entity_links,
         )

--- a/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
+++ b/metricflow-semantics/metricflow_semantics/specs/where_filter/where_filter_transform.py
@@ -70,6 +70,7 @@ class WhereSpecFactory:
                 spec_resolution_lookup=self._spec_resolution_lookup,
                 where_filter_location=filter_location,
                 rendered_spec_tracker=rendered_spec_tracker,
+                custom_granularity_names=self._semantic_model_lookup.custom_granularity_names,
             )
             time_dimension_factory = WhereFilterTimeDimensionFactory(
                 column_association_resolver=self._column_association_resolver,

--- a/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
+++ b/metricflow-semantics/metricflow_semantics/test_helpers/semantic_manifest_yamls/simple_manifest/metrics.yaml
@@ -720,6 +720,16 @@ metric:
         offset_window: 2 days
 ---
 metric:
+  name: "bookings_offset_martian_day"
+  description: bookings metric offset by a martian day.
+  type: derived
+  type_params:
+    expr: 2 * bookings
+    metrics:
+      - name: bookings
+        offset_window: 1 martian_day
+---
+metric:
   name: bookings_at_start_of_month
   description: |
     Derived metric with offset to grain - single input metric.

--- a/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
+++ b/metricflow-semantics/tests_metricflow_semantics/model/semantics/test_metric_lookup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
 from dbt_semantic_interfaces.references import MetricReference
 from dbt_semantic_interfaces.type_enums import TimeGranularity
 from metricflow_semantics.model.semantic_manifest_lookup import SemanticManifestLookup
@@ -21,3 +22,18 @@ def test_min_queryable_time_granularity_for_different_agg_time_grains(  # noqa: 
     # Since `monthly_bookings_to_daily_bookings` is based on metrics with DAY and MONTH aggregation time grains,
     # the minimum queryable grain should be MONTH.
     assert min_queryable_grain == TimeGranularity.MONTH
+
+
+def test_custom_offset_window_for_metric(
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
+) -> None:
+    """Test offset window with custom grain supplied.
+
+    TODO: As of now, the functionality of an offset window with a custom grain is not supported in MF.
+          This test is added to show that at least the parsing is successful using a custom grain offset window.
+          Once support for that is added in MF + relevant tests, this test can be removed.
+    """
+    metric = simple_semantic_manifest_lookup.metric_lookup.get_metric(MetricReference("bookings_offset_martian_day"))
+
+    assert len(metric.input_metrics) == 1
+    assert metric.input_metrics[0].offset_window == PydanticMetricTimeWindow(count=1, granularity="martian_day")

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_dunder_naming_scheme.py
@@ -75,13 +75,28 @@ def test_input_str(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D
     )
 
 
-def test_input_follows_scheme(dunder_naming_scheme: DunderNamingScheme) -> None:  # noqa: D103
-    assert dunder_naming_scheme.input_str_follows_scheme("listing__country")
-    assert dunder_naming_scheme.input_str_follows_scheme("listing__creation_time__month")
-    assert dunder_naming_scheme.input_str_follows_scheme("booking__listing")
-    assert not dunder_naming_scheme.input_str_follows_scheme("listing__creation_time__extract_month")
-    assert not dunder_naming_scheme.input_str_follows_scheme("123")
-    assert not dunder_naming_scheme.input_str_follows_scheme("TimeDimension('metric_time')")
+def test_input_follows_scheme(  # noqa: D103
+    dunder_naming_scheme: DunderNamingScheme,
+    simple_semantic_manifest_lookup: SemanticManifestLookup,
+) -> None:
+    assert dunder_naming_scheme.input_str_follows_scheme(
+        "listing__country", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert dunder_naming_scheme.input_str_follows_scheme(
+        "listing__creation_time__month", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert dunder_naming_scheme.input_str_follows_scheme(
+        "booking__listing", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert not dunder_naming_scheme.input_str_follows_scheme(
+        "listing__creation_time__extract_month", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert not dunder_naming_scheme.input_str_follows_scheme(
+        "123", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert not dunder_naming_scheme.input_str_follows_scheme(
+        "TimeDimension('metric_time')", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
 
 
 def test_spec_pattern(  # noqa: D103

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_metric_name_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_metric_name_scheme.py
@@ -19,8 +19,12 @@ def test_input_str(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D
     assert metric_naming_scheme.input_str(MetricSpec(element_name="bookings")) == "bookings"
 
 
-def test_input_follows_scheme(metric_naming_scheme: MetricNamingScheme) -> None:  # noqa: D103
-    assert metric_naming_scheme.input_str_follows_scheme("listings")
+def test_input_follows_scheme(  # noqa: D103
+    metric_naming_scheme: MetricNamingScheme, simple_semantic_manifest_lookup: SemanticManifestLookup
+) -> None:
+    assert metric_naming_scheme.input_str_follows_scheme(
+        "listings", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
 
 
 def test_spec_pattern(  # noqa: D103

--- a/metricflow-semantics/tests_metricflow_semantics/naming/test_object_builder_naming_scheme.py
+++ b/metricflow-semantics/tests_metricflow_semantics/naming/test_object_builder_naming_scheme.py
@@ -67,20 +67,30 @@ def test_input_str(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> N
     assert object_builder_naming_scheme.input_str(MetricSpec("bookings")) is None
 
 
-def test_input_follows_scheme(object_builder_naming_scheme: ObjectBuilderNamingScheme) -> None:  # noqa: D103
+def test_input_follows_scheme(  # noqa: D103
+    object_builder_naming_scheme: ObjectBuilderNamingScheme, simple_semantic_manifest_lookup: SemanticManifestLookup
+) -> None:
     assert object_builder_naming_scheme.input_str_follows_scheme(
-        "Dimension('listing__country', entity_path=['booking'])"
+        "Dimension('listing__country', entity_path=['booking'])",
+        semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )
     assert object_builder_naming_scheme.input_str_follows_scheme(
         "TimeDimension('listing__creation_time', time_granularity_name='month', date_part_name='day', "
-        "entity_path=['booking'])"
+        "entity_path=['booking'])",
+        semantic_manifest_lookup=simple_semantic_manifest_lookup,
     )
     assert object_builder_naming_scheme.input_str_follows_scheme(
-        "Entity('user', entity_path=['booking', 'listing'])",
+        "Entity('user', entity_path=['booking', 'listing'])", semantic_manifest_lookup=simple_semantic_manifest_lookup
     )
-    assert not object_builder_naming_scheme.input_str_follows_scheme("listing__creation_time__extract_month")
-    assert not object_builder_naming_scheme.input_str_follows_scheme("123")
-    assert not object_builder_naming_scheme.input_str_follows_scheme("NotADimension('listing__country')")
+    assert not object_builder_naming_scheme.input_str_follows_scheme(
+        "listing__creation_time__extract_month", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert not object_builder_naming_scheme.input_str_follows_scheme(
+        "123", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
+    assert not object_builder_naming_scheme.input_str_follows_scheme(
+        "NotADimension('listing__country')", semantic_manifest_lookup=simple_semantic_manifest_lookup
+    )
 
 
 def test_spec_pattern(  # noqa: D103

--- a/metricflow/dataflow/nodes/join_conversion_events.py
+++ b/metricflow/dataflow/nodes/join_conversion_events.py
@@ -78,7 +78,7 @@ class JoinConversionEventsNode(DataflowPlanNode):
 
     @property
     def description(self) -> str:  # noqa: D102
-        return f"Find conversions for {self.entity_spec.qualified_name} within the range of {f'{self.window.count} {self.window.granularity.value}' if self.window else 'INF'}"
+        return f"Find conversions for {self.entity_spec.qualified_name} within the range of {f'{self.window.count} {self.window.granularity}' if self.window else 'INF'}"
 
     @property
     def displayed_properties(self) -> Sequence[DisplayedProperty]:  # noqa: D102

--- a/metricflow/engine/models.py
+++ b/metricflow/engine/models.py
@@ -16,7 +16,12 @@ from dbt_semantic_interfaces.protocols.export import Export
 from dbt_semantic_interfaces.protocols.measure import MeasureAggregationParameters
 from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.metric import Metric as SemanticManifestMetric
-from dbt_semantic_interfaces.protocols.metric import MetricConfig, MetricInputMeasure, MetricType, MetricTypeParams
+from dbt_semantic_interfaces.protocols.metric import (
+    MetricInputMeasure,
+    MetricType,
+    MetricTypeParams,
+    SemanticLayerElementConfig,
+)
 from dbt_semantic_interfaces.protocols.saved_query import (
     SavedQuery as SemanticManifestSavedQuery,
 )
@@ -44,7 +49,7 @@ class Metric:
     metadata: Optional[Metadata]
     dimensions: List[Dimension]
     label: Optional[str]
-    config: Optional[MetricConfig]
+    config: Optional[SemanticLayerElementConfig]
 
     @classmethod
     def from_pydantic(cls, pydantic_metric: SemanticManifestMetric, dimensions: List[Dimension]) -> Metric:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "update-checker>=0.18.0, <0.19.0",
   # Bug with mypy: https://github.com/pallets/click/issues/2558#issuecomment-1656546003
   "click>=8.1.6",
-  "dbt-core @ git+https://github.com/dbt-labs/dbt-core@84eb0ff6720ec82ce4015c2657d512bf51381732#subdirectory=core",
+  "dbt-core @ git+https://github.com/dbt-labs/dbt-core@ff6745c79532d50139d553f3b088c5d783b4f2dd#subdirectory=core",
   "dbt-duckdb>=1.8.0, <1.9.0",
 ]
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -685,7 +685,7 @@ def test_join_to_time_spine_node_with_offset_window(
         time_range_constraint=TimeRangeConstraint(
             start_time=as_datetime("2020-01-01"), end_time=as_datetime("2021-01-01")
         ),
-        offset_window=PydanticMetricTimeWindow(count=10, granularity=TimeGranularity.DAY),
+        offset_window=PydanticMetricTimeWindow(count=10, granularity=TimeGranularity.DAY.value),
         join_type=SqlJoinType.INNER,
     )
 

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_non_default_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_non_default_grain__dfp_0.xml
@@ -62,7 +62,7 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),   -->
                             <!--     ),                                                                              -->
                             <!--   )                                                                                 -->
-                            <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
+                            <!-- window = PydanticMetricTimeWindow(count=2, granularity='month') -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                 <!-- node_id = NodeId(id_str='sma_28015') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_cumulative_metric_with_window__dfp_0.xml
@@ -35,7 +35,7 @@ docstring:
                         <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                         <!--     ),                                                                            -->
                         <!--   )                                                                               -->
-                        <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
+                        <!-- window = PydanticMetricTimeWindow(count=2, granularity='month') -->
                         <MetricTimeDimensionTransformNode>
                             <!-- description = "Metric Time Dimension 'ds'" -->
                             <!-- node_id = NodeId(id_str='sma_28015') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_cumulative_metric_with_non_default_grain__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_cumulative_metric_with_non_default_grain__dfp_0.xml
@@ -75,7 +75,7 @@ docstring:
                                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY),     -->
                                 <!--     ),                                                                                -->
                                 <!--   )                                                                                   -->
-                                <!-- window = PydanticMetricTimeWindow(count=2, granularity=MONTH) -->
+                                <!-- window = PydanticMetricTimeWindow(count=2, granularity='month') -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                     <!-- node_id = NodeId(id_str='sma_28015') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_window__dfp_0.xml
@@ -14,13 +14,13 @@ docstring:
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
-                <!-- metric_spec =                                                         -->
-                <!--   MetricSpec(                                                         -->
-                <!--     element_name='bookings',                                          -->
-                <!--     filter_spec_set=WhereFilterSpecSet(),                             -->
-                <!--     alias='bookings_5_days_ago',                                      -->
-                <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity=DAY), -->
-                <!--   )                                                                   -->
+                <!-- metric_spec =                                                           -->
+                <!--   MetricSpec(                                                           -->
+                <!--     element_name='bookings',                                            -->
+                <!--     filter_spec_set=WhereFilterSpecSet(),                               -->
+                <!--     alias='bookings_5_days_ago',                                        -->
+                <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity='day'), -->
+                <!--   )                                                                     -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
                     <!-- node_id = NodeId(id_str='am_0') -->
@@ -46,7 +46,7 @@ docstring:
                             <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
+                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                 <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_metric_offset_with_granularity__dfp_0.xml
@@ -12,13 +12,13 @@ test_filename: test_dataflow_plan_builder.py
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
-                <!-- metric_spec =                                                         -->
-                <!--   MetricSpec(                                                         -->
-                <!--     element_name='bookings',                                          -->
-                <!--     filter_spec_set=WhereFilterSpecSet(),                             -->
-                <!--     alias='bookings_5_days_ago',                                      -->
-                <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity=DAY), -->
-                <!--   )                                                                   -->
+                <!-- metric_spec =                                                           -->
+                <!--   MetricSpec(                                                           -->
+                <!--     element_name='bookings',                                            -->
+                <!--     filter_spec_set=WhereFilterSpecSet(),                               -->
+                <!--     alias='bookings_5_days_ago',                                        -->
+                <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity='day'), -->
+                <!--   )                                                                     -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
                     <!-- node_id = NodeId(id_str='am_0') -->
@@ -44,7 +44,7 @@ test_filename: test_dataflow_plan_builder.py
                             <!--   )                                                                                   -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
+                            <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                             <MetricTimeDimensionTransformNode>
                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                 <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_derived_offset_cumulative_metric__dfp_0.xml
@@ -13,13 +13,13 @@ test_filename: test_dataflow_plan_builder.py
             <ComputeMetricsNode>
                 <!-- description = 'Compute Metrics via Expressions' -->
                 <!-- node_id = NodeId(id_str='cm_0') -->
-                <!-- metric_spec =                                                         -->
-                <!--   MetricSpec(                                                         -->
-                <!--     element_name='every_two_days_bookers',                            -->
-                <!--     filter_spec_set=WhereFilterSpecSet(),                             -->
-                <!--     alias='every_2_days_bookers_2_days_ago',                          -->
-                <!--     offset_window=PydanticMetricTimeWindow(count=2, granularity=DAY), -->
-                <!--   )                                                                   -->
+                <!-- metric_spec =                                                           -->
+                <!--   MetricSpec(                                                           -->
+                <!--     element_name='every_two_days_bookers',                              -->
+                <!--     filter_spec_set=WhereFilterSpecSet(),                               -->
+                <!--     alias='every_2_days_bookers_2_days_ago',                            -->
+                <!--     offset_window=PydanticMetricTimeWindow(count=2, granularity='day'), -->
+                <!--   )                                                                     -->
                 <AggregateMeasuresNode>
                     <!-- description = 'Aggregate Measures' -->
                     <!-- node_id = NodeId(id_str='am_0') -->
@@ -45,7 +45,7 @@ test_filename: test_dataflow_plan_builder.py
                             <!--   )                                                                               -->
                             <!-- use_custom_agg_time_dimension = False -->
                             <!-- join_type = INNER -->
-                            <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                            <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                             <JoinOverTimeRangeNode>
                                 <!-- description = 'Join Self Over Time Range' -->
                                 <!-- node_id = NodeId(id_str='jotr_0') -->
@@ -56,7 +56,7 @@ test_filename: test_dataflow_plan_builder.py
                                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                 <!--     ),                                                                            -->
                                 <!--   )                                                                               -->
-                                <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                                <!-- window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                     <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_join_to_time_spine_derived_metric__dfp_0.xml
@@ -63,13 +63,13 @@ test_filename: test_dataflow_plan_builder.py
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                          -->
-                    <!--   MetricSpec(                                                          -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                         -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(),                              -->
-                    <!--     alias='bookings_2_weeks_ago',                                      -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY), -->
-                    <!--   )                                                                    -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                           -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(),                                -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
@@ -107,7 +107,7 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--   )                                                                               -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                    <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_nested_derived_metric_with_outer_offset__dfp_0.xml
@@ -21,25 +21,25 @@ test_filename: test_dataflow_plan_builder.py
                 <!--   )                                                                               -->
                 <!-- use_custom_agg_time_dimension = False -->
                 <!-- join_type = INNER -->
-                <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                <!-- offset_window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                         -->
-                    <!--   MetricSpec(                                                         -->
-                    <!--     element_name='bookings_offset_once',                              -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(),                             -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=2, granularity=DAY), -->
-                    <!--   )                                                                   -->
+                    <!-- metric_spec =                                                           -->
+                    <!--   MetricSpec(                                                           -->
+                    <!--     element_name='bookings_offset_once',                                -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(),                               -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=2, granularity='day'), -->
+                    <!--   )                                                                     -->
                     <ComputeMetricsNode>
                         <!-- description = 'Compute Metrics via Expressions' -->
                         <!-- node_id = NodeId(id_str='cm_0') -->
-                        <!-- metric_spec =                                                         -->
-                        <!--   MetricSpec(                                                         -->
-                        <!--     element_name='bookings',                                          -->
-                        <!--     filter_spec_set=WhereFilterSpecSet(),                             -->
-                        <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity=DAY), -->
-                        <!--   )                                                                   -->
+                        <!-- metric_spec =                                                           -->
+                        <!--   MetricSpec(                                                           -->
+                        <!--     element_name='bookings',                                            -->
+                        <!--     filter_spec_set=WhereFilterSpecSet(),                               -->
+                        <!--     offset_window=PydanticMetricTimeWindow(count=5, granularity='day'), -->
+                        <!--   )                                                                     -->
                         <AggregateMeasuresNode>
                             <!-- description = 'Aggregate Measures' -->
                             <!-- node_id = NodeId(id_str='am_0') -->
@@ -65,7 +65,7 @@ test_filename: test_dataflow_plan_builder.py
                                     <!--   )                                                                               -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity=DAY) -->
+                                    <!-- offset_window = PydanticMetricTimeWindow(count=5, granularity='day') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_plan_builder.py/DataflowPlan/test_offset_window_metric_filter_and_query_have_different_granularities__dfp_0.xml
@@ -62,53 +62,53 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_0') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='booking_value',                                       -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql="metric_time__day = '2020-01-01'",                  -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   METRIC_TIME,                                          -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='metric_time',                             -->
-                    <!--                 dimension_type=TIME,                                    -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 time_granularity=ExpandedTimeGranularity(               -->
-                    <!--                   name='day',                                           -->
-                    <!--                   base_granularity=DAY,                                 -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             time_dimension_specs=(                                      -->
-                    <!--               TimeDimensionSpec(                                        -->
-                    <!--                 element_name='metric_time',                             -->
-                    <!--                 time_granularity=ExpandedTimeGranularity(               -->
-                    <!--                   name='day',                                           -->
-                    <!--                   base_granularity=DAY,                                 -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=1, granularity=WEEK),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='booking_value',                                        -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql="metric_time__day = '2020-01-01'",                   -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   METRIC_TIME,                                           -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='metric_time',                              -->
+                    <!--                 dimension_type=TIME,                                     -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 time_granularity=ExpandedTimeGranularity(                -->
+                    <!--                   name='day',                                            -->
+                    <!--                   base_granularity=DAY,                                  -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             time_dimension_specs=(                                       -->
+                    <!--               TimeDimensionSpec(                                         -->
+                    <!--                 element_name='metric_time',                              -->
+                    <!--                 time_granularity=ExpandedTimeGranularity(                -->
+                    <!--                   name='day',                                            -->
+                    <!--                   base_granularity=DAY,                                  -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=1, granularity='week'), -->
+                    <!--   )                                                                      -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_0') -->
@@ -177,7 +177,7 @@ docstring:
                                     <!--   )                                             -->
                                     <!-- use_custom_agg_time_dimension = False -->
                                     <!-- join_type = INNER -->
-                                    <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity=WEEK) -->
+                                    <!-- offset_window = PydanticMetricTimeWindow(count=1, granularity='week') -->
                                     <MetricTimeDimensionTransformNode>
                                         <!-- description = "Metric Time Dimension 'ds'" -->
                                         <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/DataflowPlan/test_join_to_time_spine_node_with_offset_window__plan0.xml
@@ -19,7 +19,7 @@ docstring:
             <!--   )                                                                               -->
             <!-- use_custom_agg_time_dimension = False -->
             <!-- join_type = INNER -->
-            <!-- offset_window = PydanticMetricTimeWindow(count=10, granularity=DAY) -->
+            <!-- offset_window = PydanticMetricTimeWindow(count=10, granularity='day') -->
             <!-- time_range_constraint =                             -->
             <!--   TimeRangeConstraint(                              -->
             <!--     start_time=datetime.datetime(2020, 1, 1, 0, 0), -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfp_0.xml
@@ -191,7 +191,7 @@ docstring:
                             <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--   )                                                                             -->
                             <!-- entity_spec = EntitySpec(element_name='user') -->
-                            <!-- window = PydanticMetricTimeWindow(count=7, granularity=DAY) -->
+                            <!-- window = PydanticMetricTimeWindow(count=7, granularity='day') -->
                             <!-- unique_key_specs = MetadataSpec(element_name='mf_internal_uuid') -->
                             <FilterElementsNode>
                                 <!-- description =                                                                         -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_conversion_metric_predicate_pushdown__dfpo_0.xml
@@ -191,7 +191,7 @@ docstring:
                             <!--     time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--   )                                                                             -->
                             <!-- entity_spec = EntitySpec(element_name='user') -->
-                            <!-- window = PydanticMetricTimeWindow(count=7, granularity=DAY) -->
+                            <!-- window = PydanticMetricTimeWindow(count=7, granularity='day') -->
                             <!-- unique_key_specs = MetadataSpec(element_name='mf_internal_uuid') -->
                             <FilterElementsNode>
                                 <!-- description =                                                                         -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfp_0.xml
@@ -145,7 +145,7 @@ docstring:
                                 <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                                 <!--     ),                                                                            -->
                                 <!--   )                                                                               -->
-                                <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                                <!-- window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                                 <MetricTimeDimensionTransformNode>
                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                     <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_cumulative_metric_predicate_pushdown__dfpo_0.xml
@@ -103,7 +103,7 @@ docstring:
                             <!--       time_granularity=ExpandedTimeGranularity(name='day', base_granularity=DAY), -->
                             <!--     ),                                                                            -->
                             <!--   )                                                                               -->
-                            <!-- window = PydanticMetricTimeWindow(count=2, granularity=DAY) -->
+                            <!-- window = PydanticMetricTimeWindow(count=2, granularity='day') -->
                             <WhereConstraintNode>
                                 <!-- description = 'Constrain Output with WHERE' -->
                                 <!-- node_id = NodeId(id_str='wcc_1') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfp_0.xml
@@ -237,56 +237,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                          -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                           -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_2') -->
@@ -384,7 +384,7 @@ docstring:
                                             <!--   )                                             -->
                                             <!-- use_custom_agg_time_dimension = False -->
                                             <!-- join_type = INNER -->
-                                            <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                            <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                                 <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_predicate_pushdown__dfpo_0.xml
@@ -236,56 +236,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_4') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                          -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                           -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <JoinToTimeSpineNode>
                         <!-- description = 'Join to Time Spine Dataset' -->
                         <!-- node_id = NodeId(id_str='jts_5') -->
@@ -383,7 +383,7 @@ docstring:
                                             <!--   )                                             -->
                                             <!-- use_custom_agg_time_dimension = False -->
                                             <!-- join_type = INNER -->
-                                            <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                            <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                             <MetricTimeDimensionTransformNode>
                                                 <!-- description = "Metric Time Dimension 'ds'" -->
                                                 <!-- node_id = NodeId(id_str='sma_2') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfp_0.xml
@@ -294,56 +294,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                          -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                           -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_3') -->
@@ -490,7 +490,8 @@ docstring:
                                                 <!--   )                                             -->
                                                 <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- join_type = INNER -->
-                                                <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                                <!-- offset_window =                                         -->
+                                                <!--   PydanticMetricTimeWindow(count=14, granularity='day') -->
                                                 <MetricTimeDimensionTransformNode>
                                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                                     <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_fill_nulls_time_spine_metric_with_post_agg_join_predicate_pushdown__dfpo_0.xml
@@ -294,56 +294,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_4') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings_fill_nulls_with_0',                          -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings_fill_nulls_with_0',                           -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <WhereConstraintNode>
                         <!-- description = 'Constrain Output with WHERE' -->
                         <!-- node_id = NodeId(id_str='wcc_7') -->
@@ -490,7 +490,8 @@ docstring:
                                                 <!--   )                                             -->
                                                 <!-- use_custom_agg_time_dimension = False -->
                                                 <!-- join_type = INNER -->
-                                                <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                                <!-- offset_window =                                         -->
+                                                <!--   PydanticMetricTimeWindow(count=14, granularity='day') -->
                                                 <MetricTimeDimensionTransformNode>
                                                     <!-- description = "Metric Time Dimension 'ds'" -->
                                                     <!-- node_id = NodeId(id_str='sma_2') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfp_0.xml
@@ -224,56 +224,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_1') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings',                                            -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings',                                             -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_1') -->
@@ -359,7 +359,7 @@ docstring:
                                         <!--   )                                             -->
                                         <!-- use_custom_agg_time_dimension = False -->
                                         <!-- join_type = INNER -->
-                                        <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                        <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                         <MetricTimeDimensionTransformNode>
                                             <!-- description = "Metric Time Dimension 'ds'" -->
                                             <!-- node_id = NodeId(id_str='sma_28009') -->

--- a/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
+++ b/tests_metricflow/snapshots/test_predicate_pushdown_optimizer.py/DataflowPlan/test_offset_metric_predicate_pushdown__dfpo_0.xml
@@ -224,56 +224,56 @@ docstring:
                 <ComputeMetricsNode>
                     <!-- description = 'Compute Metrics via Expressions' -->
                     <!-- node_id = NodeId(id_str='cm_4') -->
-                    <!-- metric_spec =                                                           -->
-                    <!--   MetricSpec(                                                           -->
-                    <!--     element_name='bookings',                                            -->
-                    <!--     filter_spec_set=WhereFilterSpecSet(                                 -->
-                    <!--       query_level_filter_specs=(                                        -->
-                    <!--         WhereFilterSpec(                                                -->
-                    <!--           where_sql='booking__is_instant',                              -->
-                    <!--           bind_parameters=SqlBindParameterSet(),                        -->
-                    <!--           linkable_element_unions=(                                     -->
-                    <!--             LinkableElementUnion(                                       -->
-                    <!--               linkable_dimension=LinkableDimension(                     -->
-                    <!--                 properties=(                                            -->
-                    <!--                   LOCAL,                                                -->
-                    <!--                 ),                                                      -->
-                    <!--                 defined_in_semantic_model=SemanticModelReference(       -->
-                    <!--                   semantic_model_name='bookings_source',                -->
-                    <!--                 ),                                                      -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 dimension_type=CATEGORICAL,                             -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--                 join_path=SemanticModelJoinPath(                        -->
-                    <!--                   left_semantic_model_reference=SemanticModelReference( -->
-                    <!--                     semantic_model_name='bookings_source',              -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--           linkable_spec_set=LinkableSpecSet(                            -->
-                    <!--             dimension_specs=(                                           -->
-                    <!--               DimensionSpec(                                            -->
-                    <!--                 element_name='is_instant',                              -->
-                    <!--                 entity_links=(                                          -->
-                    <!--                   EntityReference(                                      -->
-                    <!--                     element_name='booking',                             -->
-                    <!--                   ),                                                    -->
-                    <!--                 ),                                                      -->
-                    <!--               ),                                                        -->
-                    <!--             ),                                                          -->
-                    <!--           ),                                                            -->
-                    <!--         ),                                                              -->
-                    <!--       ),                                                                -->
-                    <!--     ),                                                                  -->
-                    <!--     alias='bookings_2_weeks_ago',                                       -->
-                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity=DAY),  -->
-                    <!--   )                                                                     -->
+                    <!-- metric_spec =                                                            -->
+                    <!--   MetricSpec(                                                            -->
+                    <!--     element_name='bookings',                                             -->
+                    <!--     filter_spec_set=WhereFilterSpecSet(                                  -->
+                    <!--       query_level_filter_specs=(                                         -->
+                    <!--         WhereFilterSpec(                                                 -->
+                    <!--           where_sql='booking__is_instant',                               -->
+                    <!--           bind_parameters=SqlBindParameterSet(),                         -->
+                    <!--           linkable_element_unions=(                                      -->
+                    <!--             LinkableElementUnion(                                        -->
+                    <!--               linkable_dimension=LinkableDimension(                      -->
+                    <!--                 properties=(                                             -->
+                    <!--                   LOCAL,                                                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 defined_in_semantic_model=SemanticModelReference(        -->
+                    <!--                   semantic_model_name='bookings_source',                 -->
+                    <!--                 ),                                                       -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 dimension_type=CATEGORICAL,                              -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--                 join_path=SemanticModelJoinPath(                         -->
+                    <!--                   left_semantic_model_reference=SemanticModelReference(  -->
+                    <!--                     semantic_model_name='bookings_source',               -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--           linkable_spec_set=LinkableSpecSet(                             -->
+                    <!--             dimension_specs=(                                            -->
+                    <!--               DimensionSpec(                                             -->
+                    <!--                 element_name='is_instant',                               -->
+                    <!--                 entity_links=(                                           -->
+                    <!--                   EntityReference(                                       -->
+                    <!--                     element_name='booking',                              -->
+                    <!--                   ),                                                     -->
+                    <!--                 ),                                                       -->
+                    <!--               ),                                                         -->
+                    <!--             ),                                                           -->
+                    <!--           ),                                                             -->
+                    <!--         ),                                                               -->
+                    <!--       ),                                                                 -->
+                    <!--     ),                                                                   -->
+                    <!--     alias='bookings_2_weeks_ago',                                        -->
+                    <!--     offset_window=PydanticMetricTimeWindow(count=14, granularity='day'), -->
+                    <!--   )                                                                      -->
                     <AggregateMeasuresNode>
                         <!-- description = 'Aggregate Measures' -->
                         <!-- node_id = NodeId(id_str='am_3') -->
@@ -359,7 +359,7 @@ docstring:
                                         <!--   )                                             -->
                                         <!-- use_custom_agg_time_dimension = False -->
                                         <!-- join_type = INNER -->
-                                        <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity=DAY) -->
+                                        <!-- offset_window = PydanticMetricTimeWindow(count=14, granularity='day') -->
                                         <MetricTimeDimensionTransformNode>
                                             <!-- description = "Metric Time Dimension 'ds'" -->
                                             <!-- node_id = NodeId(id_str='sma_2') -->


### PR DESCRIPTION
## Context

We merged 2 breaking changes in DSI https://github.com/dbt-labs/dbt-semantic-interfaces/pull/363 and https://github.com/dbt-labs/dbt-semantic-interfaces/pull/365 which changed most spec typing that used time granularity to be a `str` instead of `TimeGranularity` to enable support for custom granularity. Similarly, there were additional breaking changes to the objects that requires passing in `custom_granularity_names`. This PR updates all those callsites to be compatible with the new version of DSI (to be released)

Resolves SL-3097
