### PR TITLE
Minimum grain clean up

### DIFF
--- a/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
+++ b/metricflow-semantics/metricflow_semantics/specs/linkable_spec_set.py
@@ -102,13 +102,28 @@ class LinkableSpecSet(Mergeable, SerializableDataclass):
             )
         )
 
+    def add_specs(
+        self,
+        dimension_specs: Tuple[DimensionSpec, ...] = (),
+        time_dimension_specs: Tuple[TimeDimensionSpec, ...] = (),
+        entity_specs: Tuple[EntitySpec, ...] = (),
+        group_by_metric_specs: Tuple[GroupByMetricSpec, ...] = (),
+    ) -> LinkableSpecSet:
+        """Return a new set with the new specs in addition to the existing ones."""
+        return LinkableSpecSet(
+            dimension_specs=self.dimension_specs + dimension_specs,
+            time_dimension_specs=self.time_dimension_specs + time_dimension_specs,
+            entity_specs=self.entity_specs + entity_specs,
+            group_by_metric_specs=self.group_by_metric_specs + group_by_metric_specs,
+        )
+
     @override
     def merge(self, other: LinkableSpecSet) -> LinkableSpecSet:
-        return LinkableSpecSet(
-            dimension_specs=self.dimension_specs + other.dimension_specs,
-            time_dimension_specs=self.time_dimension_specs + other.time_dimension_specs,
-            entity_specs=self.entity_specs + other.entity_specs,
-            group_by_metric_specs=self.group_by_metric_specs + other.group_by_metric_specs,
+        return self.add_specs(
+            dimension_specs=other.dimension_specs,
+            time_dimension_specs=other.time_dimension_specs,
+            entity_specs=other.entity_specs,
+            group_by_metric_specs=other.group_by_metric_specs,
         )
 
     @classmethod


### PR DESCRIPTION
Clean up.
1. Rename default grain -> min grain. This was causing me some confusion because we recently introduced the concept of default grain for metrics, which is defined in the YAML spec, but this code was not referring to that.
2. Also moves some related logic to helper functions to improve readability.