### PR TITLE
Update default SQL optimization level to use CTEs

### DIFF
--- a/.changes/unreleased/Features-20241112-215817.yaml
+++ b/.changes/unreleased/Features-20241112-215817.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Use CTEs instead of sub-queries in generated SQL.
+time: 2024-11-12T21:58:17.127471-08:00
+custom:
+  Author: plypaul
+  Issue: "1040"

--- a/metricflow/engine/metricflow_engine.py
+++ b/metricflow/engine/metricflow_engine.py
@@ -100,21 +100,21 @@ class MetricFlowQueryRequest:
     """
 
     request_id: MetricFlowRequestId
-    saved_query_name: Optional[str] = None
-    metric_names: Optional[Sequence[str]] = None
-    metrics: Optional[Sequence[MetricQueryParameter]] = None
-    group_by_names: Optional[Sequence[str]] = None
-    group_by: Optional[Tuple[GroupByParameter, ...]] = None
-    limit: Optional[int] = None
-    time_constraint_start: Optional[datetime.datetime] = None
-    time_constraint_end: Optional[datetime.datetime] = None
-    where_constraints: Optional[Sequence[str]] = None
-    order_by_names: Optional[Sequence[str]] = None
-    order_by: Optional[Sequence[OrderByQueryParameter]] = None
-    min_max_only: bool = False
-    sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4
-    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization] = DataflowPlanOptimization.enabled_optimizations()
-    query_type: MetricFlowQueryType = MetricFlowQueryType.METRIC
+    saved_query_name: Optional[str]
+    metric_names: Optional[Sequence[str]]
+    metrics: Optional[Sequence[MetricQueryParameter]]
+    group_by_names: Optional[Sequence[str]]
+    group_by: Optional[Tuple[GroupByParameter, ...]]
+    limit: Optional[int]
+    time_constraint_start: Optional[datetime.datetime]
+    time_constraint_end: Optional[datetime.datetime]
+    where_constraints: Optional[Sequence[str]]
+    order_by_names: Optional[Sequence[str]]
+    order_by: Optional[Sequence[OrderByQueryParameter]]
+    min_max_only: bool
+    sql_optimization_level: SqlQueryOptimizationLevel
+    dataflow_plan_optimizations: FrozenSet[DataflowPlanOptimization]
+    query_type: MetricFlowQueryType
 
     @staticmethod
     def create_with_random_request_id(  # noqa: D102
@@ -129,7 +129,7 @@ class MetricFlowQueryRequest:
         where_constraints: Optional[Sequence[str]] = None,
         order_by_names: Optional[Sequence[str]] = None,
         order_by: Optional[Sequence[OrderByQueryParameter]] = None,
-        sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
+        sql_optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.default_level(),
         dataflow_plan_optimizations: FrozenSet[
             DataflowPlanOptimization
         ] = DataflowPlanOptimization.enabled_optimizations(),

--- a/metricflow/plan_conversion/dataflow_to_sql.py
+++ b/metricflow/plan_conversion/dataflow_to_sql.py
@@ -182,7 +182,7 @@ class DataflowToSqlQueryPlanConverter:
         self,
         sql_engine_type: SqlEngine,
         dataflow_plan_node: DataflowPlanNode,
-        optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.O4,
+        optimization_level: SqlQueryOptimizationLevel = SqlQueryOptimizationLevel.default_level(),
         sql_query_plan_id: Optional[DagId] = None,
     ) -> ConvertToSqlPlanResult:
         """Create an SQL query plan that represents the computation up to the given dataflow plan node."""

--- a/metricflow/sql/optimizer/optimization_levels.py
+++ b/metricflow/sql/optimizer/optimization_levels.py
@@ -25,7 +25,7 @@ class SqlQueryOptimizationLevel(Enum):
 
     @staticmethod
     def default_level() -> SqlQueryOptimizationLevel:  # noqa: D102
-        return SqlQueryOptimizationLevel.O4
+        return SqlQueryOptimizationLevel.O5
 
 
 @dataclass(frozen=True)

--- a/tests_metricflow/examples/test_node_sql.py
+++ b/tests_metricflow/examples/test_node_sql.py
@@ -20,7 +20,6 @@ from metricflow.dataflow.nodes.read_sql_source import ReadSqlSourceNode
 from metricflow.dataset.convert_semantic_model import SemanticModelToDataSetConverter
 from metricflow.plan_conversion.dataflow_to_sql import DataflowToSqlQueryPlanConverter
 from metricflow.protocols.sql_client import SqlClient
-from metricflow.sql.optimizer.optimization_levels import SqlQueryOptimizationLevel
 from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
 
 logger = logging.getLogger(__name__)
@@ -57,7 +56,6 @@ def test_view_sql_generated_at_a_node(
     conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=read_source_node,
-        optimization_level=SqlQueryOptimizationLevel.O4,
     )
     sql_plan_at_read_node = conversion_result.sql_plan
     sql_at_read_node = sql_renderer.render_sql_query_plan(sql_plan_at_read_node).sql
@@ -86,7 +84,6 @@ def test_view_sql_generated_at_a_node(
     conversion_result = to_sql_plan_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=filter_elements_node,
-        optimization_level=SqlQueryOptimizationLevel.O4,
     )
     sql_plan_at_filter_elements_node = conversion_result.sql_plan
     sql_at_filter_elements_node = sql_renderer.render_sql_query_plan(sql_plan_at_filter_elements_node).sql

--- a/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_execution.py
@@ -31,7 +31,7 @@ def make_execution_plan_converter(  # noqa: D103
         ),
         sql_plan_renderer=DefaultSqlQueryPlanRenderer(),
         sql_client=sql_client,
-        sql_optimization_level=SqlQueryOptimizationLevel.O4,
+        sql_optimization_level=SqlQueryOptimizationLevel.default_level(),
     )
 
 

--- a/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
+++ b/tests_metricflow/plan_conversion/test_dataflow_to_sql_plan.py
@@ -98,7 +98,6 @@ def convert_and_check(
         sql_engine_type=sql_client.sql_engine_type,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),
         dataflow_plan_node=node,
-        optimization_level=SqlQueryOptimizationLevel.O4,
     )
     sql_query_plan = conversion_result.sql_plan
     display_graph_if_requested(

--- a/tests_metricflow/query_rendering/compare_rendered_query.py
+++ b/tests_metricflow/query_rendering/compare_rendered_query.py
@@ -63,7 +63,6 @@ def render_and_check(
     conversion_result = dataflow_to_sql_converter.convert_to_sql_query_plan(
         sql_engine_type=sql_client.sql_engine_type,
         dataflow_plan_node=optimized_plan.sink_node,
-        optimization_level=SqlQueryOptimizationLevel.O4,
         sql_query_plan_id=DagId.from_str("plan0_optimized"),
     )
     sql_query_plan = conversion_result.sql_plan

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATE_SUB(CAST(subq_24.metric_time__day AS DATETIME), INTERVAL 7 day)
+          sma_28019_cte.metric_time__day > DATE_SUB(CAST(subq_23.metric_time__day AS DATETIME), INTERVAL 7 day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATETIME_TRUNC(ds, day) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , GENERATE_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > DATE_SUB(CAST(subq_33.metric_time__day AS DATETIME), INTERVAL 7 day)
+              sma_28019_cte.metric_time__day > DATE_SUB(CAST(subq_32.metric_time__day AS DATETIME), INTERVAL 7 day)
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
     metric_time__day
-) subq_41
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
     visit__referrer_id
-) subq_29
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATE_SUB(CAST(subq_24.metric_time__day AS DATETIME), INTERVAL 7 day)
+            sma_28019_cte.metric_time__day > DATE_SUB(CAST(subq_23.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_29
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_18.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS FLOAT64) / CAST(NULLIF(MAX(subq_18.visits), 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GENERATE_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATE_SUB(CAST(subq_24.metric_time__day AS DATETIME), INTERVAL 7 day)
+          sma_28019_cte.metric_time__day > DATE_SUB(CAST(subq_23.metric_time__day AS DATETIME), INTERVAL 7 day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/BigQuery/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATETIME_TRUNC(ds, day) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS FLOAT64) / CAST(NULLIF(visits, 0) AS FLOAT64) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATETIME_TRUNC(ds, day) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATETIME_TRUNC(ds, day) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , GENERATE_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATE_SUB(CAST(subq_24.metric_time__day AS DATETIME), INTERVAL 7 day)
+            sma_28019_cte.metric_time__day > DATE_SUB(CAST(subq_23.metric_time__day AS DATETIME), INTERVAL 7 day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
     metric_time__day
     , visit__referrer_id
-) subq_29
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > DATEADD(day, -7, subq_33.metric_time__day)
+              sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day)
-) subq_41
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Databricks/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > subq_24.metric_time__day - INTERVAL 7 day
+          sma_28019_cte.metric_time__day > subq_23.metric_time__day - INTERVAL 7 day
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , GEN_RANDOM_UUID() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > subq_33.metric_time__day - INTERVAL 7 day
+              sma_28019_cte.metric_time__day > subq_32.metric_time__day - INTERVAL 7 day
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day)
-) subq_41
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > subq_24.metric_time__day - INTERVAL 7 day
+            sma_28019_cte.metric_time__day > subq_23.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > subq_24.metric_time__day - INTERVAL 7 day
+          sma_28019_cte.metric_time__day > subq_23.metric_time__day - INTERVAL 7 day
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/DuckDB/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > subq_24.metric_time__day - INTERVAL 7 day
+            sma_28019_cte.metric_time__day > subq_23.metric_time__day - INTERVAL 7 day
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > subq_24.metric_time__day - MAKE_INTERVAL(days => 7)
+          sma_28019_cte.metric_time__day > subq_23.metric_time__day - MAKE_INTERVAL(days => 7)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > subq_24.metric_time__day - MAKE_INTERVAL(days => 7)
+            sma_28019_cte.metric_time__day > subq_23.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , GEN_RANDOM_UUID() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > subq_24.metric_time__day - MAKE_INTERVAL(days => 7)
+          sma_28019_cte.metric_time__day > subq_23.metric_time__day - MAKE_INTERVAL(days => 7)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Postgres/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , GEN_RANDOM_UUID() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > subq_24.metric_time__day - MAKE_INTERVAL(days => 7)
+            sma_28019_cte.metric_time__day > subq_23.metric_time__day - MAKE_INTERVAL(days => 7)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > DATEADD(day, -7, subq_33.metric_time__day)
+              sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day)
-) subq_41
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE PRECISION) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Redshift/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE PRECISION) / CAST(NULLIF(visits, 0) AS DOUBLE PRECISION) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , CONCAT(CAST(RANDOM()*100000000 AS INT)::VARCHAR,CAST(RANDOM()*100000000 AS INT)::VARCHAR) AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID_STRING() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , UUID_STRING() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > DATEADD(day, -7, subq_33.metric_time__day)
+              sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_32.metric_time__day)
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day)
-) subq_41
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , UUID_STRING() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Snowflake/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , UUID_STRING() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATEADD(day, -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATEADD(day, -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_count_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  COALESCE(MAX(subq_28.buys), 0) AS visit_buy_conversions
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  COALESCE(MAX(subq_27.buys), 0) AS visit_buy_conversions
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATE_ADD('day', -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATE_ADD('day', -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_metric_join_to_timespine_and_fill_nulls_with_0__plan0_optimized.sql
@@ -5,15 +5,25 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
+  metric_time__day AS metric_time__day
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days_fill_nulls_with_0
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day) AS metric_time__day
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day) AS metric_time__day
     , COALESCE(MAX(subq_27.visits), 0) AS visits
-    , COALESCE(MAX(subq_40.buys), 0) AS buys
+    , COALESCE(MAX(subq_39.buys), 0) AS buys
   FROM (
     -- Join to Time Spine Dataset
     SELECT
@@ -21,19 +31,13 @@ FROM (
       , subq_24.visits AS visits
     FROM ***************************.mf_time_spine subq_26
     LEFT OUTER JOIN (
+      -- Read From CTE For node_id=sma_28019
+      -- Pass Only Elements: ['visits', 'metric_time__day']
       -- Aggregate Measures
       SELECT
         metric_time__day
         , SUM(visits) AS visits
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'metric_time__day']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_23
+      FROM sma_28019_cte sma_28019_cte
       GROUP BY
         metric_time__day
     ) subq_24
@@ -43,9 +47,9 @@ FROM (
   FULL OUTER JOIN (
     -- Join to Time Spine Dataset
     SELECT
-      subq_39.ds AS metric_time__day
-      , subq_37.buys AS buys
-    FROM ***************************.mf_time_spine subq_39
+      subq_38.ds AS metric_time__day
+      , subq_36.buys AS buys
+    FROM ***************************.mf_time_spine subq_38
     LEFT OUTER JOIN (
       -- Find conversions for user within the range of 7 day
       -- Pass Only Elements: ['buys', 'metric_time__day']
@@ -56,42 +60,33 @@ FROM (
       FROM (
         -- Dedupe the fanout with mf_internal_uuid in the conversion data set
         SELECT DISTINCT
-          FIRST_VALUE(subq_30.visits) OVER (
+          FIRST_VALUE(sma_28019_cte.visits) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS visits
-          , FIRST_VALUE(subq_30.metric_time__day) OVER (
+          , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS metric_time__day
-          , FIRST_VALUE(subq_30.user) OVER (
+          , FIRST_VALUE(sma_28019_cte.user) OVER (
             PARTITION BY
-              subq_33.user
-              , subq_33.metric_time__day
-              , subq_33.mf_internal_uuid
-            ORDER BY subq_30.metric_time__day DESC
+              subq_32.user
+              , subq_32.metric_time__day
+              , subq_32.mf_internal_uuid
+            ORDER BY sma_28019_cte.metric_time__day DESC
             ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
           ) AS user
-          , subq_33.mf_internal_uuid AS mf_internal_uuid
-          , subq_33.buys AS buys
-        FROM (
-          -- Read Elements From Semantic Model 'visits_source'
-          -- Metric Time Dimension 'ds'
-          -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-          SELECT
-            DATE_TRUNC('day', ds) AS metric_time__day
-            , user_id AS user
-            , 1 AS visits
-          FROM ***************************.fct_visits visits_source_src_28000
-        ) subq_30
+          , subq_32.mf_internal_uuid AS mf_internal_uuid
+          , subq_32.buys AS buys
+        FROM sma_28019_cte sma_28019_cte
         INNER JOIN (
           -- Read Elements From Semantic Model 'buys_source'
           -- Metric Time Dimension 'ds'
@@ -102,26 +97,26 @@ FROM (
             , 1 AS buys
             , uuid() AS mf_internal_uuid
           FROM ***************************.fct_buys buys_source_src_28000
-        ) subq_33
+        ) subq_32
         ON
           (
-            subq_30.user = subq_33.user
+            sma_28019_cte.user = subq_32.user
           ) AND (
             (
-              subq_30.metric_time__day <= subq_33.metric_time__day
+              sma_28019_cte.metric_time__day <= subq_32.metric_time__day
             ) AND (
-              subq_30.metric_time__day > DATE_ADD('day', -7, subq_33.metric_time__day)
+              sma_28019_cte.metric_time__day > DATE_ADD('day', -7, subq_32.metric_time__day)
             )
           )
-      ) subq_34
+      ) subq_33
       GROUP BY
         metric_time__day
-    ) subq_37
+    ) subq_36
     ON
-      subq_39.ds = subq_37.metric_time__day
-  ) subq_40
+      subq_38.ds = subq_36.metric_time__day
+  ) subq_39
   ON
-    subq_27.metric_time__day = subq_40.metric_time__day
+    subq_27.metric_time__day = subq_39.metric_time__day
   GROUP BY
-    COALESCE(subq_27.metric_time__day, subq_40.metric_time__day)
-) subq_41
+    COALESCE(subq_27.metric_time__day, subq_39.metric_time__day)
+) subq_40

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate__plan0_optimized.sql
@@ -5,29 +5,34 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  visit__referrer_id
+  visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id']
     -- Aggregate Measures
     SELECT
       visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id']
-      SELECT
-        referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       visit__referrer_id
   ) subq_18
@@ -41,51 +46,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -96,19 +91,19 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          (subq_21.metric_time__day <= subq_24.metric_time__day)
+          (sma_28019_cte.metric_time__day <= subq_23.metric_time__day)
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
-    subq_18.visit__referrer_id = subq_28.visit__referrer_id
+    subq_18.visit__referrer_id = subq_27.visit__referrer_id
   GROUP BY
-    COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_constant_properties__plan0_optimized.sql
@@ -5,33 +5,38 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , session_id AS session
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_by_session
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,65 +52,54 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , FIRST_VALUE(subq_21.session) OVER (
+        , FIRST_VALUE(sma_28019_cte.session) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-            , subq_24.session_id
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+            , subq_23.session_id
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS session
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user', 'session']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , session_id AS session
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -117,31 +111,31 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
-          subq_21.session = subq_24.session_id
+          sma_28019_cte.session = subq_23.session_id
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATE_ADD('day', -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATE_ADD('day', -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_no_group_by__plan0_optimized.sql
@@ -6,16 +6,25 @@ sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
 -- Compute Metrics via Expressions
-SELECT
-  CAST(MAX(subq_28.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
-FROM (
+WITH sma_28019_cte AS (
   -- Read Elements From Semantic Model 'visits_source'
   -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
+SELECT
+  CAST(MAX(subq_27.buys) AS DOUBLE) / CAST(NULLIF(MAX(subq_18.visits), 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
+FROM (
+  -- Read From CTE For node_id=sma_28019
   -- Pass Only Elements: ['visits',]
   -- Aggregate Measures
   SELECT
-    SUM(1) AS visits
-  FROM ***************************.fct_visits visits_source_src_28000
+    SUM(visits) AS visits
+  FROM sma_28019_cte sma_28019_cte
 ) subq_18
 CROSS JOIN (
   -- Find conversions for user within the range of 7 day
@@ -26,42 +35,33 @@ CROSS JOIN (
   FROM (
     -- Dedupe the fanout with mf_internal_uuid in the conversion data set
     SELECT DISTINCT
-      FIRST_VALUE(subq_21.visits) OVER (
+      FIRST_VALUE(sma_28019_cte.visits) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS visits
-      , FIRST_VALUE(subq_21.metric_time__day) OVER (
+      , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS metric_time__day
-      , FIRST_VALUE(subq_21.user) OVER (
+      , FIRST_VALUE(sma_28019_cte.user) OVER (
         PARTITION BY
-          subq_24.user
-          , subq_24.metric_time__day
-          , subq_24.mf_internal_uuid
-        ORDER BY subq_21.metric_time__day DESC
+          subq_23.user
+          , subq_23.metric_time__day
+          , subq_23.mf_internal_uuid
+        ORDER BY sma_28019_cte.metric_time__day DESC
         ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
       ) AS user
-      , subq_24.mf_internal_uuid AS mf_internal_uuid
-      , subq_24.buys AS buys
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'metric_time__day', 'user']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , user_id AS user
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_21
+      , subq_23.mf_internal_uuid AS mf_internal_uuid
+      , subq_23.buys AS buys
+    FROM sma_28019_cte sma_28019_cte
     INNER JOIN (
       -- Read Elements From Semantic Model 'buys_source'
       -- Metric Time Dimension 'ds'
@@ -72,16 +72,16 @@ CROSS JOIN (
         , 1 AS buys
         , uuid() AS mf_internal_uuid
       FROM ***************************.fct_buys buys_source_src_28000
-    ) subq_24
+    ) subq_23
     ON
       (
-        subq_21.user = subq_24.user
+        sma_28019_cte.user = subq_23.user
       ) AND (
         (
-          subq_21.metric_time__day <= subq_24.metric_time__day
+          sma_28019_cte.metric_time__day <= subq_23.metric_time__day
         ) AND (
-          subq_21.metric_time__day > DATE_ADD('day', -7, subq_24.metric_time__day)
+          sma_28019_cte.metric_time__day > DATE_ADD('day', -7, subq_23.metric_time__day)
         )
       )
-  ) subq_25
-) subq_28
+  ) subq_24
+) subq_27

--- a/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_conversion_metrics_to_sql.py/SqlQueryPlan/Trino/test_conversion_rate_with_window__plan0_optimized.sql
@@ -5,33 +5,37 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28019_cte AS (
+  -- Read Elements From Semantic Model 'visits_source'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    DATE_TRUNC('day', ds) AS metric_time__day
+    , user_id AS user
+    , referrer_id AS visit__referrer_id
+    , 1 AS visits
+  FROM ***************************.fct_visits visits_source_src_28000
+)
+
 SELECT
-  metric_time__day
-  , visit__referrer_id
+  metric_time__day AS metric_time__day
+  , visit__referrer_id AS visit__referrer_id
   , CAST(buys AS DOUBLE) / CAST(NULLIF(visits, 0) AS DOUBLE) AS visit_buy_conversion_rate_7days
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day) AS metric_time__day
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id) AS visit__referrer_id
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day) AS metric_time__day
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id) AS visit__referrer_id
     , MAX(subq_18.visits) AS visits
-    , MAX(subq_28.buys) AS buys
+    , MAX(subq_27.buys) AS buys
   FROM (
+    -- Read From CTE For node_id=sma_28019
+    -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
     -- Aggregate Measures
     SELECT
       metric_time__day
       , visit__referrer_id
       , SUM(visits) AS visits
-    FROM (
-      -- Read Elements From Semantic Model 'visits_source'
-      -- Metric Time Dimension 'ds'
-      -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day']
-      SELECT
-        DATE_TRUNC('day', ds) AS metric_time__day
-        , referrer_id AS visit__referrer_id
-        , 1 AS visits
-      FROM ***************************.fct_visits visits_source_src_28000
-    ) subq_17
+    FROM sma_28019_cte sma_28019_cte
     GROUP BY
       metric_time__day
       , visit__referrer_id
@@ -47,51 +51,41 @@ FROM (
     FROM (
       -- Dedupe the fanout with mf_internal_uuid in the conversion data set
       SELECT DISTINCT
-        FIRST_VALUE(subq_21.visits) OVER (
+        FIRST_VALUE(sma_28019_cte.visits) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visits
-        , FIRST_VALUE(subq_21.visit__referrer_id) OVER (
+        , FIRST_VALUE(sma_28019_cte.visit__referrer_id) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS visit__referrer_id
-        , FIRST_VALUE(subq_21.metric_time__day) OVER (
+        , FIRST_VALUE(sma_28019_cte.metric_time__day) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS metric_time__day
-        , FIRST_VALUE(subq_21.user) OVER (
+        , FIRST_VALUE(sma_28019_cte.user) OVER (
           PARTITION BY
-            subq_24.user
-            , subq_24.metric_time__day
-            , subq_24.mf_internal_uuid
-          ORDER BY subq_21.metric_time__day DESC
+            subq_23.user
+            , subq_23.metric_time__day
+            , subq_23.mf_internal_uuid
+          ORDER BY sma_28019_cte.metric_time__day DESC
           ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
         ) AS user
-        , subq_24.mf_internal_uuid AS mf_internal_uuid
-        , subq_24.buys AS buys
-      FROM (
-        -- Read Elements From Semantic Model 'visits_source'
-        -- Metric Time Dimension 'ds'
-        -- Pass Only Elements: ['visits', 'visit__referrer_id', 'metric_time__day', 'user']
-        SELECT
-          DATE_TRUNC('day', ds) AS metric_time__day
-          , user_id AS user
-          , referrer_id AS visit__referrer_id
-          , 1 AS visits
-        FROM ***************************.fct_visits visits_source_src_28000
-      ) subq_21
+        , subq_23.mf_internal_uuid AS mf_internal_uuid
+        , subq_23.buys AS buys
+      FROM sma_28019_cte sma_28019_cte
       INNER JOIN (
         -- Read Elements From Semantic Model 'buys_source'
         -- Metric Time Dimension 'ds'
@@ -102,29 +96,29 @@ FROM (
           , 1 AS buys
           , uuid() AS mf_internal_uuid
         FROM ***************************.fct_buys buys_source_src_28000
-      ) subq_24
+      ) subq_23
       ON
         (
-          subq_21.user = subq_24.user
+          sma_28019_cte.user = subq_23.user
         ) AND (
           (
-            subq_21.metric_time__day <= subq_24.metric_time__day
+            sma_28019_cte.metric_time__day <= subq_23.metric_time__day
           ) AND (
-            subq_21.metric_time__day > DATE_ADD('day', -7, subq_24.metric_time__day)
+            sma_28019_cte.metric_time__day > DATE_ADD('day', -7, subq_23.metric_time__day)
           )
         )
-    ) subq_25
+    ) subq_24
     GROUP BY
       metric_time__day
       , visit__referrer_id
-  ) subq_28
+  ) subq_27
   ON
     (
-      subq_18.visit__referrer_id = subq_28.visit__referrer_id
+      subq_18.visit__referrer_id = subq_27.visit__referrer_id
     ) AND (
-      subq_18.metric_time__day = subq_28.metric_time__day
+      subq_18.metric_time__day = subq_27.metric_time__day
     )
   GROUP BY
-    COALESCE(subq_18.metric_time__day, subq_28.metric_time__day)
-    , COALESCE(subq_18.visit__referrer_id, subq_28.visit__referrer_id)
-) subq_29
+    COALESCE(subq_18.metric_time__day, subq_27.metric_time__day)
+    , COALESCE(subq_18.visit__referrer_id, subq_27.visit__referrer_id)
+) subq_28

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_combined_metrics_plan__ep_0.xml
@@ -7,80 +7,77 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
         <!--    '  ds__day\n'                                                                            -->

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/BigQuery/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  is_instant')                                                                 -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  is_instant')                                                               -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Databricks/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/DuckDB/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Postgres/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Redshift/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Snowflake/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_combined_metrics_plan__ep_0.xml
@@ -7,83 +7,80 @@ test_filename: test_dataflow_to_execution.py
         <!-- node_id = NodeId(id_str='rsq_0') -->
         <!-- sql_query =                                                                                 -->
         <!--   ('-- Combine Aggregated Outputs\n'                                                        -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                              -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  SELECT\n'                                                                             -->
+        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    , is_instant\n'                                                                     -->
+        <!--    '    , 1 AS bookings\n'                                                                  -->
+        <!--    '    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                     -->
+        <!--    '    , booking_value\n'                                                                  -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    ')\n'                                                                                    -->
+        <!--    '\n'                                                                                     -->
         <!--    'SELECT\n'                                                                               -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day) AS ds__day\n'               -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant) AS is_instant\n' -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day) AS ds__day\n'               -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant) AS is_instant\n' -->
         <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                                 -->
-        <!--    '  , MAX(subq_9.instant_bookings) AS instant_bookings\n'                                 -->
-        <!--    '  , MAX(subq_14.booking_value) AS booking_value\n'                                      -->
+        <!--    '  , MAX(subq_8.instant_bookings) AS instant_bookings\n'                                 -->
+        <!--    '  , MAX(subq_12.booking_value) AS booking_value\n'                                      -->
         <!--    'FROM (\n'                                                                               -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                       -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(bookings) AS bookings\n'                                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant', 'ds__day']\n"                     -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , 1 AS bookings\n'                                                                -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_2\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    ') subq_4\n'                                                                             -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
+        <!--    "  -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"               -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(instant_bookings) AS instant_bookings\n'                                      -->
-        <!--    '  FROM (\n'                                                                             -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                           -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                                    -->
-        <!--    "    -- Pass Only Elements: ['instant_bookings', 'is_instant', 'ds__day']\n"             -->
-        <!--    '    SELECT\n'                                                                           -->
-        <!--    "      DATE_TRUNC('day', ds) AS ds__day\n"                                               -->
-        <!--    '      , is_instant\n'                                                                   -->
-        <!--    '      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings\n'                   -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n'          -->
-        <!--    '  ) subq_7\n'                                                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
         <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_9\n'                                                                             -->
+        <!--    ') subq_8\n'                                                                             -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    subq_4.is_instant = subq_9.is_instant\n'                                            -->
+        <!--    '    subq_4.is_instant = subq_8.is_instant\n'                                            -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    subq_4.ds__day = subq_9.ds__day\n'                                                  -->
+        <!--    '    subq_4.ds__day = subq_8.ds__day\n'                                                  -->
         <!--    '  )\n'                                                                                  -->
         <!--    'FULL OUTER JOIN (\n'                                                                    -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                             -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                                      -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                             -->
         <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant', 'ds__day']\n"                  -->
         <!--    '  -- Aggregate Measures\n'                                                              -->
         <!--    '  -- Compute Metrics via Expressions\n'                                                 -->
         <!--    '  SELECT\n'                                                                             -->
-        <!--    "    DATE_TRUNC('day', ds) AS ds__day\n"                                                 -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
         <!--    '    , SUM(booking_value) AS booking_value\n'                                            -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'            -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                                   -->
         <!--    '  GROUP BY\n'                                                                           -->
-        <!--    "    DATE_TRUNC('day', ds)\n"                                                            -->
+        <!--    '    ds__day\n'                                                                          -->
         <!--    '    , is_instant\n'                                                                     -->
-        <!--    ') subq_14\n'                                                                            -->
+        <!--    ') subq_12\n'                                                                            -->
         <!--    'ON\n'                                                                                   -->
         <!--    '  (\n'                                                                                  -->
-        <!--    '    COALESCE(subq_4.is_instant, subq_9.is_instant) = subq_14.is_instant\n'              -->
+        <!--    '    COALESCE(subq_4.is_instant, subq_8.is_instant) = subq_12.is_instant\n'              -->
         <!--    '  ) AND (\n'                                                                            -->
-        <!--    '    COALESCE(subq_4.ds__day, subq_9.ds__day) = subq_14.ds__day\n'                       -->
+        <!--    '    COALESCE(subq_4.ds__day, subq_8.ds__day) = subq_12.ds__day\n'                       -->
         <!--    '  )\n'                                                                                  -->
         <!--    'GROUP BY\n'                                                                             -->
-        <!--    '  COALESCE(subq_4.ds__day, subq_9.ds__day, subq_14.ds__day)\n'                          -->
-        <!--    '  , COALESCE(subq_4.is_instant, subq_9.is_instant, subq_14.is_instant)')                -->
+        <!--    '  COALESCE(subq_4.ds__day, subq_8.ds__day, subq_12.ds__day)\n'                          -->
+        <!--    '  , COALESCE(subq_4.is_instant, subq_8.is_instant, subq_12.is_instant)')                -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_small_combined_metrics_plan__ep_0.xml
+++ b/tests_metricflow/snapshots/test_dataflow_to_execution.py/ExecutionPlan/Trino/test_small_combined_metrics_plan__ep_0.xml
@@ -5,46 +5,49 @@ test_filename: test_dataflow_to_execution.py
     <SelectSqlQueryToDataTableTask>
         <!-- description = 'Run a query and write the results to a data frame' -->
         <!-- node_id = NodeId(id_str='rsq_0') -->
-        <!-- sql_query =                                                                        -->
-        <!--   ('-- Combine Aggregated Outputs\n'                                               -->
-        <!--    'SELECT\n'                                                                      -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant) AS is_instant\n'              -->
-        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                        -->
-        <!--    '  , MAX(subq_9.booking_value) AS booking_value\n'                              -->
-        <!--    'FROM (\n'                                                                      -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(bookings) AS bookings\n'                                             -->
-        <!--    '  FROM (\n'                                                                    -->
-        <!--    "    -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
-        <!--    "    -- Metric Time Dimension 'ds'\n"                                           -->
-        <!--    "    -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
-        <!--    '    SELECT\n'                                                                  -->
-        <!--    '      is_instant\n'                                                            -->
-        <!--    '      , 1 AS bookings\n'                                                       -->
-        <!--    '    FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
-        <!--    '  ) subq_2\n'                                                                  -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_4\n'                                                                    -->
-        <!--    'FULL OUTER JOIN (\n'                                                           -->
-        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                    -->
-        <!--    "  -- Metric Time Dimension 'ds'\n"                                             -->
-        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                    -->
-        <!--    '  -- Aggregate Measures\n'                                                     -->
-        <!--    '  -- Compute Metrics via Expressions\n'                                        -->
-        <!--    '  SELECT\n'                                                                    -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    '    , SUM(booking_value) AS booking_value\n'                                   -->
-        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n'   -->
-        <!--    '  GROUP BY\n'                                                                  -->
-        <!--    '    is_instant\n'                                                              -->
-        <!--    ') subq_9\n'                                                                    -->
-        <!--    'ON\n'                                                                          -->
-        <!--    '  subq_4.is_instant = subq_9.is_instant\n'                                     -->
-        <!--    'GROUP BY\n'                                                                    -->
-        <!--    '  COALESCE(subq_4.is_instant, subq_9.is_instant)')                             -->
+        <!-- sql_query =                                                                      -->
+        <!--   ('-- Combine Aggregated Outputs\n'                                             -->
+        <!--    'WITH sma_28009_cte AS (\n'                                                   -->
+        <!--    "  -- Read Elements From Semantic Model 'bookings_source'\n"                  -->
+        <!--    "  -- Metric Time Dimension 'ds'\n"                                           -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , 1 AS bookings\n'                                                       -->
+        <!--    '    , booking_value\n'                                                       -->
+        <!--    '  FROM ***************************.fct_bookings bookings_source_src_28000\n' -->
+        <!--    ')\n'                                                                         -->
+        <!--    '\n'                                                                          -->
+        <!--    'SELECT\n'                                                                    -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant) AS is_instant\n'            -->
+        <!--    '  , MAX(subq_4.bookings) AS bookings\n'                                      -->
+        <!--    '  , MAX(subq_8.booking_value) AS booking_value\n'                            -->
+        <!--    'FROM (\n'                                                                    -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['bookings', 'is_instant']\n"                       -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(bookings) AS bookings\n'                                           -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_4\n'                                                                  -->
+        <!--    'FULL OUTER JOIN (\n'                                                         -->
+        <!--    '  -- Read From CTE For node_id=sma_28009\n'                                  -->
+        <!--    "  -- Pass Only Elements: ['booking_value', 'is_instant']\n"                  -->
+        <!--    '  -- Aggregate Measures\n'                                                   -->
+        <!--    '  -- Compute Metrics via Expressions\n'                                      -->
+        <!--    '  SELECT\n'                                                                  -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    '    , SUM(booking_value) AS booking_value\n'                                 -->
+        <!--    '  FROM sma_28009_cte sma_28009_cte\n'                                        -->
+        <!--    '  GROUP BY\n'                                                                -->
+        <!--    '    is_instant\n'                                                            -->
+        <!--    ') subq_8\n'                                                                  -->
+        <!--    'ON\n'                                                                        -->
+        <!--    '  subq_4.is_instant = subq_8.is_instant\n'                                   -->
+        <!--    'GROUP BY\n'                                                                  -->
+        <!--    '  COALESCE(subq_4.is_instant, subq_8.is_instant)')                           -->
     </SelectSqlQueryToDataTableTask>
 </ExecutionPlan>

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS FLOAT64) / CAST(NULLIF(views, 0) AS FLOAT64) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,9 +44,9 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       ds__day
       , listing__country_latest
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       ds__day
       , listing__country_latest
-  ) subq_36
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
     ds__day
     , listing__country_latest
-) subq_37
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/BigQuery/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: Databricks
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE) / CAST(NULLIF(views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Databricks/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: Databricks
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE) / CAST(NULLIF(views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/DuckDB/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: Postgres
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Postgres/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: Postgres
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: Redshift
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE PRECISION) / CAST(NULLIF(views, 0) AS DOUBLE PRECISION) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Redshift/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: Redshift
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE) / CAST(NULLIF(views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Snowflake/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_combine_output_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_combine_output_node__plan0_optimized.sql
@@ -5,42 +5,41 @@ docstring:
 sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
+WITH rss_28001_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
+    , guest_id AS bookers
+    , is_instant
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_8.is_instant, subq_11.is_instant) AS is_instant
   , MAX(subq_8.bookings) AS bookings
   , COALESCE(MAX(subq_11.instant_bookings), 1) AS instant_bookings
   , COALESCE(MAX(subq_11.bookers), 1) AS bookers
 FROM (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['bookings', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['bookings', 'is_instant']
-    SELECT
-      is_instant
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_7
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_8
 FULL OUTER JOIN (
+  -- Read From CTE For node_id=rss_28001
+  -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
   -- Aggregate Measures
   SELECT
     is_instant
     , SUM(instant_bookings) AS instant_bookings
     , COUNT(DISTINCT bookers) AS bookers
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Pass Only Elements: ['instant_bookings', 'bookers', 'is_instant']
-    SELECT
-      is_instant
-      , CASE WHEN is_instant THEN 1 ELSE 0 END AS instant_bookings
-      , guest_id AS bookers
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_10
+  FROM rss_28001_cte rss_28001_cte
   GROUP BY
     is_instant
 ) subq_11

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_compute_metrics_node_ratio_from_multiple_semantic_models__plan0_optimized.sql
@@ -5,17 +5,26 @@ docstring:
 sql_engine: Trino
 ---
 -- Compute Metrics via Expressions
+WITH sma_28014_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Metric Time Dimension 'ds'
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
-  ds__day
-  , listing__country_latest
+  ds__day AS ds__day
+  , listing__country_latest AS listing__country_latest
   , CAST(bookings AS DOUBLE) / CAST(NULLIF(views, 0) AS DOUBLE) AS bookings_per_view
 FROM (
   -- Combine Aggregated Outputs
   SELECT
-    COALESCE(subq_27.ds__day, subq_36.ds__day) AS ds__day
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest) AS listing__country_latest
+    COALESCE(subq_27.ds__day, subq_35.ds__day) AS ds__day
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest) AS listing__country_latest
     , MAX(subq_27.bookings) AS bookings
-    , MAX(subq_36.views) AS views
+    , MAX(subq_35.views) AS views
   FROM (
     -- Join Standard Outputs
     -- Pass Only Elements: ['bookings', 'listing__country_latest', 'ds__day']
@@ -23,7 +32,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_20.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_20.bookings) AS bookings
     FROM (
       -- Read Elements From Semantic Model 'bookings_source'
@@ -35,12 +44,12 @@ FROM (
       FROM ***************************.fct_bookings bookings_source_src_28000
     ) subq_20
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_20.listing = listings_latest_src_28000.listing_id
+      subq_20.listing = sma_28014_cte.listing
     GROUP BY
       subq_20.ds__day
-      , listings_latest_src_28000.country
+      , sma_28014_cte.country_latest
   ) subq_27
   FULL OUTER JOIN (
     -- Join Standard Outputs
@@ -49,7 +58,7 @@ FROM (
     -- Compute Metrics via Expressions
     SELECT
       subq_29.ds__day AS ds__day
-      , listings_latest_src_28000.country AS listing__country_latest
+      , sma_28014_cte.country_latest AS listing__country_latest
       , SUM(subq_29.views) AS views
     FROM (
       -- Read Elements From Semantic Model 'views_source'
@@ -61,20 +70,20 @@ FROM (
       FROM ***************************.fct_views views_source_src_28000
     ) subq_29
     LEFT OUTER JOIN
-      ***************************.dim_listings_latest listings_latest_src_28000
+      sma_28014_cte sma_28014_cte
     ON
-      subq_29.listing = listings_latest_src_28000.listing_id
+      subq_29.listing = sma_28014_cte.listing
     GROUP BY
       subq_29.ds__day
-      , listings_latest_src_28000.country
-  ) subq_36
+      , sma_28014_cte.country_latest
+  ) subq_35
   ON
     (
-      subq_27.listing__country_latest = subq_36.listing__country_latest
+      subq_27.listing__country_latest = subq_35.listing__country_latest
     ) AND (
-      subq_27.ds__day = subq_36.ds__day
+      subq_27.ds__day = subq_35.ds__day
     )
   GROUP BY
-    COALESCE(subq_27.ds__day, subq_36.ds__day)
-    , COALESCE(subq_27.listing__country_latest, subq_36.listing__country_latest)
-) subq_37
+    COALESCE(subq_27.ds__day, subq_35.ds__day)
+    , COALESCE(subq_27.listing__country_latest, subq_35.listing__country_latest)
+) subq_36

--- a/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_dataflow_to_sql_plan.py/SqlQueryPlan/Trino/test_multi_join_node__plan0_optimized.sql
@@ -5,9 +5,18 @@ docstring:
 sql_engine: Trino
 ---
 -- Join Standard Outputs
+WITH pfe_1_cte AS (
+  -- Read Elements From Semantic Model 'listings_latest'
+  -- Pass Only Elements: ['country_latest', 'listing']
+  SELECT
+    listing_id AS listing
+    , country AS country_latest
+  FROM ***************************.dim_listings_latest listings_latest_src_28000
+)
+
 SELECT
   subq_9.country_latest AS listing__country_latest
-  , subq_11.country_latest AS listing__country_latest
+  , subq_10.country_latest AS listing__country_latest
   , subq_7.listing AS listing
   , subq_7.bookings AS bookings
 FROM (
@@ -19,22 +28,20 @@ FROM (
   FROM ***************************.fct_bookings bookings_source_src_28000
 ) subq_7
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
 ) subq_9
 ON
   subq_7.listing = subq_9.listing
 LEFT OUTER JOIN (
-  -- Read Elements From Semantic Model 'listings_latest'
-  -- Pass Only Elements: ['country_latest', 'listing']
+  -- Read From CTE For node_id=pfe_1
   SELECT
-    listing_id AS listing
-    , country AS country_latest
-  FROM ***************************.dim_listings_latest listings_latest_src_28000
-) subq_11
+    listing
+    , country_latest
+  FROM pfe_1_cte pfe_1_cte
+) subq_10
 ON
-  subq_7.listing = subq_11.listing
+  subq_7.listing = subq_10.listing

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/BigQuery/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,38 +5,43 @@ docstring:
 sql_engine: BigQuery
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATETIME_TRUNC(ds, day) AS ds__day
+    , DATETIME_TRUNC(paid_at, day) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATETIME_TRUNC(ds, day) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
     metric_time__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATETIME_TRUNC(paid_at, day) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
     metric_time__day
 ) subq_19

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Databricks/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: Databricks
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/DuckDB/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: DuckDB
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Postgres/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: Postgres
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Redshift/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: Redshift
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Snowflake/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: Snowflake
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day

--- a/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Trino/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
+++ b/tests_metricflow/snapshots/test_metric_time_dimension_to_sql.py/SqlQueryPlan/Trino/test_simple_query_with_metric_time_dimension__plan0_optimized.sql
@@ -5,40 +5,45 @@ docstring:
 sql_engine: Trino
 ---
 -- Combine Aggregated Outputs
+WITH rss_28020_cte AS (
+  -- Read Elements From Semantic Model 'bookings_source'
+  SELECT
+    1 AS bookings
+    , booking_value AS booking_payments
+    , DATE_TRUNC('day', ds) AS ds__day
+    , DATE_TRUNC('day', paid_at) AS paid_at__day
+  FROM ***************************.fct_bookings bookings_source_src_28000
+)
+
 SELECT
   COALESCE(subq_14.metric_time__day, subq_19.metric_time__day) AS metric_time__day
   , MAX(subq_14.bookings) AS bookings
   , MAX(subq_19.booking_payments) AS booking_payments
 FROM (
+  -- Read From CTE For node_id=rss_28020
+  -- Metric Time Dimension 'ds'
+  -- Pass Only Elements: ['bookings', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    metric_time__day
+    ds__day AS metric_time__day
     , SUM(bookings) AS bookings
-  FROM (
-    -- Read Elements From Semantic Model 'bookings_source'
-    -- Metric Time Dimension 'ds'
-    -- Pass Only Elements: ['bookings', 'metric_time__day']
-    SELECT
-      DATE_TRUNC('day', ds) AS metric_time__day
-      , 1 AS bookings
-    FROM ***************************.fct_bookings bookings_source_src_28000
-  ) subq_12
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    metric_time__day
+    ds__day
 ) subq_14
 FULL OUTER JOIN (
-  -- Read Elements From Semantic Model 'bookings_source'
+  -- Read From CTE For node_id=rss_28020
   -- Metric Time Dimension 'paid_at'
   -- Pass Only Elements: ['booking_payments', 'metric_time__day']
   -- Aggregate Measures
   -- Compute Metrics via Expressions
   SELECT
-    DATE_TRUNC('day', paid_at) AS metric_time__day
-    , SUM(booking_value) AS booking_payments
-  FROM ***************************.fct_bookings bookings_source_src_28000
+    paid_at__day AS metric_time__day
+    , SUM(booking_payments) AS booking_payments
+  FROM rss_28020_cte rss_28020_cte
   GROUP BY
-    DATE_TRUNC('day', paid_at)
+    paid_at__day
 ) subq_19
 ON
   subq_14.metric_time__day = subq_19.metric_time__day


### PR DESCRIPTION
Resolves #1040 

This PR updates the default SQL optimization level to use CTEs. This creates a number of snapshot changes as queries in tests now use CTEs in cases where there are common sources or common metrics in multi-metric / derived metric cases.